### PR TITLE
test(resume): read checkpoint via JobCheckpoint::load for segmented format (#127)

### DIFF
--- a/tests/builder_resume_observer_parity.rs
+++ b/tests/builder_resume_observer_parity.rs
@@ -26,7 +26,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use libviprs::resume::JobMetadata;
+use libviprs::resume::{JobCheckpoint, JobMetadata};
 use libviprs::sink::{FsSink, SinkError, Tile, TileFormat, TileSink};
 use libviprs::{
     CollectingObserver, EngineBuilder, EngineConfig, EngineEvent, EngineKind, Layout, PyramidPlan,
@@ -166,15 +166,18 @@ impl TileSink for PanickingSink {
     }
 }
 
-/// Read the persisted checkpoint as raw `JobMetadata`. Panics loudly if
-/// the file is missing or unparsable — the test that uses this needs a
+/// Load the persisted checkpoint as `JobMetadata`. Panics loudly if the
+/// checkpoint is missing or unparsable, the test that uses this needs a
 /// partial checkpoint to exist, so absence is a real bug.
+///
+/// Routes through `JobCheckpoint::load` because the completed-tile
+/// coordinates now live in an append-only segment log alongside the JSON
+/// header (libviprs issue #127); `load` merges the two into one coherent
+/// `JobMetadata`.
 fn read_job_metadata(dir: &Path) -> JobMetadata {
-    let path = dir.join(".libviprs-job.json");
-    let bytes =
-        std::fs::read(&path).unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
-    serde_json::from_slice::<JobMetadata>(&bytes)
-        .unwrap_or_else(|e| panic!("failed to parse {}: {e}", path.display()))
+    JobCheckpoint::load(dir)
+        .unwrap_or_else(|e| panic!("failed to load checkpoint in {}: {e}", dir.display()))
+        .unwrap_or_else(|| panic!("no checkpoint found in {}", dir.display()))
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/phase3_resume.rs
+++ b/tests/phase3_resume.rs
@@ -48,7 +48,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use libviprs::resume::{JobMetadata, ResumeMode};
+use libviprs::resume::{JobCheckpoint, JobMetadata, ResumeMode};
 use libviprs::{
     EngineBuilder, EngineConfig, EngineError, EngineResult, FsSink, Layout, PyramidPlan,
     PyramidPlanner, Raster, ResumePolicy, SinkError, Tile, TileCoord, TileFormat, TileSink,
@@ -105,17 +105,19 @@ fn small_plan(w: u32, h: u32, tile_size: u32) -> PyramidPlan {
         .plan()
 }
 
-/// Deserialise the job checkpoint from disk. Panics with a descriptive
-/// message if missing or malformed — tests want loud failures here.
+/// Load the job checkpoint from disk. Panics with a descriptive message if
+/// missing or malformed, tests want loud failures here.
+///
+/// Routes through `JobCheckpoint::load` rather than raw-parsing the JSON
+/// header: the completed-tile coordinates now live in an append-only segment
+/// log (`.libviprs-job.segments`) alongside the header so that per-flush
+/// checkpoint I/O stays bounded (libviprs issue #127). `load` merges the
+/// segment log with any inline header coordinates and hands back one coherent
+/// `JobMetadata`, which is exactly what these assertions want.
 fn read_job_metadata(dir: &Path) -> JobMetadata {
-    let path = dir.join(JOB_FILE);
-    let bytes =
-        std::fs::read(&path).unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
-    // The production type is expected to `impl Serialize + Deserialize`.
-    // If it does not, this test file fails to compile — which is correct
-    // TDD behaviour.
-    serde_json::from_slice::<JobMetadata>(&bytes)
-        .unwrap_or_else(|e| panic!("failed to parse {}: {e}", path.display()))
+    JobCheckpoint::load(dir)
+        .unwrap_or_else(|e| panic!("failed to load checkpoint in {}: {e}", dir.display()))
+        .unwrap_or_else(|| panic!("no checkpoint found in {}", dir.display()))
 }
 
 /// Recursively list every regular file under `dir`, returning paths relative
@@ -343,7 +345,13 @@ fn resume_mode_continues_after_partial_run() {
     let remaining: Vec<TileCoord> = remaining_idx.into_iter().map(|(_, c)| *c).collect();
 
     // Hand-crafted partial checkpoint. Keep the same plan_hash so the engine
-    // accepts it.
+    // accepts it. Completed coordinates now live in an append-only segment log
+    // beside the header (libviprs issue #127), so the first full run left a
+    // `.libviprs-job.segments` recording every tile. Remove it before writing
+    // the doctored header, otherwise the resumed run would merge that stale log
+    // and believe the whole plan is already complete. The hand-crafted header
+    // carries `done` inline, which `JobCheckpoint::load` honours on its own.
+    let _ = std::fs::remove_file(JobCheckpoint::segments_path(&base));
     let mut partial = JobMetadata::new(meta_full.plan_hash.clone(), "1970-01-01T00:00:00Z".into());
     partial.completed_tiles = done.clone();
     partial.last_checkpoint_at = "1970-01-01T00:00:00Z".into();

--- a/tests/phase3_validation_stress.rs
+++ b/tests/phase3_validation_stress.rs
@@ -338,8 +338,16 @@ fn byte_diff_dirs(a: &Path, b: &Path) -> Option<PathBuf> {
     // crash+resume (or simply appear only in one of the two), yet have no
     // bearing on output correctness. Filter them out so the comparison
     // focuses on actual tile content.
-    let is_bookkeeping =
-        |p: &Path| -> bool { p.file_name().and_then(|n| n.to_str()) == Some(".libviprs-job.json") };
+    let is_bookkeeping = |p: &Path| -> bool {
+        matches!(
+            p.file_name().and_then(|n| n.to_str()),
+            // The JSON header and its append-only completed-coordinate segment
+            // log (libviprs issue #127) are both resume bookkeeping: they
+            // legitimately differ between a clean run and a crash+resume and
+            // have no bearing on output tile content.
+            Some(".libviprs-job.json") | Some(".libviprs-job.segments")
+        )
+    };
     let list_a: Vec<PathBuf> = list_files_relative(a)
         .into_iter()
         .filter(|p| !is_bookkeeping(p))


### PR DESCRIPTION
Companion to libviprs #236 (issue #127). libviprs now moves the completed-tile coordinate log out of the JSON header into an append-only `.libviprs-job.segments` side file so per-flush checkpoint I/O is bounded.

This updates the shared suite to read the checkpoint through `JobCheckpoint::load` (which merges the header with the segment log) instead of raw-parsing `.libviprs-job.json` for `completed_tiles`, and treats `.libviprs-job.segments` as resume bookkeeping in the byte-diff comparison. Resume and validation-stress suites pass locally against libviprs main.

Refs libviprs/libviprs#127