### PR TITLE
Remove stale builder_v1 gate; wire feature-cell CI (#55)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,31 @@ jobs:
       # Prove the pinned fetch populated every fixture the ported suite needs.
       - run: cargo test --features ported_tests --test fixture_audit
 
+  feature-cells:
+    name: Feature Cell (${{ matrix.feature }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # One cell per non-default feature so a build/lint regression under a
+        # feature-gated module (the `s3` object-store sink, the `packfile`
+        # archive sink, the `tracing` span instrumentation) can no longer ship
+        # green just because the default harness never compiled that code.
+        # `-Dwarnings` (via RUSTFLAGS) means every gated test target is fully
+        # type-checked and linted here, not merely conditionally excluded.
+        # `pdfium` has its own job above; `ported_tests` is exercised by the
+        # reference-fixtures job (its full suite targets a libviprs op API that
+        # is not yet on the crate).
+        feature: [s3, packfile, tracing]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/clone-counterpart
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets --features ${{ matrix.feature }} -- -D warnings
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,6 @@ default = []
 pdfium = ["libviprs/pdfium", "dep:pdfium-render"]
 ported_tests = []
 s3 = ["libviprs/s3"]
-# Enables the v1-builder integration test suite (EngineBuilder, per-component
-# builders, extension hatch). The tests reference a public API that does not
-# yet exist in `libviprs`; enabling this feature without the matching source
-# migration in place is *expected* to fail compilation. The feature is off by
-# default so `cargo test` and CI remain green during the TDD red phase.
-builder_v1 = []
 # Enables Phase 3 packfile archive-sink integration tests in
 # `tests/phase3_packfile.rs`. Activates the `packfile` feature on the
 # core `libviprs` crate so that `libviprs::sink::PackfileSink` and
@@ -60,9 +54,8 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 # independently of the core crate's implementation.
 blake3 = "1"
 sha2 = "0.10"
-# Used by `tests/builder_composition_invariants.rs` under the `builder_v1`
-# feature. Listed unconditionally — dev-deps cannot be optional — but only
-# linked from code guarded by `#[cfg(feature = "builder_v1")]`.
+# Used by `tests/builder_composition_invariants.rs` for property-based
+# invariants over the `EngineBuilder` composition surface.
 proptest = "1"
 # Mirror the core crate's `pdfium-render` thread-safety fork. `[patch]`
 # tables apply only from the build-root manifest, so the pin in

--- a/tests/builder_composition_invariants.rs
+++ b/tests/builder_composition_invariants.rs
@@ -18,7 +18,6 @@
 //! Generators are kept small: the matrix is bounded, so proptest mostly
 //! picks combinations rather than generating unbounded value spaces.
 
-#![cfg(feature = "builder_v1")]
 #![allow(unused_imports)]
 
 use proptest::prelude::*;

--- a/tests/builder_engine_parallel.rs
+++ b/tests/builder_engine_parallel.rs
@@ -12,7 +12,6 @@
 //!   engine because that would defeat the streaming memory budget.
 //! - `Streaming` and `MapReduce` accept `&Raster` by auto-wrapping.
 
-#![cfg(feature = "builder_v1")]
 #![allow(unused_imports)]
 
 use libviprs::sink::{CollectedTile, MemorySink, TileSink};

--- a/tests/builder_engine_streaming.rs
+++ b/tests/builder_engine_streaming.rs
@@ -14,7 +14,6 @@
 //! `generate_pyramid_streaming` free function. That function has been
 //! deleted; these tests now assert on builder-only observables.
 
-#![cfg(feature = "builder_v1")]
 #![allow(unused_imports)]
 
 use libviprs::sink::{CollectedTile, MemorySink, TileSink};

--- a/tests/builder_engine_surface.rs
+++ b/tests/builder_engine_surface.rs
@@ -15,7 +15,6 @@
 //! builder-only observables (tile counts, produced tiles, background
 //! padding) instead.
 
-#![cfg(feature = "builder_v1")]
 #![allow(unused_imports)]
 
 use libviprs::sink::{CollectedTile, MemorySink, TileFormat, TileSink};
@@ -135,11 +134,8 @@ fn builder_honours_with_background_rgb() {
 
     // One edge tile at the top level must include the padding colour.
     let tiles = sink.tiles();
-    let top = tiles
-        .iter()
-        .filter(|t| t.coord.level == tiles.iter().map(|t| t.coord.level).max().unwrap())
-        .next()
-        .unwrap();
+    let top_level = tiles.iter().map(|t| t.coord.level).max().unwrap();
+    let top = tiles.iter().find(|t| t.coord.level == top_level).unwrap();
     assert!(
         top.data.windows(3).any(|w| w == [10, 20, 30]),
         "background rgb not present in padded tile data"

--- a/tests/builder_extension_hatch.rs
+++ b/tests/builder_extension_hatch.rs
@@ -12,7 +12,6 @@
 //!   `TypeId`.
 //! - Values are not required to be `Clone` or `Debug` — only `Send + Sync`.
 
-#![cfg(feature = "builder_v1")]
 #![allow(unused_imports)]
 
 use std::sync::Arc;

--- a/tests/builder_mapreduce_verify.rs
+++ b/tests/builder_mapreduce_verify.rs
@@ -34,8 +34,6 @@
 //!    emitted a Blake3 manifest, corrupting a tile is caught via the
 //!    checksum branch rather than the byte-exact branch.
 
-#![cfg(feature = "builder_v1")]
-
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
 use std::sync::Arc;

--- a/tests/builder_match_composition.rs
+++ b/tests/builder_match_composition.rs
@@ -7,7 +7,6 @@
 //! on `EngineBuilder` itself for those knobs — each `.with_*` must keep
 //! the builder type unchanged.
 
-#![cfg(feature = "builder_v1")]
 #![allow(unused_imports)]
 
 use libviprs::dedupe::DedupeStrategy;
@@ -20,6 +19,11 @@ use libviprs::{EngineBuilder, EngineKind, Layout, PyramidPlanner, ResumePolicy};
 mod common;
 use common::fixtures::canonical_raster_scaled;
 
+// These variants model the runtime modes a caller would pick before feeding a
+// matched policy into the builder. Not every variant is constructed in-test
+// (each test fixes one mode), but all appear as `match` arms, which is the
+// composition surface under test.
+#[allow(dead_code)]
 enum Mode {
     Fast,
     Safe,
@@ -58,7 +62,21 @@ fn resume_through_match() {
     let plan = PyramidPlanner::new(64, 64, 32, 0, Layout::DeepZoom)
         .unwrap()
         .plan();
-    EngineBuilder::new(&src, plan, MemorySink::new())
+
+    // The `Audit` arm selects `verify()`, which is read-only and requires an
+    // on-disk sink to audit (a `MemorySink` yields `VerifyRequiresOnDiskSink`).
+    // Seed a full pyramid on disk with an overwrite run first, then compose the
+    // match-produced policy through `.with_resume`. The point of this test is
+    // that the owned policy composes through a `match` arm and runs; seeding
+    // just gives the read-only verify arm something to audit.
+    let dir = tempfile::tempdir().unwrap();
+    let base = dir.path().join("tiles");
+    let sink = FsSink::new(base, plan.clone()).with_format(TileFormat::Raw);
+    EngineBuilder::new(&src, plan.clone(), &sink)
+        .with_resume(ResumePolicy::overwrite())
+        .run()
+        .unwrap();
+    EngineBuilder::new(&src, plan, &sink)
         .with_resume(resume)
         .run()
         .unwrap();

--- a/tests/builder_resume_matrix.rs
+++ b/tests/builder_resume_matrix.rs
@@ -18,15 +18,15 @@
 //! | StripSource  Verify     | IncompatibleSource     | ok            | ok            |
 //!
 //! Rejection cells assert the typed error. Success cells assert `Ok(_)` with
-//! the expected `tiles_produced` count: non-zero for Overwrite and Resume
-//! (resumed runs are idempotent — `tiles_produced` still counts every tile
-//! the engine visited), and zero for Verify (Verify is read-only and does
-//! not produce tiles). For Verify cells the pyramid is first seeded via an
-//! Overwrite run against the same directory.
+//! the expected `tiles_produced` count. Overwrite writes the whole plan, so it
+//! reports `plan.total_tile_count()`. Resume and Verify cells first seed a full
+//! pyramid via an Overwrite run against the same directory, so both report `0`:
+//! Resume is idempotent and skips every already-recorded tile (it accounts only
+//! the tiles it actually wrote, which is none once the checkpoint is complete),
+//! and Verify is read-only and never produces tiles. The idempotent-resume
+//! contract is pinned independently in `phase3_resume::idempotent_resume_of_completed_job`.
 
-#![cfg(feature = "builder_v1")]
-
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use libviprs::sink::{FsSink, TileFormat};
 use libviprs::streaming::RasterStripSource;
@@ -63,8 +63,8 @@ fn fresh_directory() -> (tempfile::TempDir, PathBuf, PyramidPlan) {
 /// Seed a fully-written pyramid at `base` so a subsequent Verify run has
 /// something to audit. Uses Monolithic + Overwrite — the one engine × mode
 /// pair that is supported for every Verify seed scenario.
-fn seed_pyramid(base: &PathBuf, plan: &PyramidPlan, src: &Raster) {
-    let sink = FsSink::new(base.clone(), plan.clone()).with_format(TileFormat::Raw);
+fn seed_pyramid(base: &Path, plan: &PyramidPlan, src: &Raster) {
+    let sink = FsSink::new(base.to_path_buf(), plan.clone()).with_format(TileFormat::Raw);
     EngineBuilder::new(src, plan.clone(), &sink)
         .with_engine(EngineKind::Monolithic)
         .with_resume(ResumePolicy::overwrite())
@@ -108,12 +108,11 @@ fn monolithic_resume_with_raster_source() {
         .run()
         .unwrap();
 
-    // `tiles_produced` counts every tile the engine visits, including ones
-    // short-circuited by the skip set. With a full checkpoint the count
-    // still equals the plan's total — the short-circuit happens at the sink
-    // layer, not in the engine's accounting.
-    assert_eq!(result.tiles_produced, plan.total_tile_count());
-    assert!(result.tiles_produced > 0);
+    // `tiles_produced` counts only the tiles the resumed run actually wrote.
+    // With a full checkpoint every tile is skipped, so the resumed run is a
+    // no-op and produces zero tiles. This is the idempotent-resume contract
+    // pinned in `phase3_resume::idempotent_resume_of_completed_job`.
+    assert_eq!(result.tiles_produced, 0);
 }
 
 #[test]
@@ -225,7 +224,10 @@ fn streaming_resume_with_raster_source() {
         .run()
         .unwrap();
 
-    assert!(result.tiles_produced > 0);
+    // Idempotent resume over a full checkpoint writes nothing: `tiles_produced`
+    // counts only tiles actually written, which is zero once every tile is
+    // already recorded (see `phase3_resume::idempotent_resume_of_completed_job`).
+    assert_eq!(result.tiles_produced, 0);
 }
 
 #[test]
@@ -278,7 +280,10 @@ fn streaming_resume_with_strip_source() {
         .run()
         .unwrap();
 
-    assert!(result.tiles_produced > 0);
+    // Idempotent resume over a full checkpoint writes nothing: `tiles_produced`
+    // counts only tiles actually written, which is zero once every tile is
+    // already recorded (see `phase3_resume::idempotent_resume_of_completed_job`).
+    assert_eq!(result.tiles_produced, 0);
 }
 
 #[test]
@@ -334,7 +339,10 @@ fn mapreduce_resume_with_raster_source() {
         .run()
         .unwrap();
 
-    assert!(result.tiles_produced > 0);
+    // Idempotent resume over a full checkpoint writes nothing: `tiles_produced`
+    // counts only tiles actually written, which is zero once every tile is
+    // already recorded (see `phase3_resume::idempotent_resume_of_completed_job`).
+    assert_eq!(result.tiles_produced, 0);
 }
 
 #[test]
@@ -387,7 +395,10 @@ fn mapreduce_resume_with_strip_source() {
         .run()
         .unwrap();
 
-    assert!(result.tiles_produced > 0);
+    // Idempotent resume over a full checkpoint writes nothing: `tiles_produced`
+    // counts only tiles actually written, which is zero once every tile is
+    // already recorded (see `phase3_resume::idempotent_resume_of_completed_job`).
+    assert_eq!(result.tiles_produced, 0);
 }
 
 #[test]

--- a/tests/builder_resume_observer_parity.rs
+++ b/tests/builder_resume_observer_parity.rs
@@ -20,8 +20,6 @@
 //! their bodies express the final contract so the implementer has a
 //! concrete assertion target.
 
-#![cfg(feature = "builder_v1")]
-
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/tests/builder_resume_retry.rs
+++ b/tests/builder_resume_retry.rs
@@ -10,7 +10,6 @@
 //! the short-form alias `with_max` as a synonym for `with_max_retries`
 //! (requested in the design doc) and pins the default constants.
 
-#![cfg(feature = "builder_v1")]
 #![allow(unused_imports)]
 
 use std::path::PathBuf;

--- a/tests/builder_resume_streaming.rs
+++ b/tests/builder_resume_streaming.rs
@@ -24,13 +24,11 @@
 //! 5. Plan-hash mismatch on Resume surfaces `EngineError::PlanHashMismatch`
 //!    the same way it does for Monolithic.
 
-#![cfg(feature = "builder_v1")]
-
 use std::path::Path;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use libviprs::resume::{JobCheckpoint, JobMetadata, ResumeMode};
+use libviprs::resume::{JobCheckpoint, JobMetadata};
 use libviprs::sink::{FsSink, SinkError, Tile, TileFormat, TileSink};
 use libviprs::{
     EngineBuilder, EngineConfig, EngineError, EngineKind, Layout, PyramidPlanner, ResumePolicy,

--- a/tests/builder_sink_fs.rs
+++ b/tests/builder_sink_fs.rs
@@ -5,7 +5,6 @@
 //! checksums, resume, manifest, blank strategy) is reachable through
 //! `with_*` methods that can be composed in any order.
 
-#![cfg(feature = "builder_v1")]
 #![allow(unused_imports)]
 
 use libviprs::checksum::{ChecksumAlgo, ChecksumMode};

--- a/tests/builder_sink_packfile.rs
+++ b/tests/builder_sink_packfile.rs
@@ -7,7 +7,7 @@
 //! `tile_format` defaults to `Png` so the minimum-viable call is
 //! `PackfileSink::builder(path).build()`.
 
-#![cfg(all(feature = "builder_v1", feature = "packfile"))]
+#![cfg(feature = "packfile")]
 #![allow(unused_imports)]
 
 use libviprs::sink::{PackfileFormat, PackfileSink, TileFormat, TileSink};

--- a/tests/builder_sink_third_party.rs
+++ b/tests/builder_sink_third_party.rs
@@ -15,7 +15,6 @@
 //! - `Box<dyn TileSink>` works for the match-arms-return-different-sinks
 //!   case.
 
-#![cfg(feature = "builder_v1")]
 #![allow(unused_imports)]
 
 use std::sync::Mutex;

--- a/tests/builder_stream_verify.rs
+++ b/tests/builder_stream_verify.rs
@@ -18,12 +18,9 @@
 //!   7. `streaming_verify_honours_manifest_checksums`
 //!   8. `streaming_verify_emits_observer_events`
 //!
-//! These are deliberately written against an API surface that does not yet
-//! compile; they must fail (at compile time or at runtime) until the
-//! implementation lands on the crate side. Gated behind `builder_v1` to
-//! match the other builder-level integration tests.
-
-#![cfg(feature = "builder_v1")]
+//! The Streaming+Verify surface is implemented on the crate side, so these
+//! run in the default harness alongside the other builder-level integration
+//! tests.
 
 use std::io::{Read, Seek, Write};
 use std::path::Path;

--- a/tests/builder_verify_errors.rs
+++ b/tests/builder_verify_errors.rs
@@ -16,8 +16,6 @@
 //! `IncompatibleSource` — the test still runs on Monolithic, and flips to
 //! full coverage automatically.
 
-#![cfg(feature = "builder_v1")]
-
 use std::io::{Read, Seek, Write};
 use std::path::{Path, PathBuf};
 

--- a/tests/phase3_object_store_sink.rs
+++ b/tests/phase3_object_store_sink.rs
@@ -25,14 +25,13 @@
 
 #![cfg(feature = "s3")]
 
-use libviprs::sink::{ObjectStore, ObjectStoreConfig, ObjectStoreSink, RetryPolicy};
+use libviprs::sink::{ObjectStore, ObjectStoreConfig, ObjectStoreSink};
 use libviprs::{
     EngineBuilder, EngineConfig, EngineKind, Layout, PyramidPlanner, SinkError, TileFormat,
 };
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 mod common;
 use common::fixtures::canonical_raster_scaled;
@@ -118,6 +117,10 @@ impl RecordingObjectStore {
         self.writes.lock().unwrap().len()
     }
 
+    // Read-back accessor on the recording double, kept for the retry tests
+    // deferred below (they need `ObjectStoreConfig::with_retry`, not yet on
+    // the crate). Retained so the double's capability is documented in place.
+    #[allow(dead_code)]
     fn bytes_for(&self, key: &str) -> Option<Vec<u8>> {
         self.writes
             .lock()
@@ -157,6 +160,7 @@ impl InMemoryObjectStore {
         Arc::new(Self::default())
     }
 
+    #[allow(dead_code)]
     fn get(&self, key: &str) -> Option<Vec<u8>> {
         self.objects.lock().unwrap().get(key).cloned()
     }


### PR DESCRIPTION
## What this does

Resolves the core of #55: the `builder_v1` feature gated 121 integration tests across 16 files behind a rationale that they reference an API that "does not yet exist ... expected to fail compilation." That rationale is stale. `EngineBuilder`, `ResumePolicy`, `EngineKind`, and the full per-component builder surface are on the crate and used by ungated tests and the shipping CLI. The red phase has ended, so the tests must run.

### builder_v1 removal (acceptance criterion 1: DONE)
- Delete the `builder_v1` feature from `Cargo.toml` and the `#![cfg(feature = "builder_v1")]` gate from all 16 `builder_*` test files. `builder_sink_packfile` keeps its `packfile` gate.
- All 122 builder tests now compile and run in the default harness (117 default + 5 packfile), 0 failures.

### Real bugs the first-ever compilation surfaced
These were hidden precisely because the tests never compiled, which is the failure mode #55 is about:
- `builder_resume_matrix`: the 5 Resume cells seed a full pyramid then Resume and wrongly asserted `tiles_produced > 0` (and `== total` for Monolithic). Idempotent resume over a complete checkpoint writes nothing, so the produced count is `0`. This is the contract already pinned by the ungated, passing `phase3_resume::idempotent_resume_of_completed_job`. Corrected the assertions and the matrix docstring to `== 0` (a stronger, exact pin).
- `builder_match_composition::resume_through_match` selected the `verify()` arm but ran against a `MemorySink`, which returns `VerifyRequiresOnDiskSink`. Now seeds an on-disk `FsSink` first so the read-only verify arm has something to audit, preserving the match-composition contract the test exists to prove.
- Latent clippy under `-Dwarnings`: dead `Mode::Fast` variant, `filter().next()` to `find()`, `&PathBuf` to `&Path`, unused `ResumeMode` import.

### Feature-cell CI (acceptance criterion 2: partial)
- New `feature-cells` matrix job runs `cargo clippy --all-targets --features {s3,packfile,tracing} -Dwarnings`, so a build or lint regression in a feature-gated module can no longer ship green just because the default harness never compiled it. Verified green locally for each cell.
- Made the `s3` cell lint clean (dropped imports only referenced in commented-out drafts; annotated two read-back test-double accessors kept for the deferred retry tests).

## Verification (local, against COUNTERPART_REV `1e30e23`)
- `cargo fmt -- --check`: clean.
- `cargo clippy --all-targets -Dwarnings`: clean (default + `s3` + `packfile` + `tracing`).
- All 122 `builder_*` tests: pass, 0 failures.

## Scope note / remainder (why this does not close #55)
Criterion 2 ("every feature cell compiled/tested in CI") is only partially achievable in this repo alone right now:
- **`ported_tests` does not compile** against `libviprs` at `COUNTERPART_REV`: the ~347 ported tests call `Raster` ops (`add`, `draw_circle`, `draw_circle_filled`, `getpoint`, ...) that do not exist on the crate (`ported_tests = []` activates no libviprs feature because there is nothing to activate). Wiring a green `cargo test --features ported_tests` job is blocked on the counterpart implementing that libvips-compatible op API. The existing `reference-fixtures` job continues to cover `--features ported_tests --test fixture_audit`.
- **Pre-existing counterpart failures**, on files this PR does not touch, keep the full per-feature `cargo test` runs red at `COUNTERPART_REV` and so are left as full-run remainder rather than wired as green jobs: `phase3_resume::resume_mode_refuses_if_plan_hash_differs`, `phase3_validation_stress` restart tests (default), `phase3_tracing` span/queue-pressure tests (`tracing`), `phase3_packfile::packfile_streaming_memory_bounded` (`packfile`). These are counterpart-behavior drift, outside the `builder_v1` gate this issue targets, and want their own fix or a `COUNTERPART_REV` bump.

Refs #55.