### PR TITLE
feat(tools): improve run-tests.sh and fix Docker disk exhaustion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,12 +41,19 @@ RUN cargo fetch
 WORKDIR /src/libviprs-tests
 RUN cargo fetch
 
+# Disable debug info to keep test binaries small enough for the container.
+# Each integration test is a separate binary; full debuginfo exhausts disk space.
+ENV CARGO_PROFILE_DEV_DEBUG=0
+
 # Default: run libviprs tests first, then libviprs-tests with pdfium
 CMD sh -c '\
     echo "================================================================" && \
     echo "Running libviprs unit tests (with pdfium)..." && \
     echo "================================================================" && \
     cd /src/libviprs && cargo test --features pdfium && \
+    echo "" && \
+    echo "Cleaning libviprs build artifacts to free disk space..." && \
+    cargo clean && \
     echo "" && \
     echo "================================================================" && \
     echo "Running libviprs-tests integration tests (with pdfium)..." && \

--- a/README.md
+++ b/README.md
@@ -30,9 +30,39 @@ cargo test -- --ignored stress
 cargo test --features pdfium -- --ignored pdfium_system
 ```
 
-### Docker
+### Docker (via run-tests.sh)
 
-Run the full test suite (including PDFium) without installing anything locally:
+`run-tests.sh` builds a Docker image with PDFium and runs the full test suite
+without requiring any local dependencies. It can be invoked from either repo:
+
+```bash
+# From libviprs/
+./run-tests.sh              # auto-detect arch
+./run-tests.sh arm          # force arm64
+./run-tests.sh amd64        # force amd64
+
+# From libviprs-tests/
+./tools/run-tests.sh
+```
+
+#### Miri and Loom
+
+After the Docker tests pass, you can optionally run Miri and/or Loom on the
+host (not in Docker):
+
+```bash
+./run-tests.sh --miri           # + Miri (requires nightly + miri component)
+./run-tests.sh --loom           # + Loom concurrency tests
+./run-tests.sh --miri --loom    # both
+./run-tests.sh arm --miri       # combine arch + flags
+```
+
+Miri runs `cargo +nightly miri test` on libviprs. Loom runs
+`RUSTFLAGS="--cfg loom" cargo test --lib loom_tests` on libviprs.
+
+#### Docker directly
+
+You can also use Docker without the script:
 
 ```bash
 # From the workspace root (parent of libviprs/ and libviprs-tests/)
@@ -141,6 +171,8 @@ libviprs-tests/
 ├── Cargo.toml
 ├── Dockerfile
 ├── README.md
+├── tools/
+│   └── run-tests.sh
 ├── .github/
 │   └── workflows/
 │       └── ci.yml

--- a/tools/run-tests.sh
+++ b/tools/run-tests.sh
@@ -6,23 +6,41 @@ set -euo pipefail
 #
 # Can be invoked from either the libviprs-tests/ or libviprs/ directory.
 #
-# Usage:  ./run-tests.sh          # auto-detect arch (arm64 on Apple Silicon)
-#         ./run-tests.sh arm      # build for arm64
-#         ./run-tests.sh amd64    # build for amd64
+# Usage:  ./run-tests.sh                  # auto-detect arch (arm64 on Apple Silicon)
+#         ./run-tests.sh arm              # build for arm64
+#         ./run-tests.sh amd64            # build for amd64
+#         ./run-tests.sh --miri           # also run Miri after Docker tests
+#         ./run-tests.sh --loom           # also run Loom after Docker tests
+#         ./run-tests.sh --miri --loom    # run both
+#         ./run-tests.sh arm --miri       # combine arch + flags
 #
 # Runs libviprs unit tests and libviprs-tests integration tests, both with
 # the pdfium feature enabled. Exit code reflects test results.
+#
+# --miri  Run Miri (requires nightly toolchain with miri component) on
+#         libviprs after the Docker tests pass.
+# --loom  Run Loom concurrency tests on libviprs after the Docker tests pass.
 # ---------------------------------------------------------------------------
 
+RUN_MIRI=false
+RUN_LOOM=false
+ARCH=""
+
+for arg in "$@"; do
+    case "$arg" in
+        --miri) RUN_MIRI=true ;;
+        --loom) RUN_LOOM=true ;;
+        *)      ARCH="$arg" ;;
+    esac
+done
+
 # Auto-detect architecture if not specified
-if [ $# -eq 0 ]; then
+if [ -z "$ARCH" ]; then
     HOST_ARCH="$(uname -m)"
     case "$HOST_ARCH" in
         arm64|aarch64) ARCH="arm64" ;;
         *)             ARCH="amd64" ;;
     esac
-else
-    ARCH="$1"
 fi
 
 case "$ARCH" in
@@ -67,7 +85,7 @@ fi
 #     libviprs-tests/    (integration tests + Dockerfile)
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # The Dockerfile and .dockerignore live in libviprs-tests/
 TESTS_DIR="$WORKSPACE_ROOT/libviprs-tests"
@@ -147,6 +165,37 @@ else
     echo ""
     echo "================================================================"
     echo "Tests FAILED (exit code ${EXIT_CODE})."
+    exit $EXIT_CODE
 fi
 
-exit $EXIT_CODE
+# ---------------------------------------------------------------------------
+# Miri (optional, runs on host — requires nightly + miri component)
+# ---------------------------------------------------------------------------
+
+if [ "$RUN_MIRI" = true ]; then
+    echo ""
+    echo "================================================================"
+    echo "Running Miri on libviprs..."
+    echo "================================================================"
+    cd "$LIBVIPRS_DIR"
+    cargo +nightly miri test
+    echo ""
+    echo "================================================================"
+    echo "Miri passed."
+fi
+
+# ---------------------------------------------------------------------------
+# Loom (optional, runs on host)
+# ---------------------------------------------------------------------------
+
+if [ "$RUN_LOOM" = true ]; then
+    echo ""
+    echo "================================================================"
+    echo "Running Loom concurrency tests on libviprs..."
+    echo "================================================================"
+    cd "$LIBVIPRS_DIR"
+    RUSTFLAGS="--cfg loom" cargo test --lib loom_tests
+    echo ""
+    echo "================================================================"
+    echo "Loom passed."
+fi


### PR DESCRIPTION
## Summary

- Move `run-tests.sh` to `tools/run-tests.sh` for conventional script organization
- Add `--miri` and `--loom` CLI flags to optionally run Miri and Loom tests on the host after Docker tests pass
- Fix Docker linker `No space left on device` errors by disabling debug info (`CARGO_PROFILE_DEV_DEBUG=0`) and cleaning libviprs build artifacts between test phases
- Update README with run-tests.sh usage docs, flag examples, and updated project structure

## Context

Integration tests were failing in Docker with `No space left on device` during linking because each test file compiles as a separate binary with full debug symbols. Two fixes address this:

1. `CARGO_PROFILE_DEV_DEBUG=0` strips debug info, dramatically reducing binary sizes
2. `cargo clean` between the unit and integration test phases frees ~485MB of artifacts

The `--miri` and `--loom` flags run on the host (not in Docker) since they don't need PDFium and Miri requires the nightly toolchain.

## Test plan

- [ ] `./tools/run-tests.sh` — Docker tests complete without disk space errors
- [ ] `./tools/run-tests.sh --miri` — Miri runs after Docker tests
- [ ] `./tools/run-tests.sh --loom` — Loom runs after Docker tests
- [ ] `./tools/run-tests.sh arm --miri --loom` — all flags combine correctly
- [ ] `libviprs/run-tests.sh` delegate still works (path unchanged)