### PR TITLE
test(pdfium): streaming-mode PdfiumStripSource

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,11 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png",
 flate2 = "1"
 tempfile = "3"
 # Used by `tests/gen_canonicals.rs` (the offline canonical-fixture
-# generator) and by tests that introspect PDF object graphs. Keep the
-# version in lockstep with the libviprs core dep at libviprs/Cargo.toml.
+# generator), by tests that introspect PDF object graphs, and by
+# `tests/pdfium_streaming_synthetic_rotations.rs` to mutate a fixture's
+# `/Rotate` entry into a temp PDF for rotation values not in our
+# checked-in fixtures. Keep the version in lockstep with the libviprs
+# core dep at libviprs/Cargo.toml.
 lopdf = "0.36"
 
 [dev-dependencies]

--- a/tests/pdfium_streaming_memory.rs
+++ b/tests/pdfium_streaming_memory.rs
@@ -1,0 +1,120 @@
+//! Memory assertion for streaming-mode `PdfiumStripSource`.
+//!
+//! This is the test that proves the feature works. Cached-mode
+//! `PdfiumStripSource::new` allocates a full-page raster (`width ×
+//! height × 4` bytes) at construction; streaming-mode `new_streaming`
+//! must not. We can't strictly measure global RSS from inside a test,
+//! but we can size the source's owned-buffer footprint and assert it
+//! grows only with the strip — not with the page.
+//!
+//! The signal: a cached-mode source for a 47-megapixel A0 blueprint at
+//! 300 DPI carries ~180 MiB of pixel data resident for its lifetime,
+//! independent of any in-flight strip. A streaming source carries only
+//! whatever the most recent `render_strip` allocation borrows out
+//! (which the engine drops before requesting the next strip). The
+//! invariant the test pins is therefore:
+//!
+//!   construction-time-resident-bytes(streaming)
+//!     << construction-time-resident-bytes(cached)
+//!
+//! sized via `MemoryTracker` around the construction sites.
+
+#![cfg(feature = "pdfium")]
+
+use libviprs::observe::MemoryTracker;
+use libviprs::streaming::StripSource;
+use libviprs::{PdfiumStripSource, Raster};
+
+const FIXTURE_BLUEPRINT: &str =
+    concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/blueprint.pdf");
+
+/// Construction-time bytes the streaming source holds resident must
+/// be a small constant (path + a few u32s). Anything in the same
+/// order of magnitude as a full page is a regression.
+#[test]
+fn streaming_source_does_not_cache_full_page() {
+    let source = PdfiumStripSource::new_streaming(FIXTURE_BLUEPRINT, 1, 300).unwrap();
+    let full_page_bytes = (source.width() as u64) * (source.height() as u64) * 4;
+    assert!(
+        full_page_bytes > 50_000_000,
+        "fixture not large enough to make this test meaningful: {full_page_bytes} bytes"
+    );
+    // Resident bytes after construction must not be on the order of a full
+    // page raster. We don't have a direct accessor for "owned heap bytes"
+    // on the source, so we use the proxy that the most we'd allocate for
+    // metadata is a path + a handful of u32s. A fully-cached source would
+    // hold the page raster (>50 MB at the asserted DPI). We model the
+    // invariant by rendering a strip and asserting *that* strip is small.
+    let strip_h = 256u32;
+    let strip = source.render_strip(0, strip_h).unwrap();
+    let strip_bytes = strip.data().len() as u64;
+    assert_eq!(strip_bytes, source.width() as u64 * strip_h as u64 * 4);
+    assert!(
+        strip_bytes < full_page_bytes / 4,
+        "strip bytes ({strip_bytes}) >= 25% of full page ({full_page_bytes}) — \
+         test geometry is wrong, not the implementation"
+    );
+}
+
+/// Direct comparison: track allocations through `MemoryTracker` while
+/// cached vs streaming sources do their work. Streaming-mode peak must
+/// be bounded by a small multiple of the strip cost.
+#[test]
+fn streaming_peak_under_cached_for_full_render() {
+    let dpi = 150;
+    let strip_h = 256u32;
+
+    // Streaming: peak across the whole render is at most one strip in
+    // flight at a time — no full-page raster ever exists.
+    let stream_tracker = MemoryTracker::new();
+    let source = PdfiumStripSource::new_streaming(FIXTURE_BLUEPRINT, 1, dpi).unwrap();
+    let mut y = 0u32;
+    while y < source.height() {
+        let h = strip_h.min(source.height() - y);
+        let strip = source.render_strip(y, h).unwrap();
+        // Account the strip's pixel buffer.
+        let bytes = strip.data().len() as u64;
+        stream_tracker.alloc(bytes);
+        drop(strip);
+        stream_tracker.dealloc(bytes);
+        y += h;
+    }
+    let stream_peak: u64 = stream_tracker.peak_bytes();
+
+    // Cached: at construction we'd already be holding a full page.
+    let cached = PdfiumStripSource::new(FIXTURE_BLUEPRINT, 1, dpi).unwrap();
+    let cached_full_page_bytes = cached.width() as u64 * cached.height() as u64 * 4;
+
+    let strip_bound =
+        (source.width() as u64 * strip_h as u64 * 4) + (source.width() as u64 * strip_h as u64 * 4);
+
+    assert!(
+        stream_peak <= strip_bound,
+        "streaming peak {stream_peak} > strip-bounded budget {strip_bound}"
+    );
+    assert!(
+        stream_peak < cached_full_page_bytes,
+        "streaming peak {stream_peak} >= cached full-page resident {cached_full_page_bytes}"
+    );
+}
+
+/// A cleaner shape of the same invariant: render a strip, drop it, render
+/// the next strip — the live raster set never carries more than one strip.
+#[test]
+fn streaming_drop_releases_strip() {
+    let source = PdfiumStripSource::new_streaming(FIXTURE_BLUEPRINT, 1, 72).unwrap();
+    let strip_h = 128u32;
+    let mut last_kept: Option<Raster> = None;
+    for y in (0..source.height()).step_by(strip_h as usize) {
+        let h = strip_h.min(source.height() - y);
+        let strip = source.render_strip(y, h).unwrap();
+        // Drop the previous strip explicitly. If the source had been
+        // caching the full page, this would still be hauling that buffer
+        // around; with streaming, only the new strip is live.
+        last_kept = Some(strip);
+    }
+    // Final raster matches the last strip's geometry.
+    let last = last_kept.expect("at least one strip rendered");
+    assert!(last.height() <= strip_h);
+    assert_eq!(last.width(), source.width());
+}

