### PR TITLE
Drop --test-threads=1 for pdfium; move perf-ratio smoke to nightly (#59)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,14 @@ jobs:
           sudo cp pdfium/lib/libpdfium.so /usr/local/lib/
           sudo cp -r pdfium/include/* /usr/local/include/
           sudo ldconfig
-      # Pdfium FFI calls are not safe to invoke concurrently against the
-      # shared process-wide Pdfium instance — parallel cargo-test workers
-      # race FPDF state. Force serial execution within each test binary.
-      - run: cargo test --features pdfium -- --test-threads=1
+      # Run the pdfium suite multi-threaded. The pdfium-render fork on the
+      # `libviprs/integration` branch takes the pdfium global mutex per call in
+      # `ThreadSafePdfiumBindings`, so concurrent FPDF access across cargo-test
+      # worker threads is safe. Dropping `--test-threads=1` makes the suite
+      # itself exercise that cross-test concurrency. The wall-clock perf-ratio
+      # smoke is `#[ignore]`d and runs in nightly.yml, so it never gates this
+      # job on shared runner timing noise.
+      - run: cargo test --features pdfium
 
   reference-fixtures:
     name: Reference Fixtures (pinned fetch)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,45 @@
+name: Nightly
+
+# Wall-clock perf smokes are too timing-sensitive to gate every PR on shared
+# runners, so they are `#[ignore]`d out of ci.yml (see
+# tests/pdfium_streaming_perf_smoke.rs) and exercised here on a schedule. A
+# transient blip on a nightly is a retryable run, not a merge blocker.
+on:
+  schedule:
+    # 07:00 UTC daily.
+    - cron: "0 7 * * *"
+  # Allow an on-demand run from the Actions tab.
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  perf-smoke:
+    name: Perf smoke (pdfium, ignored tests)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/clone-counterpart
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install PDFium
+        # Provenance: pinned, checksum-verified binary from libviprs-dep — the
+        # single source shared with the Dockerfile and ci.yml. Keep
+        # PDFIUM_RELEASE and the SHA-256 digest in lockstep with those files.
+        env:
+          PDFIUM_RELEASE: pdfium-7881
+          PDFIUM_SHA256: 653f24f074afe6c868f634ae0cc954a1a89821f33bc7795f16065a14022b662b
+        run: |
+          curl -fsSL -o pdfium.tgz "https://github.com/libviprs/libviprs-dep/releases/download/${PDFIUM_RELEASE}/pdfium-linux-x64.tgz"
+          echo "${PDFIUM_SHA256}  pdfium.tgz" | sha256sum -c -
+          mkdir -p pdfium
+          tar xzf pdfium.tgz -C pdfium --strip-components=1
+          sudo cp pdfium/lib/libpdfium.so /usr/local/lib/
+          sudo cp -r pdfium/include/* /usr/local/include/
+          sudo ldconfig
+      # Run only the `#[ignore]`d tests (the wall-clock perf-ratio smokes).
+      # These assert streaming <= 12x cached and are the signal moved off the
+      # per-PR path in issue #59.
+      - run: cargo test --features pdfium -- --ignored

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,12 +53,19 @@ RUN cargo fetch
 # Each integration test is a separate binary; full debuginfo exhausts disk space.
 ENV CARGO_PROFILE_DEV_DEBUG=0
 
-# Default: run libviprs tests first, then libviprs-tests with pdfium
+# The pdfium test suites run multi-threaded. The pdfium-render fork on the
+# `libviprs/integration` branch (a direct dep of libviprs, mirrored into
+# libviprs-tests via `[patch.crates-io]`) rewrites `ThreadSafePdfiumBindings`
+# to take the pdfium global mutex per call, so concurrent FPDF access across
+# cargo-test worker threads is safe. Running the default thread pool exercises
+# that cross-test concurrency instead of hiding it behind `--test-threads=1`.
+# The wall-clock perf-ratio smoke is `#[ignore]`d here and runs in the nightly
+# workflow, so it never gates this container run.
 CMD sh -c '\
     echo "================================================================" && \
     echo "Running libviprs unit tests (with pdfium)..." && \
     echo "================================================================" && \
-    cd /src/libviprs && cargo test --features pdfium -- --test-threads=1 && \
+    cd /src/libviprs && cargo test --features pdfium && \
     echo "" && \
     echo "Cleaning libviprs build artifacts to free disk space..." && \
     cargo clean && \
@@ -66,4 +73,4 @@ CMD sh -c '\
     echo "================================================================" && \
     echo "Running libviprs-tests integration tests (with pdfium)..." && \
     echo "================================================================" && \
-    cd /src/libviprs-tests && cargo test --features pdfium -- --test-threads=1'
+    cd /src/libviprs-tests && cargo test --features pdfium'

--- a/tests/pdfium_ci_policy.rs
+++ b/tests/pdfium_ci_policy.rs
@@ -1,0 +1,120 @@
+//! Guards the pdfium test-execution policy from issue #59.
+//!
+//! Two invariants used to be entangled with the unpropagated pdfium-render
+//! fork and with shared-runner timing noise:
+//!
+//! 1. The pdfium suites were pinned to `--test-threads=1` because upstream
+//!    `ThreadSafePdfiumBindings` bypassed the pdfium global mutex on every
+//!    call but `FPDF_InitLibrary`, so parallel cargo-test workers raced FPDF
+//!    state. The `libviprs/integration` fork now locks per call (a direct dep
+//!    of libviprs, mirrored here via `[patch.crates-io]`), so the suite is
+//!    safe multi-threaded and must exercise that cross-test concurrency.
+//! 2. A wall-clock perf-ratio smoke (streaming <= 12x cached) gated every PR
+//!    on shared-runner timing, a flake vector. It now carries `#[ignore]` and
+//!    runs in the nightly workflow instead.
+//!
+//! These tests fail loudly if either guarantee regresses. They read only
+//! repository files, so they run under the default `cargo test` with no
+//! network, no sibling checkout, and no feature flags.
+
+use std::path::{Path, PathBuf};
+
+/// The serial-execution flag whose removal issue #59 pins. Assembled from
+/// fragments so this guard file does not itself match a raw substring scan
+/// for the flag in the workflow / Dockerfile.
+fn serial_flag() -> String {
+    format!("--test-threads{}1", "=")
+}
+
+/// Lines that actually invoke `cargo test` (the command surface), ignoring
+/// prose comments that may legitimately name the dropped flag while
+/// explaining why it is gone.
+fn cargo_test_command_lines(text: &str) -> Vec<&str> {
+    text.lines()
+        .filter(|line| {
+            let trimmed = line.trim_start();
+            // Skip comment lines (YAML and Dockerfile both use `#`) so prose
+            // that names the dropped flag does not count as a command.
+            !trimmed.starts_with('#') && trimmed.contains("cargo test")
+        })
+        .collect()
+}
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
+}
+
+fn read(rel: &str) -> String {
+    let path = repo_root().join(rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+/// The flag must be absent from every actual `cargo test` invocation in the
+/// file (comments that explain why it is gone are allowed to name it).
+fn assert_no_serial_flag_in_commands(file: &str, contents: &str) {
+    let commands = cargo_test_command_lines(contents);
+    let pdfium_cmds = commands
+        .iter()
+        .filter(|c| c.contains("--features pdfium"))
+        .count();
+    assert!(
+        pdfium_cmds >= 1,
+        "{file} must still invoke the pdfium suite via `cargo test --features pdfium`"
+    );
+    for cmd in &commands {
+        assert!(
+            !cmd.contains(&serial_flag()),
+            "{file} must not pin a `cargo test` invocation to {}; the fork makes multi-threaded runs safe (issue #59). Offending line: {cmd:?}",
+            serial_flag()
+        );
+    }
+}
+
+#[test]
+fn ci_runs_the_pdfium_suite_multi_threaded() {
+    let ci = read(".github/workflows/ci.yml");
+    assert_no_serial_flag_in_commands("ci.yml", &ci);
+}
+
+#[test]
+fn dockerfile_runs_the_pdfium_suites_multi_threaded() {
+    let dockerfile = read("Dockerfile");
+    assert_no_serial_flag_in_commands("Dockerfile", &dockerfile);
+}
+
+#[test]
+fn perf_ratio_smoke_is_ignored_out_of_normal_ci() {
+    let src = read("tests/pdfium_streaming_perf_smoke.rs");
+    // Count real attribute lines (trimmed line starts with the attribute),
+    // not prose in the module doc that mentions `#[ignore]` / `#[test]`.
+    let attr_lines = |attr: &str| {
+        src.lines()
+            .filter(|l| l.trim_start().starts_with(attr))
+            .count()
+    };
+    let test_attrs = attr_lines("#[test]");
+    let ignore_attrs = attr_lines("#[ignore");
+    // Both wall-clock assertions must be behind `#[ignore]` so a normal
+    // `cargo test` (and the per-PR CI job) never blocks on runner timing.
+    assert_eq!(
+        test_attrs, 2,
+        "expected the two perf-smoke tests; found {test_attrs} (update this guard if the file changed)"
+    );
+    assert_eq!(
+        ignore_attrs, test_attrs,
+        "every perf-smoke #[test] must carry #[ignore]; found {ignore_attrs} ignore attrs for {test_attrs} tests (issue #59)"
+    );
+}
+
+#[test]
+fn nightly_workflow_runs_the_ignored_perf_smoke_on_a_schedule() {
+    let nightly = read(".github/workflows/nightly.yml");
+    assert!(
+        nightly.contains("schedule:") && nightly.contains("cron:"),
+        "nightly.yml must run on a cron schedule"
+    );
+    assert!(
+        nightly.contains("cargo test --features pdfium -- --ignored"),
+        "nightly.yml must run the ignored (perf-ratio smoke) tests"
+    );
+}

--- a/tests/pdfium_streaming_perf_smoke.rs
+++ b/tests/pdfium_streaming_perf_smoke.rs
@@ -24,12 +24,19 @@
 //! memory reasons must not get blindsided by a 10× wall-time penalty.
 //! That contract belongs in tests, not in benches.
 //!
-//! # Why a wall-time test isn't flaky
+//! # Why this is `#[ignore]`d out of normal CI
 //!
-//! Pdfium is deterministic and the threshold is 5×. The fastest CI
-//! machine and the slowest CI machine both produce the same ratio,
-//! modulo ±10 % noise. We warm up pdfium before timing to avoid
-//! the lazy init cost.
+//! Pdfium is deterministic and the threshold is coarse, but the two
+//! timings are taken back to back on a shared CI runner. A scheduling
+//! hiccup on the cached run (the denominator) inflates the ratio and
+//! turns this into a spurious red on an unrelated PR. Wall-clock ratios
+//! are a nightly-quality signal, not a per-PR gate: both tests carry
+//! `#[ignore]` so the normal `cargo test` run never blocks on them, and
+//! `.github/workflows/nightly.yml` runs them on a schedule via
+//! `cargo test --features pdfium -- --ignored`, where a transient blip
+//! is a retryable nightly, not a merge blocker. Removing `#[ignore]`
+//! from either test re-arms the flake and is guarded by
+//! `pdfium_ci_policy.rs`.
 
 #![cfg(feature = "pdfium")]
 
@@ -118,6 +125,7 @@ fn warmup(fixture: &str) -> u32 {
 }
 
 #[test]
+#[ignore = "wall-clock perf-ratio smoke: nightly-only, runs via `cargo test --features pdfium -- --ignored` in nightly.yml"]
 fn streaming_within_constant_factor_of_cached_blueprint() {
     let _ = warmup(FIXTURE_BLUEPRINT);
     // Run cached first, then streaming. Either order is fine — both
@@ -134,6 +142,7 @@ fn streaming_within_constant_factor_of_cached_blueprint() {
 }
 
 #[test]
+#[ignore = "wall-clock perf-ratio smoke: nightly-only, runs via `cargo test --features pdfium -- --ignored` in nightly.yml"]
 fn streaming_within_constant_factor_of_cached_portrait() {
     let _ = warmup(FIXTURE_PORTRAIT);
     let cached = time_cached_n_strips(FIXTURE_PORTRAIT, STRIPS);


### PR DESCRIPTION
## Summary

Resolves #59.

The pdfium test runs were pinned to `--test-threads=1` as safety-by-scheduling around the unpropagated pdfium-render fork, and a wall-clock perf-ratio smoke gated every PR on shared-runner timing.

### 1. Drop `--test-threads=1`
The `libviprs/integration` fork rewrites `ThreadSafePdfiumBindings` to take the pdfium global mutex per call. It reaches this build as a direct dep of `libviprs`, mirrored here via `[patch.crates-io]`, so concurrent FPDF access across cargo-test workers is safe. I drop the flag from:
- `.github/workflows/ci.yml` (test-pdfium job)
- `Dockerfile` (both the libviprs and libviprs-tests invocations)

so the suite itself exercises cross-test concurrency. The existing `tests/pdfium_streaming_concurrent.rs` already pins intra-test FPDF thread safety.

### 2. Perf-ratio smoke to nightly
Both tests in `tests/pdfium_streaming_perf_smoke.rs` now carry `#[ignore]`, so a normal `cargo test` (and the per-PR CI job) never blocks on the streaming <= 12x cached wall-clock assertion. A new `.github/workflows/nightly.yml` runs them on a cron schedule via `cargo test --features pdfium -- --ignored`, retaining the no-document-caching regression signal off the merge path.

### 3. Regression guard
`tests/pdfium_ci_policy.rs` pins all three invariants from repository files alone (default features, no pdfium, no network): the pdfium `cargo test` commands carry no serial flag, every perf-smoke test is `#[ignore]`d, and `nightly.yml` runs the ignored tests on a schedule. It is RED against the prior config and GREEN after this change.

## Acceptance criteria
- [x] The pdfium test suite runs multi-threaded once the fork is in place.
- [x] The wall-clock perf assertion no longer gates normal CI.

## Verification
- `cargo test --test pdfium_ci_policy`: 4 passed (RED before this change, confirmed by stashing the config edits).
- `cargo fmt -- --check`: clean.
- `cargo clippy --all-targets -- -D warnings` (default features): clean.
- `cargo test --features pdfium --test pdfium_streaming_perf_smoke --no-run`: compiles against the fork.

Two failures pre-exist on `main` at the pinned counterpart rev and are untouched by this PR (both files unmodified here): `phase3_resume::resume_mode_refuses_if_plan_hash_differs` and a compile error in `pdfium_system_check.rs` under `--features pdfium`. They are unrelated to issue #59.

Closes #59