### PR TITLE
Propagate pdfium-render thread-safety fork pin (Refs #149)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,8 +1042,7 @@ dependencies = [
 [[package]]
 name = "pdfium-render"
 version = "0.8.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6553f6604a52b3203db7b4e9d51eb4dd193cf455af9e56d40cab6575b547b679"
+source = "git+https://github.com/libviprs/pdfium-render.git?branch=libviprs%2Fper-call-thread-safety#f0bda9f30be1be0eb7ac7373bad4d24c411f338a"
 dependencies = [
  "bitflags",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,14 @@ sha2 = "0.10"
 # feature. Listed unconditionally — dev-deps cannot be optional — but only
 # linked from code guarded by `#[cfg(feature = "builder_v1")]`.
 proptest = "1"
+# Mirror the core crate's `pdfium-render` thread-safety fork. `[patch]`
+# tables apply only from the build-root manifest, so the pin in
+# `../libviprs/Cargo.toml` does not reach this crate when it is the
+# build root — this crate resolves the unpatched `pdfium-render 0.8.37`
+# from crates.io, whose `ThreadSafePdfiumBindings` acquires the pdfium
+# global mutex only once on `FPDF_InitLibrary` and bypasses it for
+# every other call, segfaulting under concurrent access to a shared
+# `Pdfium`. Keep this pin in lockstep with `../libviprs/Cargo.toml`;
+# drop both once the fork is upstreamed and released.
+[patch.crates-io]
+pdfium-render = { git = "https://github.com/libviprs/pdfium-render.git", branch = "libviprs/per-call-thread-safety" }


### PR DESCRIPTION
## What

Replicate the core crate's `pdfium-render` thread-safety fork pin into this sibling. `libviprs-tests` is a build root with a direct optional `pdfium-render` dep plus the transitive one via `libviprs`.

`[patch.crates-io]` tables apply only from the build-root manifest, so the pin in `../libviprs/Cargo.toml` never reached this crate — it resolved the unpatched `pdfium-render 0.8.37` from crates.io. That wrapper (`ThreadSafePdfiumBindings`) acquires the pdfium global mutex only once on `FPDF_InitLibrary` and bypasses it for every other call, segfaulting under concurrent access to a shared `Pdfium`.

## Change

- Add `[patch.crates-io] pdfium-render = { git = "https://github.com/libviprs/pdfium-render.git", branch = "libviprs/per-call-thread-safety" }`, kept in lockstep with `../libviprs/Cargo.toml`.
- Refreshed `Cargo.lock`; the `pdfium-render` entry now resolves the git fork source.

Verified locally with `cargo metadata --locked` / `cargo tree --locked` — resolution is consistent and points at the fork.

Refs libviprs/libviprs#149