### PR TITLE
test(resume): loosen checkpoint mtime poll floor for coarse-mtime fs

### DIFF
--- a/tests/phase3_resume.rs
+++ b/tests/phase3_resume.rs
@@ -625,11 +625,12 @@ fn checkpoint_written_periodically() {
     watcher.join().unwrap();
 
     // Mtime-based polling undercounts when consecutive writes land within a
-    // single filesystem mtime tick (common under tmpfs / fast containers).
-    // Halve the strict expectation; the regression we actually care about is
-    // "only the final flush happened", which would be a count of 1.
+    // single filesystem mtime tick — severe on virtiofs/9p (Docker on macOS),
+    // where 30+ flushes can collapse to ~13 observed ticks. The regression we
+    // actually care about is "only the final flush happened" (count == 1), so
+    // pin the floor at a small constant well above 1 but well below the ideal.
     let ideal = (plan.total_tile_count() / 10) as usize;
-    let expected_min = ideal / 2;
+    let expected_min = 3;
     assert!(
         observed_updates.load(Ordering::SeqCst) >= expected_min,
         "Expected at least {expected_min} checkpoint updates (ideal {ideal}), observed {}",


### PR DESCRIPTION
## Summary
- `phase3_resume::checkpoint_written_periodically` watches the on-disk job file's mtime to count distinct checkpoint flushes. On filesystems with coarse mtime granularity — notably virtiofs/9p under Docker on macOS — consecutive writes coalesce into a single tick, undercounting the true flush count.
- Locally observed 13–14 ticks against an ideal of 34, which trips the prior floor of \`ideal / 2\` (17). The author's stated intent (preserved in the comment) is to catch the "only the final flush ever happened" regression — i.e. count == 1.
- Pin the floor at a small constant (3) — well above 1, well below the ideal — so the assertion stays meaningful without false-failing on coarse-mtime filesystems.

Native and CI Linux runs comfortably exceeded the old floor and exceed the new one too; this only affects the false-fail path on Docker-on-macOS hosts.

## Test plan
- [x] Pre-push test suite passed locally (Docker, arm64) including \`phase3_resume\`
- [ ] CI green