### PR TITLE
test(conversion): import Angle45; bump COUNTERPART_REV to current main

### DIFF
--- a/COUNTERPART_REV
+++ b/COUNTERPART_REV
@@ -10,5 +10,5 @@
 # To bump: set this to a libviprs commit SHA, run the suite against the sibling
 # checkout, and update the label comment below.
 #
-# libviprs main @ 2026-07-11 (8 op batches + RgbaF32/FloatF32 float formats)
-54261ce2d3af2cb17e36875e37d8ec6309a643bd
+# libviprs main @ 2026-07-11 (+ #55 histogram-compare and conversion-straggler op batches)
+87d5b8a5100f6c1e8d12e2daa6e21c77b7f0e21b

--- a/tests/ported_conversion.rs
+++ b/tests/ported_conversion.rs
@@ -10,7 +10,7 @@
 use std::path::Path;
 
 use libviprs::{
-    Angle, CompositeMode, Extend, PixelFormat, Raster, SmartcropInteresting, decode_file,
+    Angle, Angle45, CompositeMode, Extend, PixelFormat, Raster, SmartcropInteresting, decode_file,
 };
 
 /// Path to the libvips reference test images directory.


### PR DESCRIPTION
Test-side wiring for the landed core conversion-straggler batch (#55).

- Import `Angle45` in `ported_conversion` (it did not exist when the cell was first wired).
- Bump `COUNTERPART_REV` to libviprs main `87d5b8a` (histogram-compare + conversion-straggler op batches).

`ported_conversion` now compiles; 37/44 pass, including all six newly landed ops (rot45 with the exact eight-way roundtrip, byteswap, msb, grid, ifthenelse, flatten). The seven remaining failures are pre-existing and unrelated: crop/extract/embed assert a background constant at a bright cropped location (synthetic-fixture mismatch), and falsecolour/composite/smartcrop are separate core items. No test body weakened.