### PR TITLE
Repin pdfium-render to 0.9 fork integration branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,7 +846,7 @@ dependencies = [
  "flate2",
  "image",
  "lopdf",
- "pdfium-render",
+ "pdfium-render 0.8.37",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -865,7 +865,7 @@ dependencies = [
  "image",
  "libviprs",
  "lopdf",
- "pdfium-render",
+ "pdfium-render 0.9.3",
  "proptest",
  "serde_json",
  "sha2 0.10.9",
@@ -1042,7 +1042,33 @@ dependencies = [
 [[package]]
 name = "pdfium-render"
 version = "0.8.37"
-source = "git+https://github.com/libviprs/pdfium-render.git?branch=libviprs%2Fper-call-thread-safety#f0bda9f30be1be0eb7ac7373bad4d24c411f338a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6553f6604a52b3203db7b4e9d51eb4dd193cf455af9e56d40cab6575b547b679"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "bytes",
+ "chrono",
+ "console_error_panic_hook",
+ "console_log",
+ "image",
+ "itertools",
+ "js-sys",
+ "libloading",
+ "log",
+ "maybe-owned",
+ "once_cell",
+ "utf16string",
+ "vecmath",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "pdfium-render"
+version = "0.9.3"
+source = "git+https://github.com/libviprs/pdfium-render.git?branch=libviprs%2Fintegration#1000a1aff1888425004c11432b376d2c36a4d3f2"
 dependencies = [
  "bitflags",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ tracing = ["libviprs/tracing"]
 
 [dependencies]
 libviprs = { path = "../libviprs" }
-pdfium-render = { version = "0.8", optional = true }
+pdfium-render = { version = "0.9", optional = true }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "tiff"] }
 flate2 = "1"
 tempfile = "3"
@@ -67,11 +67,11 @@ proptest = "1"
 # Mirror the core crate's `pdfium-render` thread-safety fork. `[patch]`
 # tables apply only from the build-root manifest, so the pin in
 # `../libviprs/Cargo.toml` does not reach this crate when it is the
-# build root — this crate resolves the unpatched `pdfium-render 0.8.37`
+# build root — this crate resolves the unpatched `pdfium-render 0.9.x`
 # from crates.io, whose `ThreadSafePdfiumBindings` acquires the pdfium
 # global mutex only once on `FPDF_InitLibrary` and bypasses it for
 # every other call, segfaulting under concurrent access to a shared
 # `Pdfium`. Keep this pin in lockstep with `../libviprs/Cargo.toml`;
 # drop both once the fork is upstreamed and released.
 [patch.crates-io]
-pdfium-render = { git = "https://github.com/libviprs/pdfium-render.git", branch = "libviprs/per-call-thread-safety" }
+pdfium-render = { git = "https://github.com/libviprs/pdfium-render.git", branch = "libviprs/integration" }


### PR DESCRIPTION
Bump the direct `pdfium-render` constraint from 0.8 to 0.9 and switch the `[patch.crates-io]` pin from `libviprs/per-call-thread-safety` to `libviprs/integration`, matching the libviprs core, which now builds on pdfium-render 0.9.3 from that fork branch.

Verification:
- `cargo update -p pdfium-render` refreshes the lock; the direct dependency resolves `pdfium-render 0.9.3` from the `libviprs/integration` branch.
- The patch is used (no "Patch ... was not used in the crate graph" warning); `cargo check` and `cargo check --features pdfium` finish clean.
- `cargo tree -i pdfium-render@0.9.3` shows libviprs-tests pointing at the git integration branch.

Scope: Cargo.toml + Cargo.lock only, no source or other dep changes.