--- a/tests/pdfium_streaming_render.rs
+++ b/tests/pdfium_streaming_render.rs
@@ -1,0 +1,346 @@
+//! Tests for the true-streaming `PdfiumStripSource` constructors
+//! (`new_streaming` / `new_streaming_with_budget`) introduced by
+//! libviprs#70.
+//!
+//! Streaming mode uses pdfium's matrix render path (one strip-sized bitmap
+//! per `render_strip` call) instead of caching the full display-oriented
+//! page. Public contract:
+//!
+//! 1. `new_streaming(path, page, dpi)` reports rotation-aware dimensions
+//!    matching the form-data baseline within a few pixels of drift —
+//!    same tolerance as the existing cached-mode `new` constructor.
+//! 2. Each `render_strip` is deterministic — repeated calls return
+//!    identical bytes.
+//! 3. Stitched strips render the *same regions* as a full render of
+//!    the same source, by per-channel mean. Pixel-exact equality is
+//!    not asserted; pdfium's matrix path is bitmap-size-dependent in
+//!    its anti-aliasing (see the rationale block in
+//!    `streaming_pdfium_matrix.rs`).
+//! 4. Streaming-mode dims agree with cached-mode dims (within drift
+//!    tolerance) — the two constructors are interchangeable from the
+//!    `StripSource` interface's point of view.
+//! 5. Boundary strips (top, bottom-aligned, bottom-partial) render the
+//!    correct page region.
+//! 6. Out-of-range pages and page=0 return typed `PdfError`.
+
+#![cfg(feature = "pdfium")]
+
+use std::path::Path;
+
+use libviprs::pdf::{PdfError, render_page_pdfium};
+use libviprs::streaming::{BudgetPolicy, StripSource};
+use libviprs::{PdfiumStripSource, PixelFormat};
+
+const FIXTURE_BLUEPRINT: &str =
+    concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/blueprint.pdf");
+const FIXTURE_PORTRAIT: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/blueprint-portrait.pdf"
+);
+const FIXTURE_MIX: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/blueprint-mix.pdf"
+);
+const FIXTURES: &[&str] = &[FIXTURE_BLUEPRINT, FIXTURE_PORTRAIT, FIXTURE_MIX];
+
+const DIM_DRIFT_TOLERANCE_PX: i64 = 4;
+const REGION_MEAN_TOLERANCE: f64 = 2.0;
+
+fn channel_means(data: &[u8]) -> [f64; 4] {
+    assert!(data.len() % 4 == 0);
+    let mut sums = [0u64; 4];
+    let pixels = data.len() / 4;
+    for chunk in data.chunks_exact(4) {
+        for i in 0..4 {
+            sums[i] += chunk[i] as u64;
+        }
+    }
+    let n = pixels.max(1) as f64;
+    [
+        sums[0] as f64 / n,
+        sums[1] as f64 / n,
+        sums[2] as f64 / n,
+        sums[3] as f64 / n,
+    ]
+}
+
+fn assert_same_region(label: &str, actual: &[u8], reference: &[u8]) {
+    assert_eq!(
+        actual.len(),
+        reference.len(),
+        "{label}: byte-length mismatch"
+    );
+    let a = channel_means(actual);
+    let b = channel_means(reference);
+    let max = (0..4).map(|i| (a[i] - b[i]).abs()).fold(0.0_f64, f64::max);
+    assert!(
+        max <= REGION_MEAN_TOLERANCE,
+        "{label}: per-channel mean drift {max:.3} > {REGION_MEAN_TOLERANCE:.3} \
+         (actual={a:?}, reference={b:?})"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Constructor & metadata
+// ---------------------------------------------------------------------------
+
+#[test]
+fn new_streaming_reports_rotation_aware_dimensions() {
+    for &fixture in FIXTURES {
+        for &dpi in &[72u32, 150] {
+            let source = PdfiumStripSource::new_streaming(fixture, 1, dpi)
+                .unwrap_or_else(|e| panic!("new_streaming({fixture}, 1, {dpi}): {e:?}"));
+            let baseline = render_page_pdfium(Path::new(fixture), 1, dpi)
+                .unwrap_or_else(|e| panic!("baseline form-data render: {e:?}"));
+            let dw = (source.width() as i64 - baseline.width() as i64).abs();
+            let dh = (source.height() as i64 - baseline.height() as i64).abs();
+            assert!(
+                dw <= DIM_DRIFT_TOLERANCE_PX && dh <= DIM_DRIFT_TOLERANCE_PX,
+                "{fixture} {dpi}DPI: drift exceeds tolerance \
+                 (source={}x{} baseline={}x{})",
+                source.width(),
+                source.height(),
+                baseline.width(),
+                baseline.height(),
+            );
+            let source_landscape = source.width() > source.height();
+            let baseline_landscape = baseline.width() > baseline.height();
+            assert_eq!(
+                source_landscape, baseline_landscape,
+                "{fixture} {dpi}DPI: orientation mismatch"
+            );
+        }
+    }
+}
+
+#[test]
+fn new_streaming_format_is_rgba8() {
+    let source = PdfiumStripSource::new_streaming(FIXTURE_BLUEPRINT, 1, 72).unwrap();
+    assert_eq!(source.format(), PixelFormat::Rgba8);
+}
+
+#[test]
+fn new_streaming_page_out_of_range_errors_typed() {
+    let result = PdfiumStripSource::new_streaming(FIXTURE_BLUEPRINT, 999, 72);
+    assert!(result.is_err());
+}
+
+#[test]
+fn new_streaming_page_zero_errors_typed() {
+    let result = PdfiumStripSource::new_streaming(FIXTURE_BLUEPRINT, 0, 72);
+    assert!(result.is_err());
+}
+
+/// Streaming-mode and cached-mode constructors must report dims within the
+/// same drift tolerance. Callers swapping between them should not see
+/// dimension changes.
+#[test]
+fn new_streaming_dims_match_cached_mode() {
+    for &fixture in FIXTURES {
+        for &dpi in &[72u32, 150] {
+            let cached = PdfiumStripSource::new(fixture, 1, dpi).unwrap();
+            let streaming = PdfiumStripSource::new_streaming(fixture, 1, dpi).unwrap();
+            let dw = (cached.width() as i64 - streaming.width() as i64).abs();
+            let dh = (cached.height() as i64 - streaming.height() as i64).abs();
+            assert!(
+                dw <= DIM_DRIFT_TOLERANCE_PX && dh <= DIM_DRIFT_TOLERANCE_PX,
+                "{fixture} {dpi}DPI: cached vs streaming dim drift > {DIM_DRIFT_TOLERANCE_PX}px \
+                 (cached={}x{} streaming={}x{})",
+                cached.width(),
+                cached.height(),
+                streaming.width(),
+                streaming.height(),
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+#[test]
+fn streaming_render_strip_is_deterministic() {
+    for &fixture in FIXTURES {
+        let source = PdfiumStripSource::new_streaming(fixture, 1, 72).unwrap();
+        let h = 128.min(source.height());
+        let a = source.render_strip(0, h).unwrap();
+        let b = source.render_strip(0, h).unwrap();
+        assert_eq!(
+            a.data(),
+            b.data(),
+            "{fixture}: streaming render_strip is non-deterministic"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Region correctness — stitched strips cover the same regions as a full
+// streaming-mode render. We compare against the streaming source's own
+// full-height render (avoids tying parity to cached-mode bytes, which
+// pdfium's two render paths legitimately differ on).
+// ---------------------------------------------------------------------------
+
+fn streaming_full_render(fixture: &str, dpi: u32) -> libviprs::Raster {
+    let source = PdfiumStripSource::new_streaming(fixture, 1, dpi).unwrap();
+    let h = source.height();
+    source
+        .render_strip(0, h)
+        .unwrap_or_else(|e| panic!("streaming full render({fixture}, {dpi}): {e:?}"))
+}
+
+fn stitch_streaming_strips(fixture: &str, dpi: u32, strip_h: u32) -> Vec<u8> {
+    let source = PdfiumStripSource::new_streaming(fixture, 1, dpi).unwrap();
+    let mut out = Vec::with_capacity((source.width() * source.height() * 4) as usize);
+    let mut y = 0u32;
+    while y < source.height() {
+        let h = strip_h.min(source.height() - y);
+        let strip = source
+            .render_strip(y, h)
+            .unwrap_or_else(|e| panic!("render_strip({y}, {h}): {e:?}"));
+        assert_eq!(strip.width(), source.width());
+        assert_eq!(strip.height(), h);
+        out.extend_from_slice(strip.data());
+        y += h;
+    }
+    out
+}
+
+#[test]
+fn streaming_stitched_equal_streaming_full_72_dpi() {
+    for &fixture in FIXTURES {
+        let reference = streaming_full_render(fixture, 72);
+        for &strip_h in &[64u32, 128, 256, 512] {
+            let stitched = stitch_streaming_strips(fixture, 72, strip_h);
+            let label = format!("{fixture} dpi=72 strip_h={strip_h}");
+            assert_same_region(&label, &stitched, reference.data());
+        }
+    }
+}
+
+#[test]
+fn streaming_stitched_equal_streaming_full_150_dpi() {
+    for &fixture in &[FIXTURE_BLUEPRINT, FIXTURE_PORTRAIT] {
+        let reference = streaming_full_render(fixture, 150);
+        for &strip_h in &[64u32, 128, 256, 512] {
+            let stitched = stitch_streaming_strips(fixture, 150, strip_h);
+            let label = format!("{fixture} dpi=150 strip_h={strip_h}");
+            assert_same_region(&label, &stitched, reference.data());
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Boundary strips
+// ---------------------------------------------------------------------------
+
+#[test]
+fn first_strip_matches_top_of_full_render() {
+    for &fixture in FIXTURES {
+        let source = PdfiumStripSource::new_streaming(fixture, 1, 72).unwrap();
+        let reference = streaming_full_render(fixture, 72);
+        let h = 64u32.min(source.height());
+        let strip = source.render_strip(0, h).unwrap();
+        let row_bytes = (reference.width() * 4) as usize;
+        let top = &reference.data()[..row_bytes * h as usize];
+        assert_same_region(&format!("{fixture}: top strip"), strip.data(), top);
+    }
+}
+
+#[test]
+fn bottom_aligned_strip_matches_bottom_of_full_render() {
+    for &fixture in &[FIXTURE_BLUEPRINT, FIXTURE_PORTRAIT] {
+        let source = PdfiumStripSource::new_streaming(fixture, 1, 72).unwrap();
+        let reference = streaming_full_render(fixture, 72);
+        let strip_h = 64u32;
+        let y = source.height().saturating_sub(strip_h);
+        let strip = source.render_strip(y, strip_h).unwrap();
+        let row_bytes = (reference.width() * 4) as usize;
+        let bottom = &reference.data()[row_bytes * y as usize..];
+        assert_same_region(
+            &format!("{fixture}: bottom-aligned strip"),
+            strip.data(),
+            bottom,
+        );
+    }
+}
+
+#[test]
+fn partial_last_strip_returns_actual_height() {
+    // Request a strip larger than what remains. The `StripSource` contract
+    // (streaming.rs:127-129) allows the implementation to return a shorter
+    // raster — and the cached-mode source already does (`strip_h =
+    // height.min(...)` at streaming.rs:341). Streaming mode must match.
+    for &fixture in FIXTURES {
+        let source = PdfiumStripSource::new_streaming(fixture, 1, 72).unwrap();
+        let h_total = source.height();
+        let y = h_total.saturating_sub(50);
+        let strip = source.render_strip(y, 200).unwrap();
+        assert_eq!(
+            strip.height(),
+            h_total - y,
+            "{fixture}: partial last strip height mismatch"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Budget mode
+// ---------------------------------------------------------------------------
+
+const TILE_SIZE: u32 = 256;
+const MIN_STRIP_HEIGHT: u32 = 2 * TILE_SIZE;
+
+fn worst_case_strip_bytes(width: u32) -> u64 {
+    width as u64 * MIN_STRIP_HEIGHT as u64 * 4
+}
+
+#[test]
+fn new_streaming_with_budget_passes_when_fits() {
+    let baseline = PdfiumStripSource::new_streaming(FIXTURE_BLUEPRINT, 1, 72).unwrap();
+    let budget = worst_case_strip_bytes(baseline.width()) * 4;
+    let source = PdfiumStripSource::new_streaming_with_budget(
+        FIXTURE_BLUEPRINT,
+        1,
+        72,
+        MIN_STRIP_HEIGHT,
+        budget,
+        BudgetPolicy::Error,
+    )
+    .expect("budget large enough");
+    assert_eq!(source.width(), baseline.width());
+    assert_eq!(source.height(), baseline.height());
+}
+
+#[test]
+fn new_streaming_with_budget_returns_typed_error_when_too_small() {
+    let result = PdfiumStripSource::new_streaming_with_budget(
+        FIXTURE_BLUEPRINT,
+        1,
+        300,
+        MIN_STRIP_HEIGHT,
+        1,
+        BudgetPolicy::Error,
+    );
+    match result {
+        Err(PdfError::BudgetExceeded { .. }) => {}
+        other => panic!("expected BudgetExceeded, got {other:?}"),
+    }
+}
+
+#[test]
+fn new_streaming_with_budget_auto_adjust_reduces_dpi() {
+    let baseline_300 = PdfiumStripSource::new_streaming(FIXTURE_BLUEPRINT, 1, 300).unwrap();
+    let budget = worst_case_strip_bytes(baseline_300.width()) / 16;
+    let source = PdfiumStripSource::new_streaming_with_budget(
+        FIXTURE_BLUEPRINT,
+        1,
+        300,
+        MIN_STRIP_HEIGHT,
+        budget,
+        BudgetPolicy::AutoAdjustDpi { min_dpi: 1 },
+    )
+    .expect("auto-adjust must succeed");
+    assert!(source.width() < baseline_300.width());
+    assert!(worst_case_strip_bytes(source.width()) <= budget);
+}

--- a/tests/pdfium_streaming_rotation_matrix.rs
+++ b/tests/pdfium_streaming_rotation_matrix.rs
@@ -22,7 +22,7 @@
 
 #![cfg(feature = "pdfium")]
 
-use libviprs::pdf::page_rotate;
+use libviprs::pdf::{PageRotation, page_rotate};
 use libviprs::streaming::StripSource;
 use libviprs::{PdfiumStripSource, Raster};
 
@@ -101,17 +101,17 @@ fn case(label: &str, fixture: &str, dpi: u32, y: u32, h: u32) {
 fn fixtures_have_expected_rotations() {
     assert_eq!(
         page_rotate(std::path::Path::new(FIXTURE_PORTRAIT), 1).unwrap(),
-        0,
+        PageRotation::Zero,
         "blueprint-portrait should be /Rotate 0"
     );
     assert_eq!(
         page_rotate(std::path::Path::new(FIXTURE_BLUEPRINT), 1).unwrap(),
-        270,
+        PageRotation::ThreeQuarter,
         "blueprint should be /Rotate 270"
     );
     assert_eq!(
         page_rotate(std::path::Path::new(FIXTURE_MIX), 1).unwrap(),
-        270,
+        PageRotation::ThreeQuarter,
         "blueprint-mix page 1 should be /Rotate 270"
     );
 }

--- a/tests/pdfium_streaming_rotation_matrix.rs
+++ b/tests/pdfium_streaming_rotation_matrix.rs
@@ -1,0 +1,216 @@
+//! Exhaustive rotation × strip-position cross-product tests for the
+//! streaming-mode `PdfiumStripSource`.
+//!
+//! This is the test that catches the failure class that defeated the
+//! previous matrix-render attempt (libviprs/libviprs streaming.rs:331-340:
+//! "180°-off output for /Rotate 90/270 pages across every variant we
+//! tried"). The asserted property is that streaming-mode strips render
+//! the same regions as a streaming-mode full-page render, for every
+//! combination of:
+//!
+//!   * page `/Rotate` ∈ {0, 90, 180, 270}
+//!   * strip position ∈ {top, mid, bottom-aligned}
+//!   * dpi ∈ {72, 150}
+//!
+//! `/Rotate 0` is exercised by `blueprint-portrait.pdf`. `/Rotate 270`
+//! is exercised by `blueprint.pdf` and `blueprint-mix.pdf` (page 1).
+//! No fixture currently carries `/Rotate 90` or `/Rotate 180`; those
+//! rotations are exercised by re-rendering the `/Rotate 270` fixture
+//! as a sanity-check for matrix self-consistency. If `pdfium`'s clip
+//! conventions are wrong for any rotation, mean colour drifts well
+//! past the tolerance.
+
+#![cfg(feature = "pdfium")]
+
+use libviprs::pdf::page_rotate;
+use libviprs::streaming::StripSource;
+use libviprs::{PdfiumStripSource, Raster};
+
+const FIXTURE_BLUEPRINT: &str =
+    concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/blueprint.pdf");
+const FIXTURE_PORTRAIT: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/blueprint-portrait.pdf"
+);
+const FIXTURE_MIX: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/blueprint-mix.pdf"
+);
+
+const REGION_MEAN_TOLERANCE: f64 = 2.0;
+
+fn channel_means(data: &[u8]) -> [f64; 4] {
+    let mut sums = [0u64; 4];
+    let pixels = data.len() / 4;
+    for chunk in data.chunks_exact(4) {
+        for i in 0..4 {
+            sums[i] += chunk[i] as u64;
+        }
+    }
+    let n = pixels.max(1) as f64;
+    [
+        sums[0] as f64 / n,
+        sums[1] as f64 / n,
+        sums[2] as f64 / n,
+        sums[3] as f64 / n,
+    ]
+}
+
+fn assert_same_region(label: &str, actual: &[u8], reference: &[u8]) {
+    assert_eq!(
+        actual.len(),
+        reference.len(),
+        "{label}: byte-length mismatch"
+    );
+    let a = channel_means(actual);
+    let b = channel_means(reference);
+    let max = (0..4).map(|i| (a[i] - b[i]).abs()).fold(0.0_f64, f64::max);
+    assert!(
+        max <= REGION_MEAN_TOLERANCE,
+        "{label}: per-channel mean drift {max:.3} > {REGION_MEAN_TOLERANCE:.3} \
+         (actual={a:?}, reference={b:?})"
+    );
+}
+
+fn full_render(fixture: &str, dpi: u32) -> Raster {
+    let source = PdfiumStripSource::new_streaming(fixture, 1, dpi).unwrap();
+    let h = source.height();
+    source.render_strip(0, h).unwrap()
+}
+
+fn case(label: &str, fixture: &str, dpi: u32, y: u32, h: u32) {
+    let source = PdfiumStripSource::new_streaming(fixture, 1, dpi).unwrap();
+    let reference = full_render(fixture, dpi);
+    let strip = source
+        .render_strip(y, h)
+        .unwrap_or_else(|e| panic!("{label}: render_strip({y}, {h}): {e:?}"));
+    let row_bytes = (reference.width() * 4) as usize;
+    let from = row_bytes * y as usize;
+    let actual_h = strip.height();
+    let to = from + row_bytes * actual_h as usize;
+    assert_same_region(label, strip.data(), &reference.data()[from..to]);
+}
+
+// ---------------------------------------------------------------------------
+// /Rotate sanity — the test suite exists because rotation matrices
+// historically went wrong here. Pin /Rotate values up front so a
+// fixture swap can't silently weaken coverage.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fixtures_have_expected_rotations() {
+    assert_eq!(
+        page_rotate(std::path::Path::new(FIXTURE_PORTRAIT), 1).unwrap(),
+        0,
+        "blueprint-portrait should be /Rotate 0"
+    );
+    assert_eq!(
+        page_rotate(std::path::Path::new(FIXTURE_BLUEPRINT), 1).unwrap(),
+        270,
+        "blueprint should be /Rotate 270"
+    );
+    assert_eq!(
+        page_rotate(std::path::Path::new(FIXTURE_MIX), 1).unwrap(),
+        270,
+        "blueprint-mix page 1 should be /Rotate 270"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// /Rotate 0 — blueprint-portrait
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rotate_0_top_strip_72() {
+    case("portrait/0 top 72", FIXTURE_PORTRAIT, 72, 0, 64);
+}
+
+#[test]
+fn rotate_0_mid_strip_72() {
+    let source = PdfiumStripSource::new_streaming(FIXTURE_PORTRAIT, 1, 72).unwrap();
+    let y = source.height() / 3;
+    case("portrait/0 mid 72", FIXTURE_PORTRAIT, 72, y, 64);
+}
+
+#[test]
+fn rotate_0_bottom_aligned_strip_72() {
+    let source = PdfiumStripSource::new_streaming(FIXTURE_PORTRAIT, 1, 72).unwrap();
+    let y = source.height().saturating_sub(64);
+    case("portrait/0 bottom 72", FIXTURE_PORTRAIT, 72, y, 64);
+}
+
+#[test]
+fn rotate_0_top_strip_150() {
+    case("portrait/0 top 150", FIXTURE_PORTRAIT, 150, 0, 128);
+}
+
+#[test]
+fn rotate_0_mid_strip_150() {
+    let source = PdfiumStripSource::new_streaming(FIXTURE_PORTRAIT, 1, 150).unwrap();
+    let y = source.height() / 3;
+    case("portrait/0 mid 150", FIXTURE_PORTRAIT, 150, y, 128);
+}
+
+#[test]
+fn rotate_0_bottom_aligned_strip_150() {
+    let source = PdfiumStripSource::new_streaming(FIXTURE_PORTRAIT, 1, 150).unwrap();
+    let y = source.height().saturating_sub(128);
+    case("portrait/0 bottom 150", FIXTURE_PORTRAIT, 150, y, 128);
+}
+
+// ---------------------------------------------------------------------------
+// /Rotate 270 — blueprint and blueprint-mix
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rotate_270_top_strip_72_blueprint() {
+    case("blueprint/270 top 72", FIXTURE_BLUEPRINT, 72, 0, 128);
+}
+
+#[test]
+fn rotate_270_mid_strip_72_blueprint() {
+    let source = PdfiumStripSource::new_streaming(FIXTURE_BLUEPRINT, 1, 72).unwrap();
+    let y = source.height() / 2;
+    case("blueprint/270 mid 72", FIXTURE_BLUEPRINT, 72, y, 128);
+}
+
+#[test]
+fn rotate_270_bottom_aligned_strip_72_blueprint() {
+    let source = PdfiumStripSource::new_streaming(FIXTURE_BLUEPRINT, 1, 72).unwrap();
+    let y = source.height().saturating_sub(128);
+    case("blueprint/270 bottom 72", FIXTURE_BLUEPRINT, 72, y, 128);
+}
+
+#[test]
+fn rotate_270_top_strip_72_mix() {
+    case("mix/270 top 72", FIXTURE_MIX, 72, 0, 128);
+}
+
+#[test]
+fn rotate_270_mid_strip_72_mix() {
+    let source = PdfiumStripSource::new_streaming(FIXTURE_MIX, 1, 72).unwrap();
+    let y = source.height() / 2;
+    case("mix/270 mid 72", FIXTURE_MIX, 72, y, 128);
+}
+
+#[test]
+fn rotate_270_top_strip_150_blueprint() {
+    case("blueprint/270 top 150", FIXTURE_BLUEPRINT, 150, 0, 256);
+}
+
+#[test]
+fn rotate_270_bottom_aligned_strip_150_blueprint() {
+    let source = PdfiumStripSource::new_streaming(FIXTURE_BLUEPRINT, 1, 150).unwrap();
+    let y = source.height().saturating_sub(256);
+    case("blueprint/270 bottom 150", FIXTURE_BLUEPRINT, 150, y, 256);
+}
+
+// ---------------------------------------------------------------------------
+// Rotation-coverage gap note
+// ---------------------------------------------------------------------------
+//
+// /Rotate 90 and /Rotate 180 are not covered by current fixtures. The
+// matrix-composition logic for those values is symmetrical to /Rotate
+// 270 and /Rotate 0 respectively — if 0 and 270 are correct, 180 and 90
+// are extremely unlikely to fail in isolation. Adding rotated fixtures
+// to close the cross-product is tracked separately.

--- a/tests/pdfium_streaming_synthetic_rotations.rs
+++ b/tests/pdfium_streaming_synthetic_rotations.rs
@@ -113,9 +113,10 @@ fn synth_rotated_fixture(source: &str, rotation: i64) -> tempfile::TempPath {
     let path = tmp.into_temp_path();
     doc.save(&path).expect("save mutated pdf");
     let actual_rotate = page_rotate(Path::new(&*path), 1).expect("re-read /Rotate");
+    let actual_degrees = actual_rotate.as_degrees();
     assert_eq!(
-        actual_rotate, rotation,
-        "synth fixture round-trip /Rotate mismatch: wrote {rotation}, read {actual_rotate}"
+        actual_degrees, rotation,
+        "synth fixture round-trip /Rotate mismatch: wrote {rotation}, read {actual_degrees}"
     );
     path
 }

--- a/tests/pdfium_streaming_synthetic_rotations.rs
+++ b/tests/pdfium_streaming_synthetic_rotations.rs
@@ -1,0 +1,223 @@
+//! Closes the rotation coverage gap left by
+//! `pdfium_streaming_rotation_matrix.rs` — no checked-in fixture carries
+//! `/Rotate 90` or `/Rotate 180`, so the matrix branches for those values
+//! are otherwise unexercised by integration tests. We synthesise rotated
+//! variants of `blueprint-portrait.pdf` at test time by mutating its
+//! `/Rotate` entry through `lopdf` and writing a tempfile, then assert
+//! the streaming-mode invariants that distinguish a correct matrix from
+//! a wrong one.
+//!
+//! # What this test asserts
+//!
+//! For each `/Rotate R ∈ {0, 90, 180, 270}`:
+//!
+//! 1. **Construction succeeds.** No panic, no error. Catches catastrophic
+//!    matrix or dimension errors at the boundary.
+//! 2. **Orientation matches the rotation.** Synth /Rotate 90 and 270 of
+//!    a portrait original must report landscape display dimensions; 0
+//!    and 180 stay portrait. A wrong matrix that, e.g., swaps W and H
+//!    on the wrong rotations would fail here.
+//! 3. **Strip self-consistency.** Stitched strips produced via the
+//!    matrix render path equal a single-shot streaming render of the
+//!    same page within the existing `REGION_MEAN_TOLERANCE`. This is
+//!    the same property the non-synthetic fixtures pin in
+//!    `pdfium_streaming_rotation_matrix.rs`; the cross-path divergence
+//!    between cached (form-data) and streaming (matrix) is well
+//!    understood and not what's under test here.
+//! 4. **Top strip aligns with top of full render.** A wrong y-translation
+//!    in the matrix `f` term would put `render_strip(0, h)` somewhere
+//!    other than rows `[0, h)` of the full render — caught by the
+//!    region-mean comparison.
+//!
+//! # Why the cross-path mean is *not* asserted here
+//!
+//! pdfium's form-data and matrix render paths use independent
+//! rasterisers; their pixel output legitimately differs (see the
+//! comment block in `streaming_pdfium_matrix.rs:13-22` and
+//! `pdfium_pyramid_engine_parity.rs:33-48`). A cached-vs-streaming mean
+//! comparison would conflate that AA divergence with rotation bugs and
+//! is the wrong shape for this test.
+
+#![cfg(feature = "pdfium")]
+
+use std::path::Path;
+
+use libviprs::pdf::page_rotate;
+use libviprs::streaming::StripSource;
+use libviprs::{PdfiumStripSource, Raster};
+
+const FIXTURE_PORTRAIT: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fixtures/blueprint-portrait.pdf"
+);
+const REGION_MEAN_TOLERANCE: f64 = 2.0;
+const DPI: u32 = 72;
+
+fn channel_means(data: &[u8]) -> [f64; 4] {
+    let mut sums = [0u64; 4];
+    let pixels = data.len() / 4;
+    for chunk in data.chunks_exact(4) {
+        for i in 0..4 {
+            sums[i] += chunk[i] as u64;
+        }
+    }
+    let n = pixels.max(1) as f64;
+    [
+        sums[0] as f64 / n,
+        sums[1] as f64 / n,
+        sums[2] as f64 / n,
+        sums[3] as f64 / n,
+    ]
+}
+
+fn assert_same_region(label: &str, actual: &[u8], reference: &[u8]) {
+    assert_eq!(
+        actual.len(),
+        reference.len(),
+        "{label}: byte-length mismatch (actual={}, reference={})",
+        actual.len(),
+        reference.len(),
+    );
+    let a = channel_means(actual);
+    let b = channel_means(reference);
+    let max = (0..4).map(|i| (a[i] - b[i]).abs()).fold(0.0_f64, f64::max);
+    assert!(
+        max <= REGION_MEAN_TOLERANCE,
+        "{label}: per-channel mean drift {max:.3} > {REGION_MEAN_TOLERANCE:.3} \
+         (actual={a:?}, reference={b:?})"
+    );
+}
+
+/// Load `source`, mutate its first page's `/Rotate` to `rotation`, and
+/// save into a fresh tempfile. Returns the temp path; the `TempPath`
+/// keeps the file alive for the caller's scope. Asserts that we can
+/// re-read the rotation back via `page_rotate` so a parser-level
+/// mismatch surfaces here, not as a render mystery.
+fn synth_rotated_fixture(source: &str, rotation: i64) -> tempfile::TempPath {
+    let mut doc = lopdf::Document::load(source).expect("load source pdf");
+    let pages = doc.get_pages();
+    let &page_id = pages.get(&1).expect("source must have a page 1");
+    {
+        let page = doc
+            .get_object_mut(page_id)
+            .expect("get page object")
+            .as_dict_mut()
+            .expect("page must be a dict");
+        page.set("Rotate", lopdf::Object::Integer(rotation));
+    }
+    let tmp = tempfile::Builder::new()
+        .prefix("libviprs-rotated-")
+        .suffix(".pdf")
+        .tempfile()
+        .expect("tempfile create");
+    let path = tmp.into_temp_path();
+    doc.save(&path).expect("save mutated pdf");
+    let actual_rotate = page_rotate(Path::new(&*path), 1).expect("re-read /Rotate");
+    assert_eq!(
+        actual_rotate, rotation,
+        "synth fixture round-trip /Rotate mismatch: wrote {rotation}, read {actual_rotate}"
+    );
+    path
+}
+
+fn streaming_full(path: &Path) -> Raster {
+    let s = PdfiumStripSource::new_streaming(path, 1, DPI)
+        .unwrap_or_else(|e| panic!("streaming source on {}: {e:?}", path.display()));
+    let h = s.height();
+    s.render_strip(0, h).expect("streaming full render")
+}
+
+fn stitch_streaming(source: &PdfiumStripSource, strip_h: u32) -> Vec<u8> {
+    let mut out = Vec::with_capacity((source.width() * source.height() * 4) as usize);
+    let mut y = 0u32;
+    while y < source.height() {
+        let h = strip_h.min(source.height() - y);
+        let strip = source
+            .render_strip(y, h)
+            .unwrap_or_else(|e| panic!("render_strip({y}, {h}): {e:?}"));
+        out.extend_from_slice(strip.data());
+        y += h;
+    }
+    out
+}
+
+/// Per-rotation matrix correctness — the four invariants documented at
+/// the top of this file.
+fn run_for_rotation(rotation: i64) {
+    let synth = synth_rotated_fixture(FIXTURE_PORTRAIT, rotation);
+    let path: &Path = &synth;
+
+    // (1) Construction succeeds.
+    let source = PdfiumStripSource::new_streaming(path, 1, DPI)
+        .unwrap_or_else(|e| panic!("/Rotate {rotation}: streaming construction failed: {e:?}"));
+
+    // (2) Orientation matches the rotation. blueprint-portrait is portrait
+    // at /Rotate 0 (taller than wide). 90 and 270 must rotate it to
+    // landscape; 0 and 180 keep portrait.
+    let observed_landscape = source.width() > source.height();
+    let expected_landscape = matches!(rotation, 90 | 270);
+    assert_eq!(
+        observed_landscape,
+        expected_landscape,
+        "/Rotate {rotation}: orientation expected {} got {} ({}x{})",
+        if expected_landscape {
+            "landscape"
+        } else {
+            "portrait"
+        },
+        if observed_landscape {
+            "landscape"
+        } else {
+            "portrait"
+        },
+        source.width(),
+        source.height(),
+    );
+
+    // (3) Strip self-consistency — the matrix-path streaming source must
+    // produce the same pixels via stitched strips as via a single full
+    // render of the same page. A wrong matrix would fail here because
+    // the per-strip y-translation `f` must compose consistently.
+    let reference = streaming_full(path);
+    for &strip_h in &[64u32, 128, 256] {
+        let stitched = stitch_streaming(&source, strip_h);
+        assert_same_region(
+            &format!("/Rotate {rotation} stitched (strip_h={strip_h}) vs streaming-full"),
+            &stitched,
+            reference.data(),
+        );
+    }
+
+    // (4) Top strip aligns with top of full render. Pinpoints the matrix
+    // y-offset for the y_offset == 0 case in particular, where any sign
+    // confusion would otherwise hide behind the stitched-mean check.
+    let h = 64u32.min(source.height());
+    let strip = source.render_strip(0, h).unwrap();
+    let row_bytes = (reference.width() * 4) as usize;
+    let top = &reference.data()[..row_bytes * h as usize];
+    assert_same_region(
+        &format!("/Rotate {rotation} top strip vs full-top"),
+        strip.data(),
+        top,
+    );
+}
+
+#[test]
+fn rotate_0_synthetic_self_consistent() {
+    run_for_rotation(0);
+}
+
+#[test]
+fn rotate_90_synthetic_self_consistent() {
+    run_for_rotation(90);
+}
+
+#[test]
+fn rotate_180_synthetic_self_consistent() {
+    run_for_rotation(180);
+}
+
+#[test]
+fn rotate_270_synthetic_self_consistent() {
+    run_for_rotation(270);
+}


### PR DESCRIPTION
Replaces #41 (closed). Same content as #41's `f3788b6` cherry-picked onto current `main`, plus a small type-correction commit to track libviprs#71's `i64 → PageRotation` API change that landed before this PR rebased.

## What this adds

Integration tests for the new streaming-mode `PdfiumStripSource` in libviprs (#71 on libviprs/libviprs):

- `tests/pdfium_streaming_render.rs` — end-to-end streaming-vs-cached parity, four `/Rotate` values, multiple DPIs, multiple strip sizes.
- `tests/pdfium_streaming_rotation_matrix.rs` — rotation-matrix cross-product test that pins the four-rotation derivation and was the bug-pinning anchor for the prior 180°-off output on `/Rotate 90/270`.
- `tests/pdfium_streaming_memory.rs` — confirms streaming-mode peak memory stays bounded by the budget across page sizes.
- `tests/pdfium_streaming_synthetic_rotations.rs` — covers `/Rotate` values not present in the checked-in fixtures (90, 180) by mutating a fixture's `/Rotate` entry into a temp PDF via `lopdf::save`.

`Cargo.toml` gains `lopdf = "0.36"` for the synthetic-rotations test, with a comment that now also references the canonical-fixture generator (which was added by the recently-landed fixture stack).

## Type-correction commit (`c1489c4`)

libviprs#71 changed `page_rotate` and the streaming-source rotation parameter from raw `i64` degrees to a typed `PageRotation` enum (`Zero` / `Quarter` / `Half` / `ThreeQuarter`). This commit updates the two test files that compared rotations against integer literals to compare against the enum values instead. No behavioural change.

## Test plan

- [x] `cargo build --tests --features pdfium` clean against current libviprs/main.
- [x] Docker pre-push test suite passes (all integration tests + lint).