### PR TITLE
Pin cross-repo counterpart SHA and script reference-fixture fetch

### DIFF
--- a/.github/actions/clone-counterpart/action.yml
+++ b/.github/actions/clone-counterpart/action.yml
@@ -1,0 +1,30 @@
+name: Clone counterpart libviprs at pinned SHA
+description: >
+  Clone the cross-repo counterpart (libviprs core) into ../libviprs at the exact
+  commit pinned in COUNTERPART_REV. There is no branch-name guessing and no
+  silent fallback to the default branch, so a PR is always tested against the
+  revision it declares (issue #58). Requires the calling repo to be checked out
+  first (actions/checkout@v4) so COUNTERPART_REV is present.
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -euo pipefail
+        rev_file="${GITHUB_WORKSPACE}/COUNTERPART_REV"
+        REV="$(grep -Eom1 '[0-9a-f]{40}' "$rev_file" || true)"
+        if [ -z "$REV" ]; then
+          echo "::error file=COUNTERPART_REV::no 40-char commit SHA found; refusing to guess a branch"
+          exit 1
+        fi
+        echo "Pinned libviprs revision: $REV"
+        dest="${GITHUB_WORKSPACE}/../libviprs"
+        mkdir -p "$dest"
+        git -C "$dest" init -q
+        git -C "$dest" remote add origin \
+          "https://github.com/${{ github.repository_owner }}/libviprs.git" 2>/dev/null || true
+        # Fetch exactly the pinned commit (GitHub allows fetching reachable SHAs).
+        git -C "$dest" fetch --depth 1 origin "$REV"
+        git -C "$dest" checkout -q FETCH_HEAD
+        echo "Checked out libviprs at $(git -C "$dest" rev-parse HEAD)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Clone libviprs (matching branch or main)
-        run: |
-          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
-          git clone --depth 1 --branch "$BRANCH" https://github.com/${{ github.repository_owner }}/libviprs.git ../libviprs 2>/dev/null \
-            || git clone --depth 1 https://github.com/${{ github.repository_owner }}/libviprs.git ../libviprs
+      - uses: ./.github/actions/clone-counterpart
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test
@@ -30,11 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Clone libviprs (matching branch or main)
-        run: |
-          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
-          git clone --depth 1 --branch "$BRANCH" https://github.com/${{ github.repository_owner }}/libviprs.git ../libviprs 2>/dev/null \
-            || git clone --depth 1 https://github.com/${{ github.repository_owner }}/libviprs.git ../libviprs
+      - uses: ./.github/actions/clone-counterpart
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install PDFium
@@ -57,16 +49,25 @@ jobs:
       # race FPDF state. Force serial execution within each test binary.
       - run: cargo test --features pdfium -- --test-threads=1
 
+  reference-fixtures:
+    name: Reference Fixtures (pinned fetch)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/clone-counterpart
+      - name: Fetch libvips reference suite at pinned revision
+        run: ./tools/fetch_reference_suite.sh
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # Prove the pinned fetch populated every fixture the ported suite needs.
+      - run: cargo test --features ported_tests --test fixture_audit
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Clone libviprs (matching branch or main)
-        run: |
-          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
-          git clone --depth 1 --branch "$BRANCH" https://github.com/${{ github.repository_owner }}/libviprs.git ../libviprs 2>/dev/null \
-            || git clone --depth 1 https://github.com/${{ github.repository_owner }}/libviprs.git ../libviprs
+      - uses: ./.github/actions/clone-counterpart
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt

--- a/COUNTERPART_REV
+++ b/COUNTERPART_REV
@@ -1,0 +1,14 @@
+# Pinned revision of the cross-repo counterpart: libviprs/libviprs (the core
+# crate this test suite depends on via `{ path = "../libviprs" }`).
+#
+# CI checks the counterpart out at exactly this commit instead of guessing a
+# matching branch name and silently falling back to `main`. That fallback let a
+# PR go green against the wrong revision of its counterpart (issue #58). The
+# first non-comment, non-blank line below is the authoritative 40-char SHA; the
+# trailing comment is a human label only.
+#
+# To bump: set this to a libviprs commit SHA, run the suite against the sibling
+# checkout, and update the label comment below.
+#
+# libviprs main @ 2026-07-10
+1e30e238417ef10c79377ed118eb343409cc1165

--- a/README.md
+++ b/README.md
@@ -52,6 +52,39 @@ cargo test -- --ignored stress
 
 # PDFium system check (manual diagnostic)
 cargo test --features pdfium -- --ignored pdfium_system
+
+# Ported libvips reference suite (fetch the fixtures first, see below)
+cargo test --features ported_tests
+```
+
+## Cross-repo Pinning
+
+This suite depends on the `libviprs` core crate as a sibling checkout
+(`{ path = "../libviprs" }`). CI checks the counterpart out at the exact commit
+pinned in [`COUNTERPART_REV`](./COUNTERPART_REV) via the reusable
+[`clone-counterpart`](./.github/actions/clone-counterpart/action.yml) action,
+so a PR is always tested against the revision it declares, never a branch-name
+guess that silently falls back to `main`. To point at a newer core, set the SHA
+in `COUNTERPART_REV`, run the suite against that sibling checkout, and update the
+label comment. The `counterpart_pinning` test guards these invariants.
+
+## Reference Fixtures
+
+The `ported_*` suites (feature `ported_tests`) compare libviprs output against
+the real libvips reference images. Those fixtures are fetched, not vendored, by
+a pinned script:
+
+```bash
+./tools/fetch_reference_suite.sh          # populate tmp/ from the pinned libvips rev
+./tools/fetch_reference_suite.sh --force  # refetch even if already present
+```
+
+The script sparse-clones only `test/test-suite` from a single pinned libvips
+commit into `tmp/libvips-reference-tests/` (git-ignored). Verify it populated
+everything the suites need:
+
+```bash
+cargo test --features ported_tests --test fixture_audit
 ```
 
 ### Docker (via run-tests.sh)

--- a/tests/counterpart_pinning.rs
+++ b/tests/counterpart_pinning.rs
@@ -1,0 +1,106 @@
+//! Guards the cross-repo pinning invariants from issue #58.
+//!
+//! CI used to stitch the two repos together by branch name with a silent
+//! fallback to `main`, so a PR could go green against the wrong revision of its
+//! counterpart, and the libvips reference fixtures had no pinned fetch step at
+//! all. These tests fail loudly if either guarantee regresses. They read only
+//! repository files, so they run under the default `cargo test` with no
+//! network, no sibling checkout, and no feature flags.
+
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
+}
+
+fn read(rel: &str) -> String {
+    let path = repo_root().join(rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+/// A full git object name: exactly 40 lowercase hex digits.
+fn is_full_sha(token: &str) -> bool {
+    token.len() == 40 && token.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// True if any whitespace/punctuation-delimited token in `text` is a full SHA.
+fn has_full_sha(text: &str) -> bool {
+    text.split(|c: char| !c.is_ascii_hexdigit())
+        .any(is_full_sha)
+}
+
+#[test]
+fn counterpart_rev_pins_a_full_sha() {
+    let raw = read("COUNTERPART_REV");
+    let payload = raw
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty() && !line.starts_with('#'))
+        .expect("COUNTERPART_REV must name a revision");
+    assert!(
+        is_full_sha(payload),
+        "COUNTERPART_REV must pin a 40-char commit SHA, not a branch or tag (found {payload:?})"
+    );
+}
+
+#[test]
+fn ci_checks_out_pinned_counterpart_with_no_branch_fallback() {
+    // The reusable action drives the checkout from the pinned rev.
+    let action = read(".github/actions/clone-counterpart/action.yml");
+    assert!(
+        action.contains("COUNTERPART_REV"),
+        "clone-counterpart action must read the pinned rev from COUNTERPART_REV"
+    );
+    assert!(
+        action.contains("FETCH_HEAD"),
+        "clone-counterpart action must check out the exact fetched commit"
+    );
+
+    let ci = read(".github/workflows/ci.yml");
+    assert!(
+        ci.contains("./.github/actions/clone-counterpart"),
+        "every job needing the sibling must clone it via the pinned action"
+    );
+    // The old branch-name clone and its `|| git clone ... main` fallback are gone.
+    assert!(
+        !ci.contains("--branch"),
+        "ci.yml must not clone the counterpart by branch name"
+    );
+    assert!(
+        !ci.contains("|| git clone"),
+        "ci.yml must not fall back to a default-branch clone"
+    );
+}
+
+#[test]
+fn reference_suite_fetch_is_scripted_and_pinned() {
+    let rel = "tools/fetch_reference_suite.sh";
+    let script = read(rel);
+    assert!(
+        has_full_sha(&script),
+        "{rel} must pin an explicit upstream commit SHA"
+    );
+    assert!(
+        script.contains("libvips-reference-tests/test-suite"),
+        "{rel} must populate tmp/libvips-reference-tests/test-suite"
+    );
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(repo_root().join(rel))
+            .expect("stat fetch script")
+            .permissions()
+            .mode();
+        assert!(mode & 0o111 != 0, "{rel} must be executable");
+    }
+}
+
+#[test]
+fn ci_wires_the_pinned_fetch_step() {
+    let ci = read(".github/workflows/ci.yml");
+    assert!(
+        ci.contains("tools/fetch_reference_suite.sh"),
+        "ci.yml must fetch reference fixtures via the pinned script as a CI step"
+    );
+}

--- a/tools/fetch_reference_suite.sh
+++ b/tools/fetch_reference_suite.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Fetch the libvips reference test-suite images at a pinned revision.
+#
+# The ported_* integration tests (feature = "ported_tests") compare libviprs
+# output against the real libvips reference fixtures. Those fixtures live
+# upstream in libvips at test/test-suite/images and are git-ignored here (they
+# land under tmp/). Without a fetch step the reference suite can only report the
+# fixtures as missing (issue #58). This script populates them deterministically
+# from a single pinned commit so a CI run and a local run see identical inputs.
+#
+# Usage:
+#   ./tools/fetch_reference_suite.sh [--force]
+#
+# Output:
+#   tmp/libvips-reference-tests/test-suite/images/   (the reference fixtures)
+#
+# Verify the fetch populated everything the suite needs:
+#   cargo test --features ported_tests --test fixture_audit
+
+set -euo pipefail
+
+# --- Pinned upstream revision -------------------------------------------------
+# libvips v8.18.4. The SHA is authoritative; the tag is a human label. Bump both
+# together and re-run the fixture_audit test to confirm a candidate revision
+# still carries every fixture the audit registry requires.
+LIBVIPS_REPO="https://github.com/libvips/libvips.git"
+LIBVIPS_REV="e01a4797cabe77d457fdfa7d776b7a7e7ca6d6a7"
+LIBVIPS_TAG="v8.18.4"
+SUBTREE="test/test-suite"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEST="$REPO_ROOT/tmp/libvips-reference-tests"
+IMAGES_DIR="$DEST/test-suite/images"
+MARKER="$DEST/.pinned-rev"
+
+FORCE=0
+if [ "${1:-}" = "--force" ]; then
+    FORCE=1
+elif [ "$#" -gt 0 ]; then
+    echo "ERROR: unknown argument: $1 (only --force is accepted)" >&2
+    exit 2
+fi
+
+# Idempotent: skip when already populated at the pinned rev, unless --force.
+if [ "$FORCE" -eq 0 ] && [ -f "$MARKER" ] && [ -d "$IMAGES_DIR" ] \
+   && [ "$(cat "$MARKER" 2>/dev/null)" = "$LIBVIPS_REV" ]; then
+    echo "Reference suite already at $LIBVIPS_REV ($LIBVIPS_TAG); nothing to do."
+    echo "Pass --force to refetch."
+    exit 0
+fi
+
+command -v git >/dev/null 2>&1 || { echo "ERROR: git is required." >&2; exit 1; }
+
+echo "==> Fetching libvips reference suite ($LIBVIPS_TAG / $LIBVIPS_REV)"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Partial + sparse clone: download only the subtree's blobs at exactly one
+# commit, so we never pull the whole libvips history or source tree.
+git -C "$WORK" init -q
+git -C "$WORK" remote add origin "$LIBVIPS_REPO"
+git -C "$WORK" config core.sparseCheckout true
+printf '%s/*\n' "$SUBTREE" > "$WORK/.git/info/sparse-checkout"
+git -C "$WORK" fetch --depth 1 --filter=blob:none origin "$LIBVIPS_REV"
+git -C "$WORK" checkout -q FETCH_HEAD
+
+if [ ! -d "$WORK/$SUBTREE/images" ]; then
+    echo "ERROR: expected $SUBTREE/images not present at $LIBVIPS_REV" >&2
+    exit 1
+fi
+
+# Publish into tmp/ (replace any prior copy) and stamp the pinned rev.
+rm -rf "$DEST"
+mkdir -p "$DEST"
+cp -R "$WORK/$SUBTREE" "$DEST/test-suite"
+printf '%s\n' "$LIBVIPS_REV" > "$MARKER"
+
+count="$(find "$IMAGES_DIR" -type f | wc -l | tr -d ' ')"
+echo "==> Done: $count reference image(s) under $IMAGES_DIR"


### PR DESCRIPTION
## Problem
Cross-repo CI was stitched by branch-name convention with a silent `main` fallback: `libviprs-tests` cloned core by branch name (`ci.yml:19-23`), so a renamed branch fell back to `main` and a PR could go green against the wrong revision of its counterpart. The ported libvips reference fixtures lived under a git-ignored `tmp/` with no fetch script, so the reference suite could only report the fixtures as missing (`fixture_audit.rs`).

## Fix
- **Pinned counterpart checkout.** Add `COUNTERPART_REV` (a full libviprs core SHA) and a reusable [`clone-counterpart`](./.github/actions/clone-counterpart/action.yml) composite action that fetches exactly that commit and checks out `FETCH_HEAD`. No branch-name guessing, no `|| git clone` fallback. All four CI jobs use it.
- **Scripted, pinned fixture fetch.** Add `tools/fetch_reference_suite.sh`, which sparse-clones only `test/test-suite` from a single pinned libvips commit (`v8.18.4`) into `tmp/libvips-reference-tests/` (idempotent, `--force` to refetch). A new `reference-fixtures` CI job runs it and proves the result with `cargo test --features ported_tests --test fixture_audit`.
- **Regression guard.** New `tests/counterpart_pinning.rs` (runs under default `cargo test`) asserts `COUNTERPART_REV` pins a 40-char SHA, `ci.yml` has no `--branch`/fallback and uses the pinned action, and the fetch script is scripted, pinned, and executable.

## Verification (local mirror)
- `cargo test` (default): all pass, including the 4 new guard tests.
- `./tools/fetch_reference_suite.sh` then `cargo test --features ported_tests --test fixture_audit`: 49/49 pass (every required fixture present at the pinned rev).
- `cargo fmt -- --check` clean; `cargo clippy --all-targets -- -D warnings` clean.

RED before / GREEN after: on `main` the guard test fails (no `COUNTERPART_REV`, `ci.yml` still has the branch fallback) and `fixture_audit` fails (fixtures missing); both are green after this change.

## Acceptance criteria
- [x] Cross-repo CI checks out a pinned counterpart SHA, not a branch-name fallback.
- [x] Reference fixtures are fetched by a scripted, pinned step.

Closes #58