### PR TITLE
test: reproduce streaming PdfiumStripSource rotation panic (libviprs#41)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -35,6 +35,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,12 +59,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "blake3"
+version = "1.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -144,7 +179,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -169,6 +204,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +226,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -234,6 +290,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,8 +313,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -441,6 +517,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,12 +683,16 @@ dependencies = [
 
 [[package]]
 name = "libviprs"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
+ "blake3",
  "flate2",
  "image",
  "lopdf",
  "pdfium-render",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
  "thiserror",
 ]
 
@@ -653,7 +742,7 @@ dependencies = [
  "rand",
  "rangemap",
  "rayon",
- "sha2",
+ "sha2 0.10.9",
  "stringprep",
  "thiserror",
  "time",
@@ -673,7 +762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -963,6 +1052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1005,8 +1095,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]

--- a/tests/blank_tile_strategy.rs
+++ b/tests/blank_tile_strategy.rs
@@ -7,9 +7,11 @@
 //! To regenerate fixtures after intentional output changes, run:
 //!   cargo test --test gen_blank_tile_fixtures -- --ignored generate_fixtures
 
+use libviprs::engine::is_blank_tile;
+use libviprs::sink::BLANK_TILE_MARKER;
 use libviprs::{
-    BLANK_TILE_MARKER, BlankTileStrategy, EngineConfig, FsSink, Layout, PixelFormat,
-    PyramidPlanner, Raster, TileFormat, generate_pyramid, is_blank_tile,
+    BlankTileStrategy, EngineConfig, FsSink, Layout, PixelFormat, PyramidPlanner, Raster,
+    TileFormat, generate_pyramid,
 };
 use std::path::{Path, PathBuf};
 

