### PR TITLE
Bump pdfium pin to 7881 and source CI binary from libviprs-dep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install PDFium
         run: |
-          curl -L -o pdfium.tgz https://github.com/bblanchon/pdfium-binaries/releases/download/chromium/7725/pdfium-linux-x64.tgz
+          curl -L -o pdfium.tgz https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7881/pdfium-linux-x64.tgz
           mkdir -p pdfium
-          tar xzf pdfium.tgz -C pdfium
+          tar xzf pdfium.tgz -C pdfium --strip-components=1
           sudo cp pdfium/lib/libpdfium.so /usr/local/lib/
           sudo cp -r pdfium/include/* /usr/local/include/
           sudo ldconfig

--- a/README.md
+++ b/README.md
@@ -174,11 +174,11 @@ Pre-compiled binaries built from source are available from [libviprs-dep](https:
 ```bash
 # x86_64
 curl -L -o pdfium.tgz \
-  https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-linux-x64.tgz
+  https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7881/pdfium-linux-x64.tgz
 
 # arm64
 curl -L -o pdfium.tgz \
-  https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7725/pdfium-linux-arm64.tgz
+  https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7881/pdfium-linux-arm64.tgz
 
 # Extract and install
 tar xzf pdfium.tgz


### PR DESCRIPTION
Bumps the pdfium pin from the `pdfium-7725` release to the newly published `pdfium-7881` (chromium/7881).

- CI `Integration Tests (pdfium)` job now downloads the pdfium linux-x64 archive from the `libviprs-dep` `pdfium-7881` release instead of the upstream `bblanchon/pdfium-binaries` `chromium/7725` archive. Extraction uses `--strip-components=1` because the libviprs-dep tarball nests everything under a top-level `pdfium-linux-x64/` directory; the subsequent `lib/` and `include/` copy paths are unchanged and still resolve.
- README install snippets bumped to `pdfium-7881`.

Release asset URLs verified to resolve (302). Part of #156.