### PR TITLE
test(conversion): un-ignore test_ifthenelse; bump COUNTERPART_REV to core #269

### DIFF
--- a/COUNTERPART_REV
+++ b/COUNTERPART_REV
@@ -10,7 +10,8 @@
 # To bump: set this to a libviprs commit SHA, run the suite against the sibling
 # checkout, and update the label comment below.
 #
-# libviprs main @ 2026-07-12 (+ freqfilt/matrix op batch; the rev the green
-# ported cells were proven against in PR #76 and revalidated by the #55
-# harness-wiring mirror run)
-e9a5e6f8a8fc114b5ed0c4a2864af0b246c6146e
+# libviprs main @ 2026-07-12 (+ the ifthenelse format-unify fix, core PR #269,
+# which greens ported_conversion::test_ifthenelse; builds on the freqfilt/matrix
+# op batch the green ported cells were proven against in PR #76 and revalidated
+# by the #55 harness-wiring mirror run)
+b90e6bffab1066eb31908e563ea4a315a9e7906f

--- a/tests/ported_conversion.rs
+++ b/tests/ported_conversion.rs
@@ -1081,15 +1081,14 @@ fn test_grid() {
 ///
 /// Reference: test_conversion.py::test_ifthenelse
 ///
-/// RESIDUAL RED (core defect): `add_const` promotes Rgb8 to Rgb16, and the
-/// core's `ifthenelse` only checks that the then/else CHANNEL counts match,
-/// then reads the Rgb8 else branch with the then branch's 2-byte samples,
-/// garbling the output (result(10,10) reads [770, 516, 1027], the
-/// little-endian byte pairs of [2,3,4]). Real libvips harmonises the branch
-/// formats first. Needs a core fix (format harmonisation or a typed
-/// format-mismatch error) and is out of scope for the tests repo. The old
-/// centre-origin fixture masked this by making the probe branch vacuous.
-#[ignore = "core defect: ifthenelse does not harmonise then/else pixel formats (Rgb16 vs Rgb8)"]
+/// Format harmonisation: `add_const` promotes Rgb8 to Rgb16, so the then/else
+/// branches arrive in different pixel formats. Core `ifthenelse` now casts both
+/// branches to a common format before the per-pixel select (matching libvips
+/// `vips__formatalike`), fixed in core PR #269. Before that fix it checked only
+/// channel counts and read the Rgb8 else branch at the then branch's 2-byte
+/// stride, garbling result(10,10) to [770, 516, 1027] (the little-endian byte
+/// pairs of [2,3,4]). This test pins the harmonised result and requires the
+/// counterpart at or past that fix (see COUNTERPART_REV).
 fn test_ifthenelse() {
     let mono = make_test_mono();
     let colour = make_test_colour();


### PR DESCRIPTION
Core PR libviprs/libviprs#269 harmonises `ifthenelse` then/else pixel formats (casts both branches to a common format before the per-pixel select, matching libvips `vips__formatalike`), fixing the garble where an Rgb8 else branch was read at the Rgb16 then branch's 2-byte stride.

This bumps `COUNTERPART_REV` from e9a5e6f to b90e6bf so the suite pins the fixed core, and drops the `#[ignore]` on `ported_conversion::test_ifthenelse`. That cell is now 43 passed, 0 failed, 1 ignored (only `test_smartcrop_attention` remains, tracked in #77).

Verified locally: `cargo test --features ported_tests --test ported_conversion` green (test_ifthenelse ok), `counterpart_pinning` green. Refs #55, #77.