### PR TITLE
ci: serialize pdfium test workers (--test-threads=1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,10 @@ jobs:
           sudo cp pdfium/lib/libpdfium.so /usr/local/lib/
           sudo cp -r pdfium/include/* /usr/local/include/
           sudo ldconfig
-      - run: cargo test --features pdfium
+      # Pdfium FFI calls are not safe to invoke concurrently against the
+      # shared process-wide Pdfium instance — parallel cargo-test workers
+      # race FPDF state. Force serial execution within each test binary.
+      - run: cargo test --features pdfium -- --test-threads=1
 
   lint:
     name: Lint


### PR DESCRIPTION
Stacked on top of #27.

Adds \`--test-threads=1\` to the \`Integration Tests (pdfium)\` CI job. The CI run on #27 surfaced a SIGSEGV in \`pdfium_integration\` mid-suite — pdfium's FFI is not safe to invoke concurrently against the shared process-wide \`Pdfium\` instance that libviprs#43 introduced, and parallel cargo-test workers within a binary race FPDF state.

Local runs already used \`--test-threads=1\`; this brings CI in line.

Once this lands on \`test/pdfium-streaming-source\`, #27's CI will pick up the fix on its next rerun.