### PR TITLE
merge: bring main into tests/phase3-hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,10 @@ jobs:
           sudo cp pdfium/lib/libpdfium.so /usr/local/lib/
           sudo cp -r pdfium/include/* /usr/local/include/
           sudo ldconfig
-      - run: cargo test --features pdfium
+      # Pdfium FFI calls are not safe to invoke concurrently against the
+      # shared process-wide Pdfium instance — parallel cargo-test workers
+      # race FPDF state. Force serial execution within each test binary.
+      - run: cargo test --features pdfium -- --test-threads=1
 
   lint:
     name: Lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ CMD sh -c '\
     echo "================================================================" && \
     echo "Running libviprs unit tests (with pdfium)..." && \
     echo "================================================================" && \
-    cd /src/libviprs && cargo test --features pdfium && \
+    cd /src/libviprs && cargo test --features pdfium -- --test-threads=1 && \
     echo "" && \
     echo "Cleaning libviprs build artifacts to free disk space..." && \
     cargo clean && \
@@ -58,4 +58,4 @@ CMD sh -c '\
     echo "================================================================" && \
     echo "Running libviprs-tests integration tests (with pdfium)..." && \
     echo "================================================================" && \
-    cd /src/libviprs-tests && cargo test --features pdfium'
+    cd /src/libviprs-tests && cargo test --features pdfium -- --test-threads=1'

--- a/tests/pdfium_integration.rs
+++ b/tests/pdfium_integration.rs
@@ -1,7 +1,25 @@
 #![cfg(feature = "pdfium")]
 
+// All assertions live inside a single `#[test]` function on purpose.
+//
+// pdfium-render holds process-wide FFI state inside libpdfium.so. With
+// `--test-threads=1`, libtest still runs each `#[test]` function on its
+// own worker invocation: each invocation creates and drops `PdfDocument`
+// values that release pdfium-internal resources. A second test invocation
+// in the same process then trips a double-free / SIGABRT (locally) or
+// hangs in the C library (on the CI runner).
+//
+// libviprs already serializes Pdfium creation behind `OnceLock<Pdfium>`
+// (see `libviprs::pdf::init_pdfium`), so the singleton itself is safe.
+// What is not safe is repeatedly tearing down `PdfDocument` instances
+// across multiple top-level tests in one binary. Wrapping every smoke
+// check in a single test function keeps document lifetimes nested and
+// avoids the cross-test corruption.
+//
+// Direct, raw-Pdfium smoke checks live in `pdfium_system_check.rs` and
+// run only via `--ignored`.
+
 use libviprs::pdf::{render_page_pdfium, render_page_pdfium_budgeted};
-use pdfium_render::prelude::*;
 use std::path::Path;
 
 const FIXTURE_PDF: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/blueprint.pdf");
@@ -12,172 +30,99 @@ const DEFAULT_DPI: u32 = 72;
 /// Default pixel budget for budgeted rendering tests (100 megapixels).
 const DEFAULT_MAX_PIXELS: u64 = 100_000_000;
 
-/// Verify that the PDFium shared library can be found on this system.
 #[test]
-fn pdfium_library_loads() {
-    let pdfium = Pdfium::default();
-    // If we get here, the library was found and loaded successfully.
-    // Load a trivial document to confirm it's functional.
-    let doc = pdfium.load_pdf_from_file(FIXTURE_PDF, None);
-    assert!(
-        doc.is_ok(),
-        "PDFium loaded but failed to open fixture PDF: {:?}",
-        doc.err()
-    );
-}
+fn libviprs_pdfium_render_paths() {
+    // render_page_pdfium produces a valid Raster.
+    {
+        let raster =
+            render_page_pdfium(Path::new(FIXTURE_PDF), 1, 72).expect("render_page_pdfium failed");
+        assert!(
+            raster.width() > 100,
+            "Rendered raster too narrow: {}",
+            raster.width()
+        );
+        assert!(
+            raster.height() > 100,
+            "Rendered raster too short: {}",
+            raster.height()
+        );
+        assert_eq!(raster.format(), libviprs::PixelFormat::Rgba8);
+    }
 
-/// Verify we can read page count and dimensions via pdfium.
-#[test]
-fn pdfium_reads_page_info() {
-    let pdfium = Pdfium::default();
-    let doc = pdfium
-        .load_pdf_from_file(FIXTURE_PDF, None)
-        .expect("failed to load fixture PDF");
-    let pages = doc.pages();
+    // Invalid page number returns a typed error.
+    {
+        let result = render_page_pdfium(Path::new(FIXTURE_PDF), 999, 72);
+        assert!(result.is_err(), "Expected error for out-of-range page");
+    }
 
-    assert!(pages.len() >= 1, "Expected at least 1 page");
+    // Missing file returns a typed error.
+    {
+        let result = render_page_pdfium(Path::new("/nonexistent.pdf"), 1, 72);
+        assert!(result.is_err(), "Expected error for missing file");
+    }
 
-    let page = pages.get(0).expect("failed to get first page");
-    let width = page.width().value;
-    let height = page.height().value;
+    // Budgeted render at default DPI when budget is generous.
+    {
+        let result =
+            render_page_pdfium_budgeted(Path::new(FIXTURE_PDF), 1, DEFAULT_DPI, DEFAULT_MAX_PIXELS)
+                .expect("budgeted render failed");
+        assert!(!result.capped, "Should not be capped at {DEFAULT_DPI} DPI");
+        assert_eq!(result.dpi_used, DEFAULT_DPI);
+        assert!(result.raster.width() > 100);
+        assert!(result.raster.height() > 100);
+        assert_eq!(result.raster.format(), libviprs::PixelFormat::Rgba8);
+    }
 
-    assert!(width > 0.0, "Page width should be > 0, got {width}");
-    assert!(height > 0.0, "Page height should be > 0, got {height}");
-}
+    // Budgeted render caps DPI when the pixel budget is small.
+    {
+        let tiny_budget: u64 = 100 * 100; // 10,000 pixels
+        let result =
+            render_page_pdfium_budgeted(Path::new(FIXTURE_PDF), 1, DEFAULT_DPI, tiny_budget)
+                .expect("budgeted render failed");
+        assert!(result.capped, "Should be capped with tiny budget");
+        assert!(
+            result.dpi_used < DEFAULT_DPI,
+            "DPI should be reduced from {DEFAULT_DPI}, got {}",
+            result.dpi_used
+        );
+        let total_pixels = result.raster.width() as u64 * result.raster.height() as u64;
+        assert!(
+            total_pixels <= tiny_budget,
+            "Output {total_pixels} pixels exceeds budget {tiny_budget}"
+        );
+    }
 
-/// Verify pdfium can render a page to a bitmap at a reasonable DPI.
-#[test]
-fn pdfium_renders_page_to_bitmap() {
-    let pdfium = Pdfium::default();
-    let doc = pdfium
-        .load_pdf_from_file(FIXTURE_PDF, None)
-        .expect("failed to load fixture PDF");
-    let page = doc.pages().get(0).expect("failed to get first page");
+    // Budgeted render matches unbounded render when the budget is generous.
+    {
+        let unbounded =
+            render_page_pdfium(Path::new(FIXTURE_PDF), 1, DEFAULT_DPI).expect("render failed");
+        let budgeted =
+            render_page_pdfium_budgeted(Path::new(FIXTURE_PDF), 1, DEFAULT_DPI, DEFAULT_MAX_PIXELS)
+                .expect("budgeted render failed");
+        assert_eq!(unbounded.width(), budgeted.raster.width());
+        assert_eq!(unbounded.height(), budgeted.raster.height());
+        assert_eq!(unbounded.data(), budgeted.raster.data());
+    }
 
-    let dpi: f32 = 72.0;
-    let scale = dpi / 72.0;
-    let width = (page.width().value * scale) as i32;
-    let height = (page.height().value * scale) as i32;
+    // Budgeted render handles invalid page number gracefully.
+    {
+        let result = render_page_pdfium_budgeted(
+            Path::new(FIXTURE_PDF),
+            999,
+            DEFAULT_DPI,
+            DEFAULT_MAX_PIXELS,
+        );
+        assert!(result.is_err(), "Expected error for out-of-range page");
+    }
 
-    let config = PdfRenderConfig::new()
-        .set_target_width(width)
-        .set_maximum_height(height);
-
-    let bitmap = page.render_with_config(&config);
-    assert!(bitmap.is_ok(), "PDFium render failed: {:?}", bitmap.err());
-
-    let bmp = bitmap.unwrap();
-    let img = bmp.as_image();
-    let rgba = img.to_rgba8();
-
-    assert!(rgba.width() > 0, "Rendered width is 0");
-    assert!(rgba.height() > 0, "Rendered height is 0");
-}
-
-/// Verify that libviprs::render_page_pdfium produces a valid Raster.
-#[test]
-fn libviprs_render_page_pdfium() {
-    let raster =
-        render_page_pdfium(Path::new(FIXTURE_PDF), 1, 72).expect("render_page_pdfium failed");
-
-    assert!(
-        raster.width() > 100,
-        "Rendered raster too narrow: {}",
-        raster.width()
-    );
-    assert!(
-        raster.height() > 100,
-        "Rendered raster too short: {}",
-        raster.height()
-    );
-    assert_eq!(raster.format(), libviprs::PixelFormat::Rgba8);
-}
-
-/// Verify pdfium handles an invalid page number gracefully.
-#[test]
-fn libviprs_render_page_pdfium_invalid_page() {
-    let result = render_page_pdfium(Path::new(FIXTURE_PDF), 999, 72);
-    assert!(result.is_err(), "Expected error for out-of-range page");
-}
-
-/// Verify pdfium handles a nonexistent file gracefully.
-#[test]
-fn libviprs_render_page_pdfium_missing_file() {
-    let result = render_page_pdfium(Path::new("/nonexistent.pdf"), 1, 72);
-    assert!(result.is_err(), "Expected error for missing file");
-}
-
-// ---------------------------------------------------------------------------
-// render_page_pdfium_budgeted tests
-// ---------------------------------------------------------------------------
-
-/// Verify that budgeted rendering produces a valid Raster at default DPI
-/// when the pixel budget is large enough to not constrain.
-#[test]
-fn libviprs_render_page_pdfium_budgeted_uncapped() {
-    let result =
-        render_page_pdfium_budgeted(Path::new(FIXTURE_PDF), 1, DEFAULT_DPI, DEFAULT_MAX_PIXELS)
-            .expect("budgeted render failed");
-
-    assert!(!result.capped, "Should not be capped at {DEFAULT_DPI} DPI");
-    assert_eq!(result.dpi_used, DEFAULT_DPI);
-    assert!(result.raster.width() > 100);
-    assert!(result.raster.height() > 100);
-    assert_eq!(result.raster.format(), libviprs::PixelFormat::Rgba8);
-}
-
-/// Verify that budgeted rendering caps DPI when the pixel budget is small.
-#[test]
-fn libviprs_render_page_pdfium_budgeted_capped() {
-    // Use a tiny budget that forces DPI reduction even at 72 DPI
-    let tiny_budget: u64 = 100 * 100; // 10,000 pixels
-    let result = render_page_pdfium_budgeted(Path::new(FIXTURE_PDF), 1, DEFAULT_DPI, tiny_budget)
-        .expect("budgeted render failed");
-
-    assert!(result.capped, "Should be capped with tiny budget");
-    assert!(
-        result.dpi_used < DEFAULT_DPI,
-        "DPI should be reduced from {DEFAULT_DPI}, got {}",
-        result.dpi_used
-    );
-    let total_pixels = result.raster.width() as u64 * result.raster.height() as u64;
-    assert!(
-        total_pixels <= tiny_budget,
-        "Output {total_pixels} pixels exceeds budget {tiny_budget}"
-    );
-}
-
-/// Verify that budgeted rendering matches unbounded rendering when the
-/// budget is large enough.
-#[test]
-fn libviprs_render_page_pdfium_budgeted_matches_unbounded() {
-    let unbounded =
-        render_page_pdfium(Path::new(FIXTURE_PDF), 1, DEFAULT_DPI).expect("render failed");
-    let budgeted =
-        render_page_pdfium_budgeted(Path::new(FIXTURE_PDF), 1, DEFAULT_DPI, DEFAULT_MAX_PIXELS)
-            .expect("budgeted render failed");
-
-    assert_eq!(unbounded.width(), budgeted.raster.width());
-    assert_eq!(unbounded.height(), budgeted.raster.height());
-    assert_eq!(unbounded.data(), budgeted.raster.data());
-}
-
-/// Verify budgeted rendering handles an invalid page number gracefully.
-#[test]
-fn libviprs_render_page_pdfium_budgeted_invalid_page() {
-    let result =
-        render_page_pdfium_budgeted(Path::new(FIXTURE_PDF), 999, DEFAULT_DPI, DEFAULT_MAX_PIXELS);
-    assert!(result.is_err(), "Expected error for out-of-range page");
-}
-
-/// Verify budgeted rendering handles a nonexistent file gracefully.
-#[test]
-fn libviprs_render_page_pdfium_budgeted_missing_file() {
-    let result = render_page_pdfium_budgeted(
-        Path::new("/nonexistent.pdf"),
-        1,
-        DEFAULT_DPI,
-        DEFAULT_MAX_PIXELS,
-    );
-    assert!(result.is_err(), "Expected error for missing file");
+    // Budgeted render handles missing file gracefully.
+    {
+        let result = render_page_pdfium_budgeted(
+            Path::new("/nonexistent.pdf"),
+            1,
+            DEFAULT_DPI,
+            DEFAULT_MAX_PIXELS,
+        );
+        assert!(result.is_err(), "Expected error for missing file");
+    }
 }

--- a/tests/streaming_engine.rs
+++ b/tests/streaming_engine.rs
@@ -31,6 +31,7 @@
 
 use std::path::Path;
 
+use libviprs::streaming::BudgetPolicy;
 use libviprs::{
     BlankTileStrategy, CollectingObserver, EngineConfig, EngineEvent, Layout, MemorySink,
     PixelFormat, PyramidPlanner, Raster, RasterStripSource, StreamingConfig, generate_pyramid,
@@ -160,6 +161,7 @@ fn streaming_parity_deepzoom_512x384() {
     let streaming_config = StreamingConfig {
         memory_budget_bytes: 500_000, // Force streaming
         engine: EngineConfig::default(),
+        budget_policy: BudgetPolicy::Error,
     };
     let test_tiles = streaming_tiles(&src, &plan, &streaming_config);
     assert_tiles_match(&ref_tiles, &test_tiles, "DeepZoom 512x384 streaming");
@@ -173,8 +175,10 @@ fn streaming_parity_deepzoom_300x200() {
 
     let ref_tiles = monolithic_tiles(&src, &plan, &EngineConfig::default());
     let streaming_config = StreamingConfig {
-        memory_budget_bytes: 200_000,
+        // Pre-flight minimum: 300 * (2*128) * 4 = 307_200 bytes
+        memory_budget_bytes: 400_000,
         engine: EngineConfig::default(),
+        budget_policy: BudgetPolicy::Error,
     };
     let test_tiles = streaming_tiles(&src, &plan, &streaming_config);
     assert_tiles_match(&ref_tiles, &test_tiles, "DeepZoom 300x200 streaming");
@@ -190,8 +194,11 @@ fn streaming_parity_deepzoom_odd_dimensions() {
 
         let ref_tiles = monolithic_tiles(&src, &plan, &EngineConfig::default());
         let streaming_config = StreamingConfig {
-            memory_budget_bytes: 500_000,
+            // Pre-flight minimum at worst case (1023x769, tile=256):
+            // 1023 * (2*256) * 4 = 2_095_104 bytes
+            memory_budget_bytes: 2_500_000,
             engine: EngineConfig::default(),
+            budget_policy: BudgetPolicy::Error,
         };
         let test_tiles = streaming_tiles(&src, &plan, &streaming_config);
         assert_tiles_match(
@@ -216,6 +223,7 @@ fn auto_selects_monolithic_for_large_budget() {
     let config = StreamingConfig {
         memory_budget_bytes: u64::MAX, // Huge budget → monolithic
         engine: EngineConfig::default(),
+        budget_policy: BudgetPolicy::Error,
     };
     let test_tiles = auto_tiles(&src, &plan, &config);
     assert_tiles_match(&ref_tiles, &test_tiles, "auto large budget");
@@ -229,8 +237,11 @@ fn auto_selects_streaming_for_tiny_budget() {
 
     let sink = MemorySink::new();
     let config = StreamingConfig {
-        memory_budget_bytes: 1_000, // Tiny → streaming
+        // Pre-flight minimum: 512 * (2*256) * 4 = 1_048_576 bytes.
+        // Stays well below monolithic peak so auto-router still picks streaming.
+        memory_budget_bytes: 1_200_000,
         engine: EngineConfig::default(),
+        budget_policy: BudgetPolicy::Error,
     };
     let result = generate_pyramid_auto(
         &src,
@@ -257,8 +268,11 @@ fn streaming_deterministic_across_tile_sizes() {
 
         let ref_tiles = monolithic_tiles(&src, &plan, &EngineConfig::default());
         let streaming_config = StreamingConfig {
-            memory_budget_bytes: 200_000,
+            // Pre-flight minimum at worst case (tile=256):
+            // 300 * (2*256) * 4 = 614_400 bytes
+            memory_budget_bytes: 700_000,
             engine: EngineConfig::default(),
+            budget_policy: BudgetPolicy::Error,
         };
         let test_tiles = streaming_tiles(&src, &plan, &streaming_config);
         assert_tiles_match(&ref_tiles, &test_tiles, &format!("tile_size={tile_size}"));
@@ -279,8 +293,11 @@ fn streaming_parity_google_centre_small() {
 
     let ref_tiles = monolithic_tiles(&src, &plan, &EngineConfig::default());
     let streaming_config = StreamingConfig {
-        memory_budget_bytes: 500_000,
+        // Pre-flight minimum: Google centre pads canvas; observed worst case
+        // 786_432 bytes for this fixture (per BudgetExceeded report).
+        memory_budget_bytes: 1_000_000,
         engine: EngineConfig::default(),
+        budget_policy: BudgetPolicy::Error,
     };
     let test_tiles = streaming_tiles(&src, &plan, &streaming_config);
     assert_tiles_match(&ref_tiles, &test_tiles, "Google centre 400x300");
@@ -294,8 +311,11 @@ fn streaming_parity_google_no_centre() {
 
     let ref_tiles = monolithic_tiles(&src, &plan, &EngineConfig::default());
     let streaming_config = StreamingConfig {
-        memory_budget_bytes: 500_000,
+        // Pre-flight minimum: Google layout pads canvas; observed worst case
+        // 786_432 bytes for this fixture (per BudgetExceeded report).
+        memory_budget_bytes: 1_000_000,
         engine: EngineConfig::default(),
+        budget_policy: BudgetPolicy::Error,
     };
     let test_tiles = streaming_tiles(&src, &plan, &streaming_config);
     assert_tiles_match(&ref_tiles, &test_tiles, "Google no-centre 500x300");
@@ -316,6 +336,7 @@ fn streaming_observer_events() {
     let config = StreamingConfig {
         memory_budget_bytes: 500_000,
         engine: EngineConfig::default(),
+        budget_policy: BudgetPolicy::Error,
     };
     let strip_src = RasterStripSource::new(&src);
     let result = generate_pyramid_streaming(&strip_src, &plan, &sink, &config, &obs).unwrap();
@@ -362,6 +383,7 @@ fn streaming_blank_tile_placeholder_solid_white() {
     let config = StreamingConfig {
         memory_budget_bytes: 50_000,
         engine: EngineConfig::default().with_blank_tile_strategy(BlankTileStrategy::Placeholder),
+        budget_policy: BudgetPolicy::Error,
     };
     let strip_src = RasterStripSource::new(&src);
     let result = generate_pyramid_streaming(
@@ -386,6 +408,7 @@ fn streaming_blank_tile_placeholder_gradient() {
     let config = StreamingConfig {
         memory_budget_bytes: 50_000,
         engine: EngineConfig::default().with_blank_tile_strategy(BlankTileStrategy::Placeholder),
+        budget_policy: BudgetPolicy::Error,
     };
     let strip_src = RasterStripSource::new(&src);
     let sink = MemorySink::new();
@@ -424,6 +447,7 @@ fn streaming_parity_blueprint_portrait() {
     let streaming_config = StreamingConfig {
         memory_budget_bytes: 2_000_000, // 2 MB — forces streaming for 3300x5024
         engine: EngineConfig::default(),
+        budget_policy: BudgetPolicy::Error,
     };
     let test_tiles = streaming_tiles(&src, &plan, &streaming_config);
     assert_tiles_match(&ref_tiles, &test_tiles, "blueprint portrait DeepZoom");
@@ -443,6 +467,7 @@ fn streaming_parity_blueprint_portrait_google_centre() {
     let streaming_config = StreamingConfig {
         memory_budget_bytes: 5_000_000, // 5 MB
         engine: EngineConfig::default(),
+        budget_policy: BudgetPolicy::Error,
     };
     let test_tiles = streaming_tiles(&src, &plan, &streaming_config);
     assert_tiles_match(&ref_tiles, &test_tiles, "blueprint portrait Google+centre");
@@ -462,11 +487,14 @@ fn streaming_peak_memory_lower_than_monolithic() {
     let mono_sink = MemorySink::new();
     let mono_result = generate_pyramid(&src, &plan, &mono_sink, &EngineConfig::default()).unwrap();
 
-    // Streaming with constrained budget
+    // Streaming with constrained budget. Pre-flight minimum:
+    // 2048 * (2*256) * 4 = 4_194_304 bytes. Bump to 5 MB — still much less
+    // than monolithic peak for a 2048x2048 pyramid.
     let streaming_sink = MemorySink::new();
     let config = StreamingConfig {
-        memory_budget_bytes: 1_000_000, // 1 MB
+        memory_budget_bytes: 5_000_000,
         engine: EngineConfig::default(),
+        budget_policy: BudgetPolicy::Error,
     };
     let strip_src = RasterStripSource::new(&src);
     let stream_result = generate_pyramid_streaming(
@@ -534,11 +562,15 @@ fn streaming_memory_savings_scale_with_image_size() {
         let mono_result =
             generate_pyramid(&src, &plan, &mono_sink, &EngineConfig::default()).unwrap();
 
-        // Streaming with 1 MB budget
+        // Per-image adaptive budget = 1.25 × pre-flight minimum
+        // (canvas_w * 2*tile_size * 4 bytes), keeping a tight bottleneck so
+        // streaming's memory savings remain visible at every image size.
         let stream_sink = MemorySink::new();
+        let min_budget = u64::from(plan.canvas_width) * u64::from(2 * plan.tile_size) * 4;
         let config = StreamingConfig {
-            memory_budget_bytes: 1_000_000,
+            memory_budget_bytes: min_budget * 5 / 4,
             engine: EngineConfig::default(),
+            budget_policy: BudgetPolicy::Error,
         };
         let strip_src = RasterStripSource::new(&src);
         let stream_result = generate_pyramid_streaming(

--- a/tests/streaming_pdfium_matrix.rs
+++ b/tests/streaming_pdfium_matrix.rs
@@ -1,0 +1,739 @@
+//! Tests for libviprs#42 — per-strip PDF rendering via
+//! `FPDF_RenderPageBitmapWithMatrix`.
+//!
+//! TDD spec for the new clean API:
+//!
+//!     PdfiumStripSource::new(path, page, dpi) -> Result<Self, PdfError>
+//!
+//! No `full_width`/`full_height` arguments. The source is the dimension
+//! authority (rotation-honoured, queried from pdfium metadata) and renders
+//! only the requested strip on each `render_strip` call — no full-page
+//! raster cache.
+//!
+//! These tests verify:
+//!
+//! 1. Constructor reports rotation-aware dimensions (within a few pixels of
+//!    the form-data baseline; orientation is preserved).
+//! 2. `render_strip` is deterministic — same inputs, identical bytes.
+//! 3. Stitched strips render the *same regions* as a full matrix-path
+//!    render, by per-channel mean. Pixel-exact equality is not asserted:
+//!    PDFium's matrix path is bitmap-size-dependent in its antialiasing and
+//!    image resampling, which is a property of the C library and not a
+//!    defect in our composition.
+//! 4. Boundary strips (top, middle, last partial) cover the corresponding
+//!    page region.
+//! 5. End-to-end `generate_pyramid_streaming` on the call shape that
+//!    triggered libviprs#41 succeeds — the bug is structurally gone now
+//!    that callers can no longer mis-predict dimensions.
+//! 6. Out-of-range errors are reported as typed `PdfError`, not panics.
+
+#![cfg(feature = "pdfium")]
+
+use std::path::Path;
+
+use libviprs::observe::NoopObserver;
+use libviprs::pdf::{PdfError, render_page_pdfium};
+use libviprs::streaming::{BudgetPolicy, StripSource, generate_pyramid_streaming};
+use libviprs::{
+    EngineConfig, EngineError, Layout, MemorySink, PdfiumStripSource, PixelFormat, PyramidPlan,
+    PyramidPlanner, StreamingConfig,
+};
+
+const FIXTURE_BLUEPRINT: &str =
+    concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/blueprint.pdf");
+const FIXTURE_PORTRAIT: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/blueprint-portrait.pdf"
+);
+const FIXTURE_MIX: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/blueprint-mix.pdf"
+);
+
+const TILE_SIZE: u32 = 256;
+const BACKGROUND_RGB: [u8; 3] = [0xE7, 0xE7, 0xE7];
+const FIXTURES: &[&str] = &[FIXTURE_BLUEPRINT, FIXTURE_PORTRAIT, FIXTURE_MIX];
+
+// ---------------------------------------------------------------------------
+// Constructor & metadata
+// ---------------------------------------------------------------------------
+
+/// The constructor is a metadata probe — it must report rotation-aware
+/// dimensions matching the form-data baseline within a few pixels and
+/// preserving orientation (landscape stays landscape, portrait stays
+/// portrait). The form-data path uses `set_target_width` which makes
+/// PDFium's internal aspect-preserving auto-scaler compute the final size
+/// via `round(source_dim * derived_scale)`; our streaming source uses a
+/// straight `(pts * scale) as u32` truncation. At high DPI those differ by
+/// up to a few pixels — that drift is fine as long as orientation is
+/// preserved and the magnitudes are close. The contract that matters for
+/// the streaming engine is determinism *within* the source itself, which
+/// the rest of the suite covers.
+#[test]
+fn new_reports_rotation_aware_dimensions() {
+    const DIM_DRIFT_TOLERANCE_PX: i64 = 4;
+    for &fixture in FIXTURES {
+        for &dpi in &[72u32, 150] {
+            let source = PdfiumStripSource::new(fixture, 1, dpi)
+                .unwrap_or_else(|e| panic!("PdfiumStripSource::new({fixture}, 1, {dpi}): {e:?}"));
+            let baseline = render_page_pdfium(Path::new(fixture), 1, dpi)
+                .unwrap_or_else(|e| panic!("render_page_pdfium({fixture}, 1, {dpi}): {e:?}"));
+            let dw = (source.width() as i64 - baseline.width() as i64).abs();
+            let dh = (source.height() as i64 - baseline.height() as i64).abs();
+            assert!(
+                dw <= DIM_DRIFT_TOLERANCE_PX && dh <= DIM_DRIFT_TOLERANCE_PX,
+                "dimension drift > {DIM_DRIFT_TOLERANCE_PX}px for {fixture} at {dpi} DPI: \
+                 source={}x{} baseline={}x{}",
+                source.width(),
+                source.height(),
+                baseline.width(),
+                baseline.height(),
+            );
+            let source_landscape = source.width() > source.height();
+            let baseline_landscape = baseline.width() > baseline.height();
+            assert_eq!(
+                source_landscape,
+                baseline_landscape,
+                "orientation mismatch for {fixture} at {dpi} DPI: \
+                 source={}x{} baseline={}x{}",
+                source.width(),
+                source.height(),
+                baseline.width(),
+                baseline.height(),
+            );
+        }
+    }
+}
+
+/// PDF rendering is RGBA8 in libviprs (pdfium emits BGRA; the source must
+/// convert before exposing). Format is fixed at construction.
+#[test]
+fn format_is_rgba8() {
+    let source = PdfiumStripSource::new(FIXTURE_BLUEPRINT, 1, 72).unwrap();
+    assert_eq!(source.format(), PixelFormat::Rgba8);
+}
+
+/// Page numbers are 1-based per the public contract; out-of-range pages
+/// must surface a typed error, not a panic.
+#[test]
+fn page_out_of_range_errors_typed() {
+    let result = PdfiumStripSource::new(FIXTURE_BLUEPRINT, 999, 72);
+    assert!(
+        result.is_err(),
+        "page 999 should error, got Ok with dims {:?}",
+        result.as_ref().map(|s| (s.width(), s.height()))
+    );
+}
+
+#[test]
+fn page_zero_errors_typed() {
+    let result = PdfiumStripSource::new(FIXTURE_BLUEPRINT, 0, 72);
+    assert!(result.is_err(), "page 0 (1-based contract) should error");
+}
+
+// ---------------------------------------------------------------------------
+// Strip correctness — what we can and cannot assert about PDFium's matrix
+// path:
+//
+//   * Pixel-exact equality of strip(K, h) and full[K..K+h] is not a property
+//     PDFium provides. FPDF_RenderPageBitmapWithMatrix's antialiasing and
+//     image-resampling output depends on the destination bitmap's size, even
+//     when the matrix and clip rect both point at the same source region.
+//     For some content (sharp glyph edges, raster images) we have empirically
+//     measured up to 15% of pixels in a strip differing from the same
+//     pixels in a full render, with channel deltas up to 172/255. This is a
+//     C-library property, not a defect in our composition — see
+//     `diag_strip_vs_full_per_row_diff`.
+//
+//   * What we *can* assert is that strip(K, h) renders the *correct region*
+//     of the page: orientation matches /Rotate, mean colour over the strip
+//     matches the mean over the corresponding full-render slice, and the
+//     stitched output covers the whole page exactly once with no overlap or
+//     gap. These catch the failure modes the original libviprs#41 test
+//     suite was meant to catch (wrong rotation, off-by-page-size shift,
+//     transposed scale) without pinning us to byte parity that the matrix
+//     path doesn't promise.
+//
+//   * Cross-path sanity (matrix vs form-data) only checks dimensions and
+//     pixel format. The two PDFium entry points are independent C functions
+//     with their own rasterizers and form-rendering settings; their pixel
+//     output legitimately differs on the order of 10% with arbitrary deltas.
+// ---------------------------------------------------------------------------
+
+/// Mean of each RGBA channel over `data`, returned as f64 to keep
+/// per-channel sums precise across million-pixel buffers.
+fn channel_means(data: &[u8]) -> [f64; 4] {
+    assert!(
+        data.len() % 4 == 0,
+        "RGBA8 byte length must be a multiple of 4"
+    );
+    let mut sums = [0u64; 4];
+    let pixels = data.len() / 4;
+    for chunk in data.chunks_exact(4) {
+        for i in 0..4 {
+            sums[i] += chunk[i] as u64;
+        }
+    }
+    let n = pixels.max(1) as f64;
+    [
+        sums[0] as f64 / n,
+        sums[1] as f64 / n,
+        sums[2] as f64 / n,
+        sums[3] as f64 / n,
+    ]
+}
+
+/// A strip that renders the wrong region (e.g. wrong rotation, off-by-page
+/// translation, transposed axes) lands on grossly different page content
+/// from `reference`. The mean of each channel is a coarse but extremely
+/// stable signal: even a 90° rotation across asymmetric content shifts the
+/// mean by tens of /255. PDFium's bitmap-size-dependent antialiasing, by
+/// contrast, perturbs the mean by well under 1.0 in our fixtures. A
+/// threshold of ±2.0 leaves comfortable headroom on both sides.
+const REGION_MEAN_TOLERANCE: f64 = 2.0;
+
+fn assert_renders_same_region(label: &str, actual: &[u8], reference: &[u8]) {
+    assert_eq!(
+        actual.len(),
+        reference.len(),
+        "{label}: byte-length mismatch (actual={}, reference={})",
+        actual.len(),
+        reference.len(),
+    );
+    let a = channel_means(actual);
+    let b = channel_means(reference);
+    let deltas = [a[0] - b[0], a[1] - b[1], a[2] - b[2], a[3] - b[3]];
+    let max = deltas.iter().map(|d| d.abs()).fold(0.0_f64, f64::max);
+    assert!(
+        max <= REGION_MEAN_TOLERANCE,
+        "{label}: per-channel mean drift {:.3} > {:.3} \
+         (actual={:?}, reference={:?}) — strip likely renders wrong region",
+        max,
+        REGION_MEAN_TOLERANCE,
+        a,
+        b,
+    );
+}
+
+/// Render the full page via the matrix path in one shot. This is the
+/// reference for the self-consistency gate.
+fn matrix_full_render(fixture: &str, dpi: u32) -> libviprs::Raster {
+    let source = PdfiumStripSource::new(fixture, 1, dpi).unwrap();
+    let h = source.height();
+    source
+        .render_strip(0, h)
+        .unwrap_or_else(|e| panic!("matrix_full_render({fixture}, {dpi}): {e:?}"))
+}
+
+fn stitch_strips(source: &PdfiumStripSource, strip_h: u32) -> Vec<u8> {
+    let mut out = Vec::with_capacity((source.width() * source.height() * 4) as usize);
+    let mut y = 0u32;
+    while y < source.height() {
+        let h = strip_h.min(source.height() - y);
+        let strip = source
+            .render_strip(y, h)
+            .unwrap_or_else(|e| panic!("render_strip({y}, {h}): {e:?}"));
+        assert_eq!(
+            strip.width(),
+            source.width(),
+            "strip at y={y}: width mismatch"
+        );
+        assert_eq!(strip.height(), h, "strip at y={y}: returned h != requested");
+        out.extend_from_slice(strip.data());
+        y += h;
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Self-consistency: stitched strips render the same regions as the full
+// matrix-path render (region-correctness via mean colour, not pixel
+// equality — see the rationale block above).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn full_height_strip_self_consistent() {
+    // Trivial sanity check on the reference itself: render_strip(0, H) twice
+    // must produce identical bytes. If this fails, render_strip is non-
+    // deterministic and the rest of the suite is meaningless.
+    for &fixture in FIXTURES {
+        let dpi = 72;
+        let source = PdfiumStripSource::new(fixture, 1, dpi).unwrap();
+        let a = source.render_strip(0, source.height()).unwrap();
+        let b = source.render_strip(0, source.height()).unwrap();
+        assert!(
+            a.data() == b.data(),
+            "{fixture}: render_strip is non-deterministic"
+        );
+    }
+}
+
+#[test]
+fn strips_stitched_equal_matrix_full_72_dpi() {
+    stitched_self_consistency_for(FIXTURE_BLUEPRINT, 72);
+    stitched_self_consistency_for(FIXTURE_PORTRAIT, 72);
+    stitched_self_consistency_for(FIXTURE_MIX, 72);
+}
+
+#[test]
+fn strips_stitched_equal_matrix_full_150_dpi() {
+    stitched_self_consistency_for(FIXTURE_BLUEPRINT, 150);
+    stitched_self_consistency_for(FIXTURE_PORTRAIT, 150);
+}
+
+fn stitched_self_consistency_for(fixture: &str, dpi: u32) {
+    let source = PdfiumStripSource::new(fixture, 1, dpi).unwrap();
+    let reference = matrix_full_render(fixture, dpi);
+    assert_eq!(reference.width(), source.width());
+    assert_eq!(reference.height(), source.height());
+    for &strip_h in &[64u32, 128, 256, 512] {
+        let stitched = stitch_strips(&source, strip_h);
+        let label = format!("{fixture} dpi={dpi} strip_h={strip_h}");
+        assert_renders_same_region(&label, &stitched, reference.data());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Boundary cases (region-correctness)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn first_strip_y_zero_matches_matrix_full_top() {
+    let dpi = 72;
+    let source = PdfiumStripSource::new(FIXTURE_BLUEPRINT, 1, dpi).unwrap();
+    let reference = matrix_full_render(FIXTURE_BLUEPRINT, dpi);
+    let h = 64u32;
+    let strip = source.render_strip(0, h).unwrap();
+    let row_bytes = (reference.width() * 4) as usize;
+    let top = &reference.data()[..row_bytes * h as usize];
+    assert_renders_same_region("top strip vs matrix-full top", strip.data(), top);
+}
+
+#[test]
+fn middle_strip_matches_matrix_full_middle() {
+    let dpi = 72;
+    let source = PdfiumStripSource::new(FIXTURE_BLUEPRINT, 1, dpi).unwrap();
+    let reference = matrix_full_render(FIXTURE_BLUEPRINT, dpi);
+    let mid = source.height() / 2;
+    let h = 64u32.min(source.height() - mid);
+    let strip = source.render_strip(mid, h).unwrap();
+    let row_bytes = (reference.width() * 4) as usize;
+    let start = row_bytes * mid as usize;
+    let end = start + row_bytes * h as usize;
+    assert_renders_same_region(
+        "mid-page strip vs matrix-full middle",
+        strip.data(),
+        &reference.data()[start..end],
+    );
+}
+
+#[test]
+fn last_partial_strip_clipped_to_available() {
+    let dpi = 72;
+    let source = PdfiumStripSource::new(FIXTURE_BLUEPRINT, 1, dpi).unwrap();
+    let reference = matrix_full_render(FIXTURE_BLUEPRINT, dpi);
+    let last_full_y = source.height() - 1;
+    let strip = source.render_strip(last_full_y, 256).unwrap();
+    assert!(
+        strip.height() <= 256,
+        "returned h ({}) must not exceed requested",
+        strip.height()
+    );
+    assert!(
+        strip.height() >= 1,
+        "expected at least one row; got {}",
+        strip.height()
+    );
+    let row_bytes = (reference.width() * 4) as usize;
+    let tail = &reference.data()[row_bytes * last_full_y as usize..];
+    assert_renders_same_region("last-row strip vs matrix-full tail", strip.data(), tail);
+}
+
+// ---------------------------------------------------------------------------
+// Cross-path sanity: matrix-full vs form-data baseline (structural only)
+// ---------------------------------------------------------------------------
+//
+// Why no pixel comparison: FPDF_RenderPageBitmap and FPDF_RenderPageBitmap-
+// WithMatrix are independent C entry points in PDFium with separate
+// coordinate setup, antialiasing, and form-rendering pipelines. Empirically
+// they disagree on ~5-10% of pixels with full-channel-range deltas on
+// fixtures with annotations or rasters — that drift is not a correctness
+// signal for our streaming source. We assert only that the two paths agree
+// on output dimensions and pixel format, which is the property a downstream
+// pyramid pipeline actually relies on.
+
+/// Diagnostic: print per-row differing pixel counts so we can see whether
+/// strip(K, h) diverges from full[K..K+h] uniformly across the strip, only
+/// near boundaries, or in some other pattern. Marked #[ignore] — opt in by
+/// running explicitly when investigating.
+#[test]
+#[ignore]
+fn diag_strip_vs_full_per_row_diff() {
+    for &fixture in FIXTURES {
+        for &dpi in &[72u32, 150] {
+            for &strip_h in &[64u32, 128, 256, 512] {
+                eprintln!("\n=== {fixture} dpi={dpi} strip_h={strip_h} ===");
+                let source = PdfiumStripSource::new(fixture, 1, dpi).unwrap();
+                let reference = matrix_full_render(fixture, dpi);
+                let w = source.width();
+                let row_bytes = (w * 4) as usize;
+                let mut printed = 0;
+                let mut total_diff_rows = 0usize;
+                let mut overall_max_delta = 0u8;
+                let mut overall_diff_pixels = 0usize;
+                let mut y = 0u32;
+                while y < source.height() {
+                    let h = strip_h.min(source.height() - y);
+                    let strip = source.render_strip(y, h).unwrap();
+                    for row in 0..h {
+                        let r0 = (row as usize) * row_bytes;
+                        let r1 = r0 + row_bytes;
+                        let strip_row = &strip.data()[r0..r1];
+                        let full_row_start = ((y + row) as usize) * row_bytes;
+                        let full_row =
+                            &reference.data()[full_row_start..full_row_start + row_bytes];
+                        let diff_pixels = strip_row
+                            .chunks_exact(4)
+                            .zip(full_row.chunks_exact(4))
+                            .filter(|(a, b)| a != b)
+                            .count();
+                        if diff_pixels > 0 {
+                            total_diff_rows += 1;
+                            overall_diff_pixels += diff_pixels;
+                            let max_delta: u8 = strip_row
+                                .iter()
+                                .zip(full_row.iter())
+                                .map(|(a, b)| a.abs_diff(*b))
+                                .max()
+                                .unwrap_or(0);
+                            if max_delta > overall_max_delta {
+                                overall_max_delta = max_delta;
+                            }
+                            if printed < 8 {
+                                eprintln!(
+                                    "  diff y={} strip_row={} diff_pixels={}/{} max_delta={}",
+                                    y + row,
+                                    row,
+                                    diff_pixels,
+                                    w,
+                                    max_delta
+                                );
+                                printed += 1;
+                            }
+                        }
+                    }
+                    y += h;
+                }
+                eprintln!(
+                    "  SUMMARY: {} diff rows, {} diff pixels, overall max delta = {}",
+                    total_diff_rows, overall_diff_pixels, overall_max_delta
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn matrix_full_structural_match_with_form_data_baseline() {
+    const DIM_DRIFT_TOLERANCE_PX: i64 = 4;
+    for &fixture in FIXTURES {
+        let dpi = 72;
+        let matrix = matrix_full_render(fixture, dpi);
+        let baseline = render_page_pdfium(Path::new(fixture), 1, dpi).unwrap();
+        let dw = (matrix.width() as i64 - baseline.width() as i64).abs();
+        let dh = (matrix.height() as i64 - baseline.height() as i64).abs();
+        assert!(
+            dw <= DIM_DRIFT_TOLERANCE_PX && dh <= DIM_DRIFT_TOLERANCE_PX,
+            "{fixture}: matrix vs form-data dimension drift > {DIM_DRIFT_TOLERANCE_PX}px \
+             (matrix={}x{}, baseline={}x{})",
+            matrix.width(),
+            matrix.height(),
+            baseline.width(),
+            baseline.height(),
+        );
+        assert_eq!(matrix.format(), baseline.format(), "{fixture}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end with the streaming pyramid engine
+// ---------------------------------------------------------------------------
+
+/// This is the exact call shape that triggered libviprs#41. With the new
+/// dim-authority source, the panic is structurally impossible: there is
+/// nothing for the caller to mis-predict. Each call sizes its budget from
+/// the plan's canvas width (which Google layout pads to a power-of-two
+/// multiple of the tile size), so the budget is just large enough to clear
+/// the engine's pre-flight check — exercising the real path, not a no-op.
+#[test]
+fn generate_pyramid_streaming_blueprint_pre_flight_min() {
+    end_to_end_streaming_pre_flight_min(FIXTURE_BLUEPRINT);
+}
+
+#[test]
+fn generate_pyramid_streaming_blueprint_generous() {
+    end_to_end_streaming_generous(FIXTURE_BLUEPRINT, 4);
+}
+
+#[test]
+fn generate_pyramid_streaming_portrait_pre_flight_min() {
+    end_to_end_streaming_pre_flight_min(FIXTURE_PORTRAIT);
+}
+
+#[test]
+fn generate_pyramid_streaming_mix_pre_flight_min() {
+    end_to_end_streaming_pre_flight_min(FIXTURE_MIX);
+}
+
+/// Budget = minimum strip the engine pre-flight will accept for the plan's
+/// (Google-padded) canvas width. Verifies streaming completes at the
+/// boundary, not just with comfortable headroom.
+fn end_to_end_streaming_pre_flight_min(fixture: &str) {
+    let dpi = 72;
+    let source = PdfiumStripSource::new(fixture, 1, dpi).unwrap();
+    let plan = PyramidPlanner::new(
+        source.width(),
+        source.height(),
+        TILE_SIZE,
+        0,
+        Layout::Google,
+    )
+    .expect("PyramidPlanner::new")
+    .plan();
+    let canvas_w = plan.canvas_width;
+    let budget = canvas_w as u64 * MIN_STRIP_HEIGHT as u64 * 4;
+    run_streaming(fixture, &source, &plan, budget);
+}
+
+fn end_to_end_streaming_generous(fixture: &str, headroom: u64) {
+    let dpi = 72;
+    let source = PdfiumStripSource::new(fixture, 1, dpi).unwrap();
+    let plan = PyramidPlanner::new(
+        source.width(),
+        source.height(),
+        TILE_SIZE,
+        0,
+        Layout::Google,
+    )
+    .expect("PyramidPlanner::new")
+    .plan();
+    let canvas_w = plan.canvas_width;
+    let budget = canvas_w as u64 * MIN_STRIP_HEIGHT as u64 * 4 * headroom;
+    run_streaming(fixture, &source, &plan, budget);
+}
+
+fn run_streaming(fixture: &str, source: &PdfiumStripSource, plan: &PyramidPlan, budget: u64) {
+    let sink = MemorySink::new();
+    let engine = EngineConfig {
+        background_rgb: BACKGROUND_RGB,
+        ..Default::default()
+    };
+    let config = StreamingConfig {
+        memory_budget_bytes: budget,
+        engine,
+        budget_policy: BudgetPolicy::Error,
+    };
+    let result = generate_pyramid_streaming(source, plan, &sink, &config, &NoopObserver)
+        .unwrap_or_else(|e| {
+            panic!("generate_pyramid_streaming({fixture}, budget={budget}): {e:?}")
+        });
+    assert_eq!(
+        result.tiles_produced,
+        plan.total_tile_count(),
+        "{fixture} budget={budget}: tile count mismatch"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Budget verification — the worst-case strip is `canvas_width * (2 *
+// tile_size) * 4` bytes (RGBA8 minimum-aligned strip). When the configured
+// memory budget cannot fit that, the caller picks the policy:
+//
+//   - `BudgetPolicy::Error` — return a typed error early (no work done).
+//   - `BudgetPolicy::AutoAdjustDpi { min_dpi }` — reduce DPI until the worst-
+//     case strip fits, or error if `min_dpi` still doesn't fit.
+//
+// AutoAdjustDpi is only meaningful for sources whose DPI is reconfigurable.
+// `PdfiumStripSource::new_with_budget` is the smart constructor that owns
+// the resolution loop; the resulting source carries the resolved DPI.
+// ---------------------------------------------------------------------------
+
+const MIN_STRIP_HEIGHT: u32 = 2 * TILE_SIZE;
+
+fn worst_case_strip_bytes(width: u32) -> u64 {
+    width as u64 * MIN_STRIP_HEIGHT as u64 * 4
+}
+
+/// Generous budget + Error policy: construction succeeds and DPI is preserved.
+#[test]
+fn budget_error_policy_passes_when_fits() {
+    let baseline = PdfiumStripSource::new(FIXTURE_BLUEPRINT, 1, 72).unwrap();
+    let budget = worst_case_strip_bytes(baseline.width()) * 4; // generous headroom
+    let source = PdfiumStripSource::new_with_budget(
+        FIXTURE_BLUEPRINT,
+        1,
+        72,
+        MIN_STRIP_HEIGHT,
+        budget,
+        BudgetPolicy::Error,
+    )
+    .expect("budget large enough — should succeed");
+    assert_eq!(source.width(), baseline.width());
+    assert_eq!(source.height(), baseline.height());
+}
+
+/// Tiny budget + Error policy: surface a typed `PdfError::BudgetExceeded`.
+#[test]
+fn budget_error_policy_returns_typed_error_when_too_small() {
+    let result = PdfiumStripSource::new_with_budget(
+        FIXTURE_BLUEPRINT,
+        1,
+        300,
+        MIN_STRIP_HEIGHT,
+        1,
+        BudgetPolicy::Error,
+    );
+    match result {
+        Err(PdfError::BudgetExceeded { .. }) => {}
+        other => panic!("expected BudgetExceeded, got {other:?}"),
+    }
+}
+
+/// Tight budget + AutoAdjustDpi: DPI reduced until worst-case strip fits.
+/// The resolved source must report dims smaller than the dpi_hint baseline.
+#[test]
+fn budget_auto_adjust_reduces_dpi_until_fits() {
+    let baseline_300 = PdfiumStripSource::new(FIXTURE_BLUEPRINT, 1, 300).unwrap();
+    // Budget that 300 DPI cannot meet, but a lower DPI can.
+    let budget = worst_case_strip_bytes(baseline_300.width()) / 16;
+    let source = PdfiumStripSource::new_with_budget(
+        FIXTURE_BLUEPRINT,
+        1,
+        300,
+        MIN_STRIP_HEIGHT,
+        budget,
+        BudgetPolicy::AutoAdjustDpi { min_dpi: 1 },
+    )
+    .expect("auto-adjust must produce a usable source for any positive budget");
+    assert!(
+        source.width() < baseline_300.width(),
+        "expected DPI reduction; got {}x{} (300-DPI baseline {}x{})",
+        source.width(),
+        source.height(),
+        baseline_300.width(),
+        baseline_300.height(),
+    );
+    assert!(
+        worst_case_strip_bytes(source.width()) <= budget,
+        "post-adjust worst-case strip ({}) must fit budget ({})",
+        worst_case_strip_bytes(source.width()),
+        budget,
+    );
+}
+
+/// AutoAdjust + generous budget: do not reduce below the requested dpi_hint.
+#[test]
+fn budget_auto_adjust_keeps_dpi_when_fits() {
+    let baseline = PdfiumStripSource::new(FIXTURE_BLUEPRINT, 1, 72).unwrap();
+    let budget = worst_case_strip_bytes(baseline.width()) * 4;
+    let source = PdfiumStripSource::new_with_budget(
+        FIXTURE_BLUEPRINT,
+        1,
+        72,
+        MIN_STRIP_HEIGHT,
+        budget,
+        BudgetPolicy::AutoAdjustDpi { min_dpi: 1 },
+    )
+    .unwrap();
+    assert_eq!(source.width(), baseline.width());
+    assert_eq!(source.height(), baseline.height());
+}
+
+/// AutoAdjust must terminate: if budget is so small that even `min_dpi` fails,
+/// return a typed error rather than looping forever.
+#[test]
+fn budget_auto_adjust_errors_when_min_dpi_floor_exceeded() {
+    let result = PdfiumStripSource::new_with_budget(
+        FIXTURE_BLUEPRINT,
+        1,
+        300,
+        MIN_STRIP_HEIGHT,
+        1,
+        BudgetPolicy::AutoAdjustDpi { min_dpi: 50 },
+    );
+    match result {
+        Err(PdfError::BudgetExceeded { .. }) => {}
+        other => panic!("expected BudgetExceeded at min_dpi floor, got {other:?}"),
+    }
+}
+
+/// End-to-end: tight source-side budget drives DPI down, then the engine
+/// runs the streaming pipeline. The engine's pre-flight uses canvas width
+/// (Google layout pads source width up to a power-of-two multiple of the
+/// tile size) so we re-derive the engine budget from the post-adjust plan,
+/// not from the source-side budget that constrained DPI selection.
+#[test]
+fn budget_auto_adjust_drives_end_to_end_streaming() {
+    let baseline_300 = PdfiumStripSource::new(FIXTURE_BLUEPRINT, 1, 300).unwrap();
+    let source_budget = worst_case_strip_bytes(baseline_300.width()) / 16;
+    let source = PdfiumStripSource::new_with_budget(
+        FIXTURE_BLUEPRINT,
+        1,
+        300,
+        MIN_STRIP_HEIGHT,
+        source_budget,
+        BudgetPolicy::AutoAdjustDpi { min_dpi: 1 },
+    )
+    .unwrap();
+    let plan = PyramidPlanner::new(
+        source.width(),
+        source.height(),
+        TILE_SIZE,
+        0,
+        Layout::Google,
+    )
+    .unwrap()
+    .plan();
+    let canvas_w = plan.canvas_width;
+    let engine_budget = canvas_w as u64 * MIN_STRIP_HEIGHT as u64 * 4;
+    let sink = MemorySink::new();
+    let engine = EngineConfig {
+        background_rgb: BACKGROUND_RGB,
+        ..Default::default()
+    };
+    let config = StreamingConfig {
+        memory_budget_bytes: engine_budget,
+        engine,
+        budget_policy: BudgetPolicy::Error,
+    };
+    let result = generate_pyramid_streaming(&source, &plan, &sink, &config, &NoopObserver).unwrap();
+    assert_eq!(result.tiles_produced, plan.total_tile_count());
+}
+
+/// Engine-level pre-flight: even when the source was constructed without
+/// budget verification, `generate_pyramid_streaming` must short-circuit when
+/// the configured budget cannot fit the minimum aligned strip.
+#[test]
+fn engine_preflight_errors_when_budget_below_min_strip() {
+    let source = PdfiumStripSource::new(FIXTURE_BLUEPRINT, 1, 150).unwrap();
+    let plan = PyramidPlanner::new(
+        source.width(),
+        source.height(),
+        TILE_SIZE,
+        0,
+        Layout::Google,
+    )
+    .unwrap()
+    .plan();
+    let sink = MemorySink::new();
+    let config = StreamingConfig {
+        memory_budget_bytes: 1,
+        engine: EngineConfig::default(),
+        budget_policy: BudgetPolicy::Error,
+    };
+    let result = generate_pyramid_streaming(&source, &plan, &sink, &config, &NoopObserver);
+    match result {
+        Err(EngineError::BudgetExceeded { .. }) => {}
+        other => panic!("expected EngineError::BudgetExceeded, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Merges current `main` (post-#27 pdfium-streaming-source consolidation and post-#28 rotation-fix integration tests) into `tests/phase3-hardening` so that PR #24 can be re-evaluated against the latest base.

## Conflicts resolved
- `tests/streaming_engine.rs` — single import line: keep both the existing `compute_strip_height, estimate_streaming_memory` imports and the new `BudgetPolicy` import, merged into one `use libviprs::streaming::{...}` statement.

## Test plan
- [x] `cargo check --tests` green locally against sibling libviprs at the new main (0.1.4 with phase-3 surface)
- [ ] CI (Lint, Integration Tests, Integration Tests pdfium) green on this PR