### PR TITLE
Bump COUNTERPART_REV to libviprs main; handle #67 tile-event fields (#55 AC2 partial)

### DIFF
--- a/COUNTERPART_REV
+++ b/COUNTERPART_REV
@@ -10,5 +10,5 @@
 # To bump: set this to a libviprs commit SHA, run the suite against the sibling
 # checkout, and update the label comment below.
 #
-# libviprs main @ 2026-07-10
-1e30e238417ef10c79377ed118eb343409cc1165
+# libviprs main @ 2026-07-11
+0c1caf702a4f2bbc336852f835b6c30a167033e1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,13 +840,13 @@ dependencies = [
 
 [[package]]
 name = "libviprs"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "blake3",
  "flate2",
  "image",
  "lopdf",
- "pdfium-render 0.8.37",
+ "pdfium-render",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -865,7 +865,7 @@ dependencies = [
  "image",
  "libviprs",
  "lopdf",
- "pdfium-render 0.9.3",
+ "pdfium-render",
  "proptest",
  "serde_json",
  "sha2 0.10.9",
@@ -1037,32 +1037,6 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "hmac",
-]
-
-[[package]]
-name = "pdfium-render"
-version = "0.8.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6553f6604a52b3203db7b4e9d51eb4dd193cf455af9e56d40cab6575b547b679"
-dependencies = [
- "bitflags",
- "bytemuck",
- "bytes",
- "chrono",
- "console_error_panic_hook",
- "console_log",
- "image",
- "itertools",
- "js-sys",
- "libloading",
- "log",
- "maybe-owned",
- "once_cell",
- "utf16string",
- "vecmath",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/tests/observability.rs
+++ b/tests/observability.rs
@@ -70,7 +70,7 @@ fn level_started_before_tile_completed() {
             EngineEvent::LevelStarted { level, .. } => {
                 current_level = Some(*level);
             }
-            EngineEvent::TileCompleted { coord } => {
+            EngineEvent::TileCompleted { coord, .. } => {
                 assert_eq!(
                     current_level,
                     Some(coord.level),


### PR DESCRIPTION
## What

Advances issue #55 acceptance criterion 2 by the tractable amount now that libviprs core main lands the Raster op seam (round 1) and the #67 EngineEvent break.

- Bump `COUNTERPART_REV` from `1e30e23` to libviprs main `0c1caf7` (adds `Raster::{add,getpoint,draw_circle,draw_circle_filled,draw_rect,put_pixel}` and the #67 optional `worker_id`/`timestamp` on the tile-lifecycle events).
- Bind the new #67 fields in the one destructuring arm that broke: `observability.rs` `TileCompleted { coord, .. }`. Every other event-variant reference already used `{ .. }`.
- `Cargo.lock` tracks libviprs 0.4.0.

## Cell status against the bumped rev

- `default`, `s3`, `packfile`, `tracing`: compile and pass `cargo clippy --all-targets --features <cell> -- -D warnings`.
- `ported_tests`: still does not compile. Its ~347 tests target a large libvips op surface (`bandjoin`, `extract_band`, `avg`, `crop`, `embed`, `identity`, `switch`, `draw_line`/`draw_flood`/`draw_mask`/`draw_smudge`/`draw_image`, `save`, `get_field`, `constant`, `Interpretation`, `tokenize`, `CompositeMode`, `Angle`, `SmartcropInteresting`, ...) that main's round-1 slice does not provide. The `--test fixture_audit` job CI actually runs for that feature still compiles.

## Not fixed here (counterpart-side, tests left intact)

Pre-existing counterpart-behavior failures remain at main and are genuine core bugs, not test wiring:
- `phase3_resume::resume_mode_refuses_if_plan_hash_differs`: a failed Resume writes tile files despite a plan-hash mismatch.
- `phase3_validation_stress::restart_during_{level_generation,tile_encode}_resume_completes_output`: crash+resume output diverges byte-for-byte from a clean run.

These are documented in #55 as the remaining core-side work; the tests are not weakened.

Refs #55.