### PR TITLE
Consolidate pdfium provenance onto libviprs-dep verified binaries [skip ci]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install PDFium
+        # Provenance: pinned, checksum-verified binary from libviprs-dep — the
+        # single source shared with the Dockerfile. Keep PDFIUM_RELEASE and the
+        # SHA-256 digest in lockstep with the Dockerfile.
+        env:
+          PDFIUM_RELEASE: pdfium-7881
+          PDFIUM_SHA256: 653f24f074afe6c868f634ae0cc954a1a89821f33bc7795f16065a14022b662b
         run: |
-          curl -L -o pdfium.tgz https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7881/pdfium-linux-x64.tgz
+          curl -fsSL -o pdfium.tgz "https://github.com/libviprs/libviprs-dep/releases/download/${PDFIUM_RELEASE}/pdfium-linux-x64.tgz"
+          echo "${PDFIUM_SHA256}  pdfium.tgz" | sha256sum -c -
           mkdir -p pdfium
           tar xzf pdfium.tgz -C pdfium --strip-components=1
           sudo cp pdfium/lib/libpdfium.so /usr/local/lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,24 @@ FROM debian:bookworm-slim AS pdfium
 
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
+# PDFium provenance: consume the pinned, checksum-verified binaries published by
+# libviprs-dep (the branch-pinned builder that runs real ABI/symbol
+# verification) rather than the floating upstream `releases/latest`. This is the
+# single provenance source shared with CI. Keep PDFIUM_RELEASE and the per-arch
+# SHA-256 digests in lockstep with the release consumed by
+# .github/workflows/ci.yml.
+ARG PDFIUM_RELEASE=pdfium-7881
 ARG TARGETARCH
 RUN case "${TARGETARCH}" in \
-        amd64) PDFIUM_ARCH="linux-x64" ;; \
-        arm64) PDFIUM_ARCH="linux-arm64" ;; \
+        amd64) PDFIUM_ARCH="linux-x64";   PDFIUM_SHA256="653f24f074afe6c868f634ae0cc954a1a89821f33bc7795f16065a14022b662b" ;; \
+        arm64) PDFIUM_ARCH="linux-arm64"; PDFIUM_SHA256="3a8940ae414a54601f6bc0b25fb3d589025320ee91fff378e12708259da5702d" ;; \
         *)     echo "Unsupported arch: ${TARGETARCH}" && exit 1 ;; \
     esac && \
-    curl -L -o /tmp/pdfium.tgz \
-        "https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-${PDFIUM_ARCH}.tgz" && \
+    curl -fsSL -o /tmp/pdfium.tgz \
+        "https://github.com/libviprs/libviprs-dep/releases/download/${PDFIUM_RELEASE}/pdfium-${PDFIUM_ARCH}.tgz" && \
+    echo "${PDFIUM_SHA256}  /tmp/pdfium.tgz" | sha256sum -c - && \
     mkdir -p /opt/pdfium && \
-    tar xzf /tmp/pdfium.tgz -C /opt/pdfium && \
+    tar xzf /tmp/pdfium.tgz -C /opt/pdfium --strip-components=1 && \
     rm /tmp/pdfium.tgz
 
 # Stage 2: Build and test

--- a/README.md
+++ b/README.md
@@ -190,18 +190,20 @@ See the [libviprs-dep pdfium README](https://github.com/libviprs/libviprs-dep/tr
 
 ### macOS
 
-Third-party prebuilt binaries:
+Pre-compiled binaries built from source are available from [libviprs-dep](https://github.com/libviprs/libviprs-dep/releases):
 
 ```bash
 # Apple Silicon
-curl -L -o pdfium.tgz https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-mac-arm64.tgz
-tar xzf pdfium.tgz
-sudo cp lib/libpdfium.dylib /usr/local/lib/
+curl -L -o pdfium.tgz \
+  https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7881/pdfium-mac-arm64.tgz
 
 # Intel
-curl -L -o pdfium.tgz https://github.com/bblanchon/pdfium-binaries/releases/latest/download/pdfium-mac-x64.tgz
+curl -L -o pdfium.tgz \
+  https://github.com/libviprs/libviprs-dep/releases/download/pdfium-7881/pdfium-mac-x64.tgz
+
+# Extract and install
 tar xzf pdfium.tgz
-sudo cp lib/libpdfium.dylib /usr/local/lib/
+sudo cp pdfium-mac-*/lib/libpdfium.dylib /usr/local/lib/
 ```
 
 ### Verify Installation


### PR DESCRIPTION
## Summary
Consolidate the pdfium provenance in this repo onto the pinned, checksum-verified `libviprs-dep` release (`pdfium-7881`), so the binary the tests certify is the same one produced by the branch-pinned builder that runs real ABI/symbol verification.

- **Dockerfile**: switch the `pdfium` stage off the floating `bblanchon/pdfium-binaries/releases/latest` channel to `libviprs-dep`'s pinned release. Adds `PDFIUM_RELEASE=pdfium-7881`, verifies per-arch SHA-256 digests with `sha256sum -c`, and strips the top-level dir on extract (the libviprs-dep tarballs are nested one level deeper than the old bblanchon layout).
- **CI** (`Install PDFium`): pin `PDFIUM_RELEASE` + `PDFIUM_SHA256` and verify the download, using `curl -fsSL`.
- **README**: point the macOS local-dev instructions at libviprs-dep as well (the Linux section already did), so every documented install path shares one provenance source.

## Verification
- SHA-256 digests confirmed against the live `libviprs-dep` `pdfium-7881` assets:
  - `linux-x64`  → `653f24f0…22b662b`
  - `linux-arm64`→ `3a8940ae…a5702d`
- Built the Docker `pdfium` stage (`--target pdfium --platform linux/amd64`): download succeeded, `sha256sum -c` reported `OK`, and the lib extracted to `/opt/pdfium/lib/libpdfium.so` — exactly the path the builder stage copies from.
- `ci.yml` validated as well-formed YAML.

## Scope
This completes the libviprs-tests half of the issue: tests fetch the pinned, checksum-verified binary, and the committed `libpdfium.dylib` is already absent from the tree. The `libviprs-bench/Dockerfile` switch lives in a separate repo and remains outstanding, so this does not fully close the issue.

Refs #156