### PR TITLE
test(phase3): adapt tests to non-exhaustive EngineConfig + clippy fix

### DIFF
--- a/tests/phase3_validation_stress.rs
+++ b/tests/phase3_validation_stress.rs
@@ -109,10 +109,10 @@ impl<S: TileSink> TileSink for PanickingSink<S> {
                 self.fired.store(true, Ordering::SeqCst);
                 panic!("PanickingSink: deliberate panic at write #{n}");
             }
-            PanicTrigger::Coord(c) if *c == tile.coord => {
-                if !self.fired.swap(true, Ordering::SeqCst) {
-                    panic!("PanickingSink: deliberate panic at coord {:?}", c);
-                }
+            PanicTrigger::Coord(c)
+                if *c == tile.coord && !self.fired.swap(true, Ordering::SeqCst) =>
+            {
+                panic!("PanickingSink: deliberate panic at coord {:?}", c);
             }
             _ => {}
         }

--- a/tests/streaming_pdfium_matrix.rs
+++ b/tests/streaming_pdfium_matrix.rs
@@ -524,10 +524,8 @@ fn end_to_end_streaming_generous(fixture: &str, headroom: u64) {
 
 fn run_streaming(fixture: &str, source: &PdfiumStripSource, plan: &PyramidPlan, budget: u64) {
     let sink = MemorySink::new();
-    let engine = EngineConfig {
-        background_rgb: BACKGROUND_RGB,
-        ..Default::default()
-    };
+    let mut engine = EngineConfig::default();
+    engine.background_rgb = BACKGROUND_RGB;
     let config = StreamingConfig {
         memory_budget_bytes: budget,
         engine,
@@ -697,10 +695,8 @@ fn budget_auto_adjust_drives_end_to_end_streaming() {
     let canvas_w = plan.canvas_width;
     let engine_budget = canvas_w as u64 * MIN_STRIP_HEIGHT as u64 * 4;
     let sink = MemorySink::new();
-    let engine = EngineConfig {
-        background_rgb: BACKGROUND_RGB,
-        ..Default::default()
-    };
+    let mut engine = EngineConfig::default();
+    engine.background_rgb = BACKGROUND_RGB;
     let config = StreamingConfig {
         memory_budget_bytes: engine_budget,
         engine,


### PR DESCRIPTION
## Summary
Two compile/lint failures surfaced after PR #30 brought `main` into `tests/phase3-hardening`:

- `streaming_pdfium_matrix` used `EngineConfig { .., ..Default::default() }`, but phase 3 marked `EngineConfig` as `#[non_exhaustive]`. Switched to mutate-after-default at both call sites (lines 527, 700).
- `phase3_validation_stress` tripped `clippy::collapsible_match` (Rust 1.95). Folded the inner `if !fired.swap(true)` into the match-arm guard.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features pdfium -- -D warnings`
- [ ] CI on this PR (no checks fire — base is feature branch)