### PR TITLE
Bump COUNTERPART_REV to libviprs 54261ce; test-side wiring for ported cells

### DIFF
--- a/COUNTERPART_REV
+++ b/COUNTERPART_REV
@@ -10,5 +10,5 @@
 # To bump: set this to a libviprs commit SHA, run the suite against the sibling
 # checkout, and update the label comment below.
 #
-# libviprs main @ 2026-07-11
-0c1caf702a4f2bbc336852f835b6c30a167033e1
+# libviprs main @ 2026-07-11 (8 op batches + RgbaF32/FloatF32 float formats)
+54261ce2d3af2cb17e36875e37d8ec6309a643bd

--- a/tests/ported_arithmetic.rs
+++ b/tests/ported_arithmetic.rs
@@ -744,7 +744,7 @@ mod statistics {
     ///
     /// Reference: test_arithmetic.py::test_avg
     fn test_avg() {
-        let left = Raster::zeroed(50, 100, PixelFormat::Gray8);
+        let left = Raster::zeroed(50, 100, PixelFormat::Gray8).unwrap();
         let right_data = vec![100u8; 50 * 100];
         let right = Raster::new(50, 100, PixelFormat::Gray8, right_data).unwrap();
         let combined = left.insert(&right, 50, 0, true);
@@ -774,7 +774,7 @@ mod statistics {
     ///
     /// Reference: test_arithmetic.py::test_deviate
     fn test_deviate() {
-        let left = Raster::zeroed(50, 100, PixelFormat::Gray8);
+        let left = Raster::zeroed(50, 100, PixelFormat::Gray8).unwrap();
         let right_data = vec![100u8; 50 * 100];
         let right = Raster::new(50, 100, PixelFormat::Gray8, right_data).unwrap();
         let combined = left.insert(&right, 50, 0, true);
@@ -808,7 +808,7 @@ mod statistics {
     ///
     /// Reference: test_arithmetic.py::test_max
     fn test_max() {
-        let mut im = Raster::zeroed(100, 100, PixelFormat::Gray8);
+        let mut im = Raster::zeroed(100, 100, PixelFormat::Gray8).unwrap();
         im.draw_rect_filled(100, 40, 50, 1, 1);
 
         assert!((im.max() - 100.0).abs() < 1.0);
@@ -875,7 +875,7 @@ mod statistics {
     ///
     /// Reference: test_arithmetic.py::test_stats
     fn test_stats() {
-        let left = Raster::zeroed(50, 50, PixelFormat::Gray8);
+        let left = Raster::zeroed(50, 50, PixelFormat::Gray8).unwrap();
         let right_data = vec![10u8; 50 * 50];
         let right = Raster::new(50, 50, PixelFormat::Gray8, right_data).unwrap();
         let im = left.insert(&right, 50, 0, true);
@@ -912,7 +912,7 @@ mod statistics {
     ///
     /// Reference: test_arithmetic.py::test_measure
     fn test_measure() {
-        let left = Raster::zeroed(50, 50, PixelFormat::Gray8);
+        let left = Raster::zeroed(50, 50, PixelFormat::Gray8).unwrap();
         let right_data = vec![10u8; 50 * 50];
         let right = Raster::new(50, 50, PixelFormat::Gray8, right_data).unwrap();
         let im = left.insert(&right, 50, 0, true);
@@ -976,7 +976,7 @@ mod statistics {
     ///
     /// Reference: test_arithmetic.py::test_profile
     fn test_profile() {
-        let mut im = Raster::zeroed(100, 100, PixelFormat::Gray8);
+        let mut im = Raster::zeroed(100, 100, PixelFormat::Gray8).unwrap();
         im.draw_rect_filled(100, 40, 50, 1, 1);
 
         let (columns, rows) = im.profile();
@@ -1015,7 +1015,7 @@ mod statistics {
     ///
     /// Reference: test_arithmetic.py::test_project
     fn test_project() {
-        let left = Raster::zeroed(50, 50, PixelFormat::Gray8);
+        let left = Raster::zeroed(50, 50, PixelFormat::Gray8).unwrap();
         let right_data = vec![10u8; 50 * 50];
         let right = Raster::new(50, 50, PixelFormat::Gray8, right_data).unwrap();
         let im = left.insert(&right, 50, 0, true);
@@ -1773,7 +1773,7 @@ mod complex_histogram {
     ///
     /// Reference: test_arithmetic.py::test_histfind
     fn test_histfind() {
-        let left = Raster::zeroed(50, 100, PixelFormat::Gray8);
+        let left = Raster::zeroed(50, 100, PixelFormat::Gray8).unwrap();
         let right_data = vec![10u8; 50 * 100];
         let right = Raster::new(50, 100, PixelFormat::Gray8, right_data).unwrap();
         let im = left.insert(&right, 50, 0, true);
@@ -1810,7 +1810,7 @@ mod complex_histogram {
     ///
     /// Reference: test_arithmetic.py::test_histfind_indexed
     fn test_histfind_indexed() {
-        let left = Raster::zeroed(50, 100, PixelFormat::Gray8);
+        let left = Raster::zeroed(50, 100, PixelFormat::Gray8).unwrap();
         let right_data = vec![10u8; 50 * 100];
         let right = Raster::new(50, 100, PixelFormat::Gray8, right_data).unwrap();
         let im = left.insert(&right, 50, 0, true);
@@ -1882,7 +1882,7 @@ mod complex_histogram {
     ///
     /// Reference: test_arithmetic.py::test_hough_circle
     fn test_hough_circle() {
-        let mut im = Raster::zeroed(100, 100, PixelFormat::Gray8);
+        let mut im = Raster::zeroed(100, 100, PixelFormat::Gray8).unwrap();
         im.draw_circle(100, 50, 50, 40, false);
 
         let hough = im.hough_circle(35, 45);
@@ -1930,7 +1930,7 @@ mod complex_histogram {
     ///
     /// Reference: test_arithmetic.py::test_hough_line
     fn test_hough_line() {
-        let mut im = Raster::zeroed(100, 100, PixelFormat::Gray8);
+        let mut im = Raster::zeroed(100, 100, PixelFormat::Gray8).unwrap();
         im.draw_line(100, 10, 90, 90, 10);
 
         let hough = im.hough_line();

--- a/tests/ported_colour.rs
+++ b/tests/ported_colour.rs
@@ -9,7 +9,7 @@
 
 use std::path::Path;
 
-use libviprs::{PixelFormat, Raster, decode_file};
+use libviprs::{Interpretation, PixelFormat, Raster, decode_file};
 
 /// Path to the libvips reference test images directory.
 const REF_IMAGES: &str = concat!(

--- a/tests/ported_conversion.rs
+++ b/tests/ported_conversion.rs
@@ -9,7 +9,9 @@
 
 use std::path::Path;
 
-use libviprs::{PixelFormat, Raster, decode_file};
+use libviprs::{
+    Angle, CompositeMode, Extend, PixelFormat, Raster, SmartcropInteresting, decode_file,
+};
 
 /// Path to the libvips reference test images directory.
 const REF_IMAGES: &str = concat!(

--- a/tests/ported_infrastructure.rs
+++ b/tests/ported_infrastructure.rs
@@ -9,8 +9,8 @@
 use std::path::Path;
 
 use libviprs::{
-    EngineBuilder, EngineConfig, EngineKind, FsSink, Layout, PixelFormat, PyramidPlanner, Raster,
-    TileFormat, decode_file,
+    EngineBuilder, EngineConfig, EngineKind, FsSink, Layout, MetadataValue, PixelFormat,
+    PyramidPlanner, Raster, TileFormat, decode_file,
 };
 
 /// Path to the libvips reference test images directory.
@@ -321,7 +321,7 @@ mod sequential {
     /// Reference: test_seq.sh
     fn test_seq_no_temps() {
         let dir = tempfile::tempdir().unwrap();
-        std::env::set_var("TMPDIR", dir.path());
+        unsafe { std::env::set_var("TMPDIR", dir.path()) };
 
         let im = decode_file(&ref_image("sample.jpg")).unwrap();
         let _thumb = im.thumbnail(im.width() / 4);
@@ -356,7 +356,7 @@ mod sequential {
     /// Reference: test_seq.sh
     fn test_seq_shrink_no_temps() {
         let dir = tempfile::tempdir().unwrap();
-        std::env::set_var("TMPDIR", dir.path());
+        unsafe { std::env::set_var("TMPDIR", dir.path()) };
 
         let im = decode_file(&ref_image("sample.jpg")).unwrap();
         let _shrunk = im.shrink(4.0, 4.0);
@@ -755,7 +755,7 @@ mod cli {
         // (Depending on API design, this might panic, return Err, or silently succeed)
 
         // A small image should succeed
-        let result = Raster::zeroed(500, 500, PixelFormat::Gray8);
+        let result = Raster::zeroed(500, 500, PixelFormat::Gray8).unwrap();
         assert_eq!(result.width(), 500);
     }
 
@@ -780,11 +780,11 @@ mod cli {
     fn test_cli_max_coord_env() {
         use libviprs::{get_max_coord, init_from_env};
 
-        std::env::set_var("VIPS_MAX_COORD", "500");
+        unsafe { std::env::set_var("VIPS_MAX_COORD", "500") };
         init_from_env();
         assert_eq!(get_max_coord(), 500);
 
         // Clean up
-        std::env::remove_var("VIPS_MAX_COORD");
+        unsafe { std::env::remove_var("VIPS_MAX_COORD") };
     }
 }


### PR DESCRIPTION
Part of #55 (does not close it; the core ops are still pending).

## What

- **COUNTERPART_REV**: 0c1caf7 -> 54261ce (libviprs main with the 8 op batches: bands, arithmetic, extract/crop, conversion, drawing, histogram, IO/composite, and the RgbaF32/FloatF32 float formats). The default suite and `fixture_audit --features ported_tests` pass against the new pin.
- **Imports**: the core now exports `Interpretation`, `Angle`, `CompositeMode`, `Extend`, `SmartcropInteresting`, and `MetadataValue`; the ported files used them unqualified without a `use`, so every reference raised E0433 (and `Extend` silently resolved to `std::iter::Extend`, raising E0782). Added the imports in ported_colour, ported_conversion, and ported_infrastructure. All variants the tests reference exist on the core enums.
- **Edition 2024**: wrapped the four `std::env::set_var`/`remove_var` calls in ported_infrastructure in `unsafe` blocks, as required by the 2024 edition.
- **`Raster::zeroed` unwraps**: the core constructor is fallible (byte budget); ported_draw and ported_morphology already call `.unwrap()` on it. Aligned the 12 remaining call sites in ported_arithmetic and ported_infrastructure. No assertion changed.

## Result

- `ported_draw` compiles and passes 8/8 with `--features ported_tests -- --include-ignored`.
- The other 13 ported_* targets now fail **only** on missing core symbols (op batches for #55): colour-space/ICC, complex/trig/log arithmetic, rot45/byteswap/flatten/grid/ifthenelse/msb, convolution, morphology, mosaicing, resample/thumbnail, create (mask_*/noise/text), foreign encode/save/load surface, and Source/Target streaming.
- `#[ignore]` markers stay in place; `--include-ignored` runs them without weakening the checked-in files while the surface is incomplete.