### PR TITLE
Wire the green ported_tests cells into the enforced mirror and ci.yml (#55)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
       # job on shared runner timing noise.
       - run: cargo test --features pdfium
 
-  reference-fixtures:
-    name: Reference Fixtures (pinned fetch)
+  ported-tests:
+    name: Ported Cells (green subset)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -62,9 +62,18 @@ jobs:
       - name: Fetch libvips reference suite at pinned revision
         run: ./tools/fetch_reference_suite.sh
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
       - uses: Swatinem/rust-cache@v2
-      # Prove the pinned fetch populated every fixture the ported suite needs.
-      - run: cargo test --features ported_tests --test fixture_audit
+      # tools/run_ported_cells.sh is the single source of truth for the green
+      # ported_* cells (eleven cells, 210 tests; ported_infrastructure runs
+      # with --test-threads=1 per its header). The test pass runs
+      # fixture_audit first, proving the pinned fetch populated every fixture
+      # the suite needs. Clippy is scoped to the same green targets because
+      # the three deferred codec cells (ported_foreign, ported_connection,
+      # ported_iofuncs) do not compile yet; issue #77 tracks that remainder.
+      - run: ./tools/run_ported_cells.sh --clippy
+      - run: ./tools/run_ported_cells.sh --require-fixtures
 
   feature-cells:
     name: Feature Cell (${{ matrix.feature }})
@@ -78,9 +87,10 @@ jobs:
         # green just because the default harness never compiled that code.
         # `-Dwarnings` (via RUSTFLAGS) means every gated test target is fully
         # type-checked and linted here, not merely conditionally excluded.
-        # `pdfium` has its own job above; `ported_tests` is exercised by the
-        # reference-fixtures job (its full suite targets a libviprs op API that
-        # is not yet on the crate).
+        # `pdfium` has its own job above; `ported_tests` has the ported-tests
+        # job above (it cannot join this `--all-targets` matrix because the
+        # three deferred codec cells do not compile yet, so its clippy pass is
+        # scoped to the green cells via tools/run_ported_cells.sh; issue #77).
         feature: [s3, packfile, tracing]
     steps:
       - uses: actions/checkout@v4

--- a/COUNTERPART_REV
+++ b/COUNTERPART_REV
@@ -10,5 +10,7 @@
 # To bump: set this to a libviprs commit SHA, run the suite against the sibling
 # checkout, and update the label comment below.
 #
-# libviprs main @ 2026-07-11 (+ #55 histogram-compare and conversion-straggler op batches)
-87d5b8a5100f6c1e8d12e2daa6e21c77b7f0e21b
+# libviprs main @ 2026-07-12 (+ freqfilt/matrix op batch; the rev the green
+# ported cells were proven against in PR #76 and revalidated by the #55
+# harness-wiring mirror run)
+e9a5e6f8a8fc114b5ed0c4a2864af0b246c6146e

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,15 @@ ENV CARGO_PROFILE_DEV_DEBUG=0
 # that cross-test concurrency instead of hiding it behind `--test-threads=1`.
 # The wall-clock perf-ratio smoke is `#[ignore]`d here and runs in the nightly
 # workflow, so it never gates this container run.
+#
+# The final step runs the green ported_* cells (feature = "ported_tests") via
+# tools/run_ported_cells.sh, the single source of truth for the green-cell
+# list (deferred remainder: issue #77). The cells read the pinned libvips
+# reference suite under tmp/, which .dockerignore excludes from the build
+# context; run-tests.sh fetches it on the host and bind-mounts it read-only
+# into /src/libviprs-tests/tmp/. When the mount is absent (offline host with
+# no cached copy) the script skips that step with a clear message instead of
+# failing, matching how the repo treats optional fixtures.
 CMD sh -c '\
     echo "================================================================" && \
     echo "Running libviprs unit tests (with pdfium)..." && \
@@ -73,4 +82,9 @@ CMD sh -c '\
     echo "================================================================" && \
     echo "Running libviprs-tests integration tests (with pdfium)..." && \
     echo "================================================================" && \
-    cd /src/libviprs-tests && cargo test --features pdfium'
+    cd /src/libviprs-tests && cargo test --features pdfium && \
+    echo "" && \
+    echo "================================================================" && \
+    echo "Running libviprs-tests green ported cells (ported_tests)..." && \
+    echo "================================================================" && \
+    ./tools/run_ported_cells.sh'

--- a/tests/pdfium_system_check.rs
+++ b/tests/pdfium_system_check.rs
@@ -92,7 +92,11 @@ fn pdfium_system_check() {
 
     match page.render_with_config(&config) {
         Ok(bitmap) => {
-            let img = bitmap.as_image();
+            // The pdfium-render 0.9 line returns Result from as_image(); a
+            // conversion failure is a system-check failure like any other.
+            let img = bitmap
+                .as_image()
+                .expect("FAILED: rendered bitmap could not be converted to an image");
             let rgba = img.to_rgba8();
             println!(
                 "Render test (100px): OK ({}x{} RGBA)",

--- a/tests/ported_arithmetic.rs
+++ b/tests/ported_arithmetic.rs
@@ -7,8 +7,6 @@
 //! The libvips test suite uses a synthetic `mask_ideal` image; we use
 //! a similar generated test image (100×100, 3-band) plus sample.jpg.
 
-use std::path::Path;
-
 use libviprs::{PixelFormat, Raster};
 
 /// Create a synthetic 100×100 single-band (Gray8) test image with recognisable

--- a/tools/install-hooks.sh
+++ b/tools/install-hooks.sh
@@ -51,8 +51,13 @@ LIBVIPRS_CLI_CARGO_STEPS=(
 )
 
 # libviprs-tests CI is plainer — no incompatible_msrv / deprecated lints.
+# The second step mirrors the ci.yml ported-tests clippy line: it lints the
+# green ported_* cells under `--features ported_tests`, scoped through
+# tools/run_ported_cells.sh because the three deferred codec cells do not
+# compile yet (issue #77), so `--all-targets` cannot carry that feature.
 LIBVIPRS_TESTS_CARGO_STEPS=(
     "cargo clippy --all-targets -- -D warnings"
+    "./tools/run_ported_cells.sh --clippy"
 )
 
 cargo_steps_for_repo() {

--- a/tools/run-tests.sh
+++ b/tools/run-tests.sh
@@ -115,6 +115,35 @@ if [ ! -f "$TESTS_DIR/Dockerfile" ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Reference fixtures for the ported_tests cells (idempotent, offline-tolerant)
+# ---------------------------------------------------------------------------
+# The green ported_* cells (tools/run_ported_cells.sh) compare against the
+# pinned libvips reference suite under tmp/, which is git- and docker-ignored.
+# Fetch it here on the host (the fetch script is a no-op when the pinned
+# revision is already present) and hand it to the container as a read-only
+# mount. Offline is not fatal: with a previously fetched copy the mount still
+# happens, and with no copy at all the ported step inside the container skips
+# with a clear message instead of failing, matching how the repo treats
+# optional fixtures. gen_fixtures.sh is not needed for the ported cells; they
+# use only the reference suite plus in-test synthetics.
+
+FIXTURES_DIR="$TESTS_DIR/tmp/libvips-reference-tests"
+echo "Fetching libvips reference suite (pinned, idempotent)..."
+if ! "$TESTS_DIR/tools/fetch_reference_suite.sh"; then
+    if [ -d "$FIXTURES_DIR/test-suite/images" ]; then
+        echo "Warning: reference-suite fetch failed (offline?); using the existing copy."
+    else
+        echo "Warning: reference-suite fetch failed and no local copy exists."
+        echo "The ported_tests step will be skipped inside the container."
+    fi
+fi
+
+DOCKER_RUN_MOUNTS=()
+if [ -d "$FIXTURES_DIR/test-suite/images" ]; then
+    DOCKER_RUN_MOUNTS+=( -v "$FIXTURES_DIR:/src/libviprs-tests/tmp/libvips-reference-tests:ro" )
+fi
+
+# ---------------------------------------------------------------------------
 # Stop any previous instance
 # ---------------------------------------------------------------------------
 
@@ -147,6 +176,7 @@ docker run \
     --platform "$PLATFORM" \
     --name "$CONTAINER_NAME" \
     --memory=4g \
+    ${DOCKER_RUN_MOUNTS[@]+"${DOCKER_RUN_MOUNTS[@]}"} \
     "$IMAGE_NAME"
 
 EXIT_CODE=$?

--- a/tools/run_ported_cells.sh
+++ b/tools/run_ported_cells.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# run_ported_cells.sh — Run the green subset of the ported_* test cells.
+#
+# The ported_* integration tests (feature = "ported_tests") are ports of the
+# libvips reference test suite. Eleven cells compile and run green against
+# the current core (210 tests). Three codec cells (ported_foreign,
+# ported_connection, ported_iofuncs) target an external-decoder surface the
+# core does not expose yet and do not compile, so a blanket
+# `cargo test --features ported_tests` build of every test target fails.
+# This script is the single source of truth for the green-cell list: the
+# Docker mirror (Dockerfile CMD via run-tests.sh), the pre-commit hooks
+# (install-hooks.sh), and .github/workflows/ci.yml all call it, so promoting
+# a cell to green is a one-file change. The deferred remainder (codec cells
+# plus the per-test `#[ignore]` reds inside green cells) is tracked in
+# issue #77.
+#
+# ported_infrastructure runs single-threaded: its tests mutate process-global
+# state (TMPDIR, the max-coord limit) that individual tests save and restore
+# but cannot make atomic across concurrently running tests. The cell header
+# documents this.
+#
+# Usage:
+#   ./tools/run_ported_cells.sh                     # run tests; skip if fixtures missing
+#   ./tools/run_ported_cells.sh --require-fixtures  # hard-fail if fixtures missing (CI)
+#   ./tools/run_ported_cells.sh --clippy            # clippy -D warnings on the green cells
+#
+# Fixtures: the cells read the pinned libvips reference suite under
+# tmp/libvips-reference-tests/ (populate with tools/fetch_reference_suite.sh).
+# Without --require-fixtures a missing suite SKIPS the test run with a clear
+# message instead of failing, so an offline pre-push hook stays usable; CI
+# fetches first and passes --require-fixtures. tools/gen_fixtures.sh output is
+# not needed here: the green cells use only the reference suite plus synthetic
+# rasters generated in-test.
+# ---------------------------------------------------------------------------
+
+# Green cells that run with the default cargo-test thread pool.
+PARALLEL_CELLS=(
+    ported_arithmetic
+    ported_colour
+    ported_conversion
+    ported_convolution
+    ported_create
+    ported_draw
+    ported_histogram
+    ported_morphology
+    ported_mosaicing
+    ported_resample
+)
+# Green cell that must run with --test-threads=1 (see header).
+SERIAL_CELL="ported_infrastructure"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+MODE="test"
+REQUIRE_FIXTURES=0
+for arg in "$@"; do
+    case "$arg" in
+        --clippy)           MODE="clippy" ;;
+        --require-fixtures) REQUIRE_FIXTURES=1 ;;
+        *)
+            echo "ERROR: unknown argument: $arg" >&2
+            echo "Usage: $0 [--clippy] [--require-fixtures]" >&2
+            exit 2
+            ;;
+    esac
+done
+
+# Target-selection flags for every green cell plus the fixture audit.
+TARGETS=(--test fixture_audit)
+for cell in "${PARALLEL_CELLS[@]}" "$SERIAL_CELL"; do
+    TARGETS+=(--test "$cell")
+done
+
+if [ "$MODE" = "clippy" ]; then
+    # Scoped to the green cells: --all-targets would also compile the three
+    # deferred codec cells, which do not build yet (issue #77).
+    echo "cargo clippy --features ported_tests (green ported cells) -D warnings..."
+    cargo clippy --features ported_tests "${TARGETS[@]}" -- -D warnings
+    exit 0
+fi
+
+IMAGES_DIR="$REPO_ROOT/tmp/libvips-reference-tests/test-suite/images"
+if [ ! -d "$IMAGES_DIR" ]; then
+    if [ "$REQUIRE_FIXTURES" -eq 1 ]; then
+        echo "ERROR: libvips reference suite not found at $IMAGES_DIR" >&2
+        echo "Run ./tools/fetch_reference_suite.sh first." >&2
+        exit 1
+    fi
+    echo "SKIP: libvips reference suite not found at $IMAGES_DIR."
+    echo "The ported_tests cells need it; run ./tools/fetch_reference_suite.sh"
+    echo "(requires network). Skipping the ported cells for this run."
+    exit 0
+fi
+
+echo "Running the green ported cells (--features ported_tests)..."
+
+# fixture_audit first: it proves the fetched suite is complete at the pinned
+# revision before the cells consume it. Then the ten parallel-safe cells in
+# one invocation, then the serial cell.
+PARALLEL_TARGETS=(--test fixture_audit)
+for cell in "${PARALLEL_CELLS[@]}"; do
+    PARALLEL_TARGETS+=(--test "$cell")
+done
+
+cargo test --features ported_tests "${PARALLEL_TARGETS[@]}"
+
+echo ""
+echo "Running $SERIAL_CELL with --test-threads=1 (mutates process-global state)..."
+cargo test --features ported_tests --test "$SERIAL_CELL" -- --test-threads=1
+
+echo ""
+echo "Green ported cells passed."


### PR DESCRIPTION
## Round 2 of #55: wire the green ported cells into the enforced harnesses

The enablement round (PR #76) made eleven pure-Rust `ported_*` cells compile and run green (210 tests). This round wires that green subset into the enforced local mirror and the documented ci.yml feature matrix, automates the fixture fetch, and hands the deferred remainder to #77.

### Enforced local mirror

- `tools/run_ported_cells.sh` (new): the single source of truth for the green-cell list. It runs `fixture_audit` plus the ten parallel-safe cells in one `cargo test --features ported_tests` invocation, then `ported_infrastructure` with `--test-threads=1` (its tests mutate process-global state; the cell header documents this). `--clippy` lints the same green targets with `-D warnings`; `--require-fixtures` turns the missing-fixture skip into a hard failure for CI. Promoting a cell to green is a one-file change here.
- `tools/run-tests.sh`: fetches the pinned libvips reference suite on the host (`tools/fetch_reference_suite.sh` is already idempotent via its `.pinned-rev` marker) and bind-mounts it read-only into the container, since `.dockerignore` excludes `tmp/` from the build context. Offline is not fatal: a previously fetched copy still mounts, and with no copy at all the container step skips with a clear message. `tools/gen_fixtures.sh` is not needed for the ported cells; they use only the reference suite plus in-test synthetics.
- `Dockerfile`: the container CMD now ends with `./tools/run_ported_cells.sh` after the existing default and pdfium steps.
- `tools/install-hooks.sh`: the libviprs-tests pre-commit gains `./tools/run_ported_cells.sh --clippy`, mirroring the new ci.yml clippy line. The pre-push hook picks up the test step automatically through `run-tests.sh`. Hooks reinstalled locally.

### ci.yml (documentation parity; the local mirror is what gates)

- The `reference-fixtures` job (which ran only `fixture_audit`) becomes `ported-tests`: fetch the reference suite, clippy the green cells under `--features ported_tests`, then run them with `--require-fixtures`. `fixture_audit` still runs first inside the script, so the pinned-fetch completeness proof is kept.
- The `s3`/`packfile`/`tracing` clippy matrix stays untouched; its comment now explains that `ported_tests` cannot join the `--all-targets` matrix because the three deferred codec cells do not compile yet (#77), so its clippy pass is scoped through the script.

### Also in this change

- `tests/pdfium_system_check.rs`: adapted the render smoke to the fork's `Result`-returning `as_image()` (the pdfium-render 0.9 line; both the locked rev and the `libviprs/integration` branch head carry the new signature). This compile break pre-existed on main (noted in PR #76) and failed the entire Docker mirror before the ported step could run. A conversion failure now panics with a system-check message; nothing is weakened.
- `tests/ported_arithmetic.rs`: dropped an unused `use std::path::Path;` that failed the new scoped clippy gate.
- `COUNTERPART_REV`: pinned at core main `e9a5e6f` (the rev PR #76 proved the green subset against; the subset keeps `test_ifthenelse` ignored, so it does not depend on the later ifthenelse fix).

### Proof

- Host: `./tools/run_ported_cells.sh` green. 210 passed across the eleven cells (61+9+42+7+30+8+12+5+6+9+21), 9 residual `#[ignore]` reds untouched, `fixture_audit` 49 passed.
- Container: the ported step run inside the built image against the read-only mounted reference suite (`docker run ... ./tools/run_ported_cells.sh`) is green, proving the Dockerfile CMD wiring and the fixture mount path.
- `cargo fmt -- --check` and both pre-commit clippy steps clean.

Honest note on the full `run-tests.sh`: it is not yet green end-to-end, but not because of this change. Two pre-existing counterpart-behaviour reds on `origin/main` fail earlier in the pipeline and short-circuit the ported step via `&&`: `pdfium_system_check` (a pdfium-render 0.9 compile break, which this PR fixes) and `phase3_tracing::queue_pressure_peak_bounded_by_concurrency` (a core queue-pressure accounting bug: it reports peak 43 in-flight tiles at concurrency 4; ungated, so it runs in the default harness, last touched well before this work). These, plus the `phase3_resume` / `phase3_validation_stress` reds enumerated in the #55 thread, are core-behaviour bugs distinct from the ported-tests wiring and are not feature-cell compile/test gaps. This PR fixes one of them and introduces none.

Deferred remainder: #77 (the codec cells `ported_foreign`, `ported_connection`, `ported_iofuncs`, plus the nine per-test ignores and their core gaps).

Refs #55.
