### PR TITLE
Add MSRV and deprecation lint flags to pre-commit hook

### DIFF
--- a/tools/install-hooks.sh
+++ b/tools/install-hooks.sh
@@ -60,8 +60,11 @@ if ! cargo fmt -- --check 2>/dev/null; then
 fi
 
 # Clippy (uses cached build artifacts, usually fast on incremental changes)
+# -D warnings: treat all warnings as errors
+# -W clippy::incompatible_msrv: flag APIs newer than the declared rust-version
+# -W deprecated: flag usage of deprecated APIs
 echo "  cargo clippy..."
-if ! cargo clippy --all-targets -- -D warnings 2>/dev/null; then
+if ! cargo clippy --all-targets -- -D warnings -W clippy::incompatible_msrv -W deprecated 2>/dev/null; then
     echo ""
     echo "Clippy check failed. Fix warnings and re-stage."
     exit 1


### PR DESCRIPTION
## Summary

- Update the pre-commit hook template in `install-hooks.sh` to flag deprecated API usage and MSRV-incompatible standard library calls before commit

## Changes

### `tools/install-hooks.sh` — Pre-commit hook template

- **Added `-W clippy::incompatible_msrv`** to the clippy invocation in the generated pre-commit hook. This flags any standard library API call that requires a Rust version newer than the `rust-version` declared in the target crate's `Cargo.toml`. Without this, developers on newer toolchains could commit code that compiles locally but fails on the project's MSRV (1.85).

- **Added `-W deprecated`** to the same clippy invocation. This surfaces usage of deprecated standard library methods (e.g. `Error::description()`, `Error::cause()`) at commit time rather than relying solely on CI. Combined with the `deprecated = "deny"` lint now configured in the libviprs manifest, this provides defense-in-depth: the hook catches issues locally before they reach the remote.

These flags are added to the hook template that `install-hooks.sh` writes into `.git/hooks/pre-commit` for all workspace repos (libviprs, libviprs-cli, libviprs-tests). Existing hooks are updated by re-running `./tools/install-hooks.sh`.

## Companion PR

- libviprs: Enforce MSRV compliance and deprecated API detection (adds `[lints]` config and MSRV CI job)

## Test plan

- [x] Pre-commit hook runs successfully with new flags on all workspace repos
- [x] Full Docker integration test suite passes (147 unit + all integration tests)