### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libviprs-tests"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 authors = ["Roman Goldmann <roman@devshell.org>"]
 rust-version = "1.85"


### PR DESCRIPTION
Bumps libviprs-tests to 0.2.0 alongside the libviprs 0.2.0 release.

## Test plan
- [ ] CI green