--- a/tests/streaming_engine.rs
+++ b/tests/streaming_engine.rs
@@ -605,7 +605,7 @@ fn compute_strip_height_respects_budget() {
     // Budget must be large enough for at least one strip unit
     // (2×tile_size rows across all pyramid levels).
     let budget: u64 = 50_000_000;
-    let sh = libviprs::compute_strip_height(&plan, PixelFormat::Rgb8, budget);
+    let sh = libviprs::streaming::compute_strip_height(&plan, PixelFormat::Rgb8, budget);
     assert!(
         sh.is_some(),
         "budget {budget} should allow at least one strip unit"
@@ -622,7 +622,7 @@ fn compute_strip_height_respects_budget() {
     );
 
     // Actual memory at this strip height should be within budget
-    let est = libviprs::estimate_streaming_memory(&plan, PixelFormat::Rgb8, sh);
+    let est = libviprs::streaming::estimate_streaming_memory(&plan, PixelFormat::Rgb8, sh);
     assert!(
         est <= budget,
         "Estimated memory {est} exceeds budget {budget} for strip_height={sh}",
@@ -634,6 +634,6 @@ fn compute_strip_height_returns_none_for_impossible_budget() {
     let planner = PyramidPlanner::new(4096, 4096, 256, 0, Layout::DeepZoom).unwrap();
     let plan = planner.plan();
 
-    let sh = libviprs::compute_strip_height(&plan, PixelFormat::Rgb8, 1);
+    let sh = libviprs::streaming::compute_strip_height(&plan, PixelFormat::Rgb8, 1);
     assert!(sh.is_none());
 }

--- a/tests/streaming_pdfium_repro.rs
+++ b/tests/streaming_pdfium_repro.rs
@@ -1,0 +1,177 @@
+//! Reproduces the istracked/server #95 / PR #96 streaming panic.
+//!
+//! Mirrors the call sequence in `ensure_tiles_generated` from
+//! `istracked/server/src/rest_api/sheets.rs` on PR branch
+//! `libviprs_streaming`:
+//!
+//!     pdf_info(path) -> width_pts, height_pts
+//!     width_px  = (width_pts / 72 * dpi) as u32
+//!     height_px = (height_pts / 72 * dpi) as u32
+//!     PdfiumStripSource::new(path, 1, dpi, width_px, height_px)
+//!     PyramidPlanner::new(width_px, height_px, 256, 0, Layout::Google)
+//!     StreamingConfig { memory_budget_bytes: 1_000_000, .. }
+//!     generate_pyramid_streaming(...)
+//!
+//! Reported panic (libviprs 0.1.4):
+//!     thread '...' panicked at libviprs-0.1.4/src/streaming.rs:840:51:
+//!     range end index 1009732 out of range for slice of length 953568
+//!
+//! Hypothesis: `PdfiumStripSource::width()/height()` returns the user-
+//! supplied prediction, but `extract_strip` returns a strip sized from
+//! the actual pdfium-rendered raster. When pdfium honours a page-rotation
+//! hint (or rounds dimensions differently from the caller's prediction),
+//! the streaming engine's per-row copy in `obtain_canvas_strip` writes
+//! `actual_width * bpp` bytes per row into a destination buffer striped
+//! at `predicted_width * bpp`, producing the slice OOB.
+
+#![cfg(feature = "pdfium")]
+
+use std::path::Path;
+
+use libviprs::pdf::{pdf_info, render_page_pdfium};
+use libviprs::streaming::generate_pyramid_streaming;
+use libviprs::{
+    EngineConfig, Layout, MemorySink, PdfiumStripSource, PyramidPlanner, StreamingConfig,
+    observe::NoopObserver,
+};
+
+const FIXTURE_PDF: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/blueprint.pdf");
+
+const TILE_SIZE: u32 = 256;
+// PR #96 sets `let dpi = 300` in source, but the runtime that reported the
+// panic used 72 DPI. The dimension-mismatch bug shape is identical at any
+// DPI (rotation swaps width/height regardless), and 72 DPI keeps
+// blueprint.pdf at ~16 MP × 4 bpp = ~64 MB, well inside the 4 GB container
+// budget. Lower DPI just makes the test cheaper to run.
+const DPI: u32 = 72;
+const BACKGROUND_RGB: [u8; 3] = [0xE7, 0xE7, 0xE7];
+const MEMORY_BUDGET_BYTES_1MB: u64 = 1_000_000;
+const MEMORY_BUDGET_BYTES_2MB: u64 = 2_000_000;
+
+/// Compute the predicted pixel dimensions exactly the way PR #96 does,
+/// using `(width_pts / 72.0 * dpi) as u32` truncation.
+fn predicted_dims(path: &Path, dpi: u32) -> (u32, u32) {
+    let info = pdf_info(path).expect("pdf_info failed");
+    let page = &info.pages[0];
+    let w = (page.width_pts / 72.0 * dpi as f64) as u32;
+    let h = (page.height_pts / 72.0 * dpi as f64) as u32;
+    (w, h)
+}
+
+/// Diagnostic: print predicted dims vs. what pdfium actually renders.
+/// If they differ, that is the off-by-row that wedges the streaming engine.
+#[test]
+fn diagnostic_predicted_vs_actual_dims() {
+    let (pw, ph) = predicted_dims(Path::new(FIXTURE_PDF), DPI);
+    let raster =
+        render_page_pdfium(Path::new(FIXTURE_PDF), 1, DPI).expect("render_page_pdfium failed");
+    let (aw, ah) = (raster.width(), raster.height());
+
+    eprintln!("blueprint.pdf @ {DPI} DPI:");
+    eprintln!("  predicted: {pw} x {ph}");
+    eprintln!("  actual:    {aw} x {ah}");
+    eprintln!(
+        "  delta:     dw={} dh={}",
+        aw as i64 - pw as i64,
+        ah as i64 - ph as i64,
+    );
+
+    // We don't fail this test — it's purely diagnostic. The streaming
+    // tests below will panic if the delta matters.
+}
+
+/// Replicates PR #96's code path verbatim with a 1MB memory budget on the
+/// blueprint.pdf fixture. If `streaming.rs` panics here, we have a
+/// bug-in-libviprs reproduction without needing the original failing PDF.
+///
+/// Marked `#[ignore]` because it intentionally panics — opt in with
+/// `cargo test --test streaming_pdfium_repro -- --ignored` to reproduce.
+/// Remove the attribute once libviprs#41 is fixed so this becomes a
+/// regression guard.
+#[test]
+#[ignore = "intentionally panics; reproduces libviprs#41"]
+fn pdfium_streaming_blueprint_1mb_budget_replicates_pr96() {
+    let path = Path::new(FIXTURE_PDF);
+    let (width_px, height_px) = predicted_dims(path, DPI);
+
+    let strip_src = PdfiumStripSource::new(path, 1, DPI, width_px, height_px);
+    let planner = PyramidPlanner::new(width_px, height_px, TILE_SIZE, 0, Layout::Google)
+        .expect("PyramidPlanner::new failed");
+    let plan = planner.plan();
+
+    let sink = MemorySink::new();
+    let mut engine = EngineConfig::default();
+    engine.background_rgb = BACKGROUND_RGB;
+    let config = StreamingConfig {
+        memory_budget_bytes: MEMORY_BUDGET_BYTES_1MB,
+        engine,
+    };
+
+    // If this panics with "range end index N out of range for slice of
+    // length M" inside libviprs::streaming, we have reproduced #95/#96.
+    let result = generate_pyramid_streaming(&strip_src, &plan, &sink, &config, &NoopObserver)
+        .expect("generate_pyramid_streaming failed (non-panic error)");
+
+    assert_eq!(
+        result.tiles_produced,
+        plan.total_tile_count(),
+        "tile count mismatch (produced != planned)"
+    );
+}
+
+/// Same call sequence at the 2MB budget that the PR author tried after
+/// the 1MB budget panicked. Matches the report that doubling the budget
+/// did not change the panic. Same `#[ignore]` rationale as the 1MB test.
+#[test]
+#[ignore = "intentionally panics; reproduces libviprs#41"]
+fn pdfium_streaming_blueprint_2mb_budget_replicates_pr96_followup() {
+    let path = Path::new(FIXTURE_PDF);
+    let (width_px, height_px) = predicted_dims(path, DPI);
+
+    let strip_src = PdfiumStripSource::new(path, 1, DPI, width_px, height_px);
+    let planner = PyramidPlanner::new(width_px, height_px, TILE_SIZE, 0, Layout::Google)
+        .expect("PyramidPlanner::new failed");
+    let plan = planner.plan();
+
+    let sink = MemorySink::new();
+    let mut engine = EngineConfig::default();
+    engine.background_rgb = BACKGROUND_RGB;
+    let config = StreamingConfig {
+        memory_budget_bytes: MEMORY_BUDGET_BYTES_2MB,
+        engine,
+    };
+
+    let result = generate_pyramid_streaming(&strip_src, &plan, &sink, &config, &NoopObserver)
+        .expect("generate_pyramid_streaming failed (non-panic error)");
+    assert_eq!(result.tiles_produced, plan.total_tile_count());
+}
+
+/// Control: feed the *actual* rendered dimensions (from `render_page_pdfium`)
+/// to both `PdfiumStripSource` and `PyramidPlanner`. If this passes while
+/// the predicted-dims tests above panic, the bug is the prediction-vs-actual
+/// dimension mismatch (and the fix in istracked/server is to render first
+/// and use `raster.width()/height()`, mirroring the pre-PR code path).
+#[test]
+fn pdfium_streaming_blueprint_actual_dims_should_pass() {
+    let path = Path::new(FIXTURE_PDF);
+    let raster = render_page_pdfium(path, 1, DPI).expect("render_page_pdfium failed");
+    let (width_px, height_px) = (raster.width(), raster.height());
+    drop(raster); // PdfiumStripSource will re-render lazily.
+
+    let strip_src = PdfiumStripSource::new(path, 1, DPI, width_px, height_px);
+    let planner = PyramidPlanner::new(width_px, height_px, TILE_SIZE, 0, Layout::Google)
+        .expect("PyramidPlanner::new failed");
+    let plan = planner.plan();
+
+    let sink = MemorySink::new();
+    let mut engine = EngineConfig::default();
+    engine.background_rgb = BACKGROUND_RGB;
+    let config = StreamingConfig {
+        memory_budget_bytes: MEMORY_BUDGET_BYTES_1MB,
+        engine,
+    };
+
+    let result = generate_pyramid_streaming(&strip_src, &plan, &sink, &config, &NoopObserver)
+        .expect("generate_pyramid_streaming failed (non-panic error)");
+    assert_eq!(result.tiles_produced, plan.total_tile_count());
+}


### PR DESCRIPTION
## Summary

Adds `tests/streaming_pdfium_repro.rs` reproducing the slice OOB panic from [libviprs#41](https://github.com/libviprs/libviprs/issues/41) on the existing `blueprint.pdf` fixture.

## Tests

- `pdfium_streaming_blueprint_1mb_budget_replicates_pr96` — `#[ignore]` (intentionally panics)
- `pdfium_streaming_blueprint_2mb_budget_replicates_pr96_followup` — `#[ignore]` (intentionally panics; same panic, different memory budget)
- `pdfium_streaming_blueprint_actual_dims_should_pass` — control test, passes when actual rendered dims are passed instead of `pdf_info`-predicted
- `diagnostic_predicted_vs_actual_dims` — prints predicted vs actual dimensions

Run the panicking cases with:

```
cargo test --test streaming_pdfium_repro -- --ignored
```

Once libviprs#41 is fixed, drop the `#[ignore]` attributes so they become regression guards.

## Why two commits

The first commit (`fix: update tests for libviprs API drift`) updates `tests/streaming_engine.rs` and `tests/blank_tile_strategy.rs` for `pub`-export reorganisation in libviprs (`compute_strip_height` / `estimate_streaming_memory` now live in `libviprs::streaming`; `BLANK_TILE_MARKER` / `is_blank_tile` moved into `libviprs::sink` / `libviprs::engine`). Without this, `cargo clippy --all-targets` (and the pre-commit hook) fails on plain `main`.

The second commit adds the reproduction test itself.