### PR TITLE
test: enable #77/#79 reds against core 5ffae90; bump COUNTERPART_REV

### DIFF
--- a/COUNTERPART_REV
+++ b/COUNTERPART_REV
@@ -10,8 +10,10 @@
 # To bump: set this to a libviprs commit SHA, run the suite against the sibling
 # checkout, and update the label comment below.
 #
-# libviprs main @ 2026-07-12 (+ the ifthenelse format-unify fix, core PR #269,
-# which greens ported_conversion::test_ifthenelse; builds on the freqfilt/matrix
-# op batch the green ported cells were proven against in PR #76 and revalidated
-# by the #55 harness-wiring mirror run)
-b90e6bffab1066eb31908e563ea4a315a9e7906f
+# libviprs main @ 2026-07-12 (+ the final #77/#79 enablement batch: atanh /
+# divide-float promotion core PRs #303/#304, smartcrop attention parity #305,
+# Phase 3 resume + queue-admission #306, and the thumbnail family + nohalo/lbb
+# interpolators #307). Greens the previously-ignored ported reds (atanh, sinh,
+# cosh, smartcrop_attention, thumbnail x3, affine) and keeps the #79 phase3
+# resume/queue cells green.
+5ffae90bd01b80ccbd67de0658e1da80c7c28fa6

--- a/tests/ported_arithmetic.rs
+++ b/tests/ported_arithmetic.rs
@@ -1284,25 +1284,29 @@ mod math_functions {
     ///
     /// ## Test logic (from libvips test_arithmetic.py::test_sinh)
     ///
-    /// 1. Apply sinh to mono test image, verify at (10,10).
+    /// 1. Apply sinh to a small representable input, verify at (50,50).
     ///
     /// Reference: test_arithmetic.py::test_sinh
     ///
-    /// RESIDUAL RED (fixture-probe remainder): make_test_mono's nonzero
-    /// values are all >= 100 (r*200 for r > 0.5), and sinh overflows the
-    /// op's f32 output above ~88.7 (real libvips also yields inf there),
-    /// so no faithful nonzero probe exists on this fixture; mono(10,10)
-    /// is 226. The libvips original probes mask_ideal-derived values 3
-    /// and 5. Not weakened; kept in its authored ignored spec-state
-    /// pending a faithful fixture.
-    #[ignore = "fixture-probe remainder: sinh(226) overflows the f32 op output"]
+    /// MIS-PORT CORRECTION (probe value, not the op): the earlier port
+    /// probed make_test_mono, whose nonzero pixels are all >= 100
+    /// (mono(10,10) = 226). The core sinh op is libvips-faithful: it
+    /// outputs f32 and overflows to +inf above ~88.7, exactly as real
+    /// libvips does (the vips oracle `vips math mono.v out.v sinh` yields
+    /// inf at (10,10) too). So the op is correct; the probe pixel was the
+    /// mis-port. The libvips original probes small values (3 and 5). This
+    /// corrects the probe to a constant-3 input and pins the libvips-exact
+    /// output captured from the real oracle:
+    ///   `vips math const3.v out.v sinh` (uchar -> float) = 10.017874717712402
     fn test_sinh() {
-        let mono = make_test_mono();
-        let result = mono.sinh();
-        let px_m = mono.getpoint(10, 10);
-        let px_r = result.getpoint(10, 10);
-        let expected = px_m[0].sinh();
-        assert!((px_r[0] - expected).abs() / expected.abs().max(1.0) < 0.01);
+        // Small, representable: sinh(3) = 10.0179 does not overflow f32.
+        let data = vec![3u8; 100 * 100];
+        let im = Raster::new(100, 100, PixelFormat::Gray8, data).unwrap();
+        let result = im.sinh();
+        let px_r = result.getpoint(50, 50);
+        // libvips-exact (vips-8.18 oracle): vips math const3.v out.v sinh.
+        let expected = 10.017874717712402_f64;
+        assert!((px_r[0] - expected).abs() < 0.001);
     }
 
     #[test]
@@ -1316,17 +1320,24 @@ mod math_functions {
     ///
     /// Reference: test_arithmetic.py::test_cosh
     ///
-    /// RESIDUAL RED (fixture-probe remainder): same as test_sinh;
-    /// cosh(226) overflows the op's f32 output (inf in real libvips too)
-    /// and the fixture has no representable nonzero probe value.
-    #[ignore = "fixture-probe remainder: cosh(226) overflows the f32 op output"]
+    /// MIS-PORT CORRECTION (probe value, not the op): same as test_sinh.
+    /// cosh(226) overflows the op's f32 output to +inf, which is the real
+    /// libvips result (`vips math mono.v out.v cosh` yields inf at (10,10)),
+    /// so the op is faithful and the mono probe pixel was the mis-port.
+    /// This corrects the probe to a constant-5 input (a small value the
+    /// libvips original also probes) and pins the libvips-exact oracle
+    /// output:
+    ///   `vips math const5.v out.v cosh` (uchar -> float) = 74.209945678710938
     fn test_cosh() {
-        let mono = make_test_mono();
-        let result = mono.cosh();
-        let px_m = mono.getpoint(10, 10);
-        let px_r = result.getpoint(10, 10);
-        let expected = px_m[0].cosh();
-        assert!((px_r[0] - expected).abs() / expected.abs().max(1.0) < 0.01);
+        // Small, representable: cosh(5) = 74.21 does not overflow f32.
+        let data = vec![5u8; 100 * 100];
+        let im = Raster::new(100, 100, PixelFormat::Gray8, data).unwrap();
+        let result = im.cosh();
+        let px_r = result.getpoint(50, 50);
+        // libvips-exact (vips-8.18 oracle): vips math const5.v out.v cosh
+        // getpoint = 74.209945678710938, the f32 value 74.209_945_678_710_94.
+        let expected = 74.209_945_678_710_94_f64;
+        assert!((px_r[0] - expected).abs() < 0.001);
     }
 
     #[test]
@@ -1397,14 +1408,12 @@ mod math_functions {
     ///
     /// Reference: test_arithmetic.py::test_atanh
     ///
-    /// RESIDUAL RED (linear-float-contract remainder): the core's
-    /// div_const follows the integer round-saturate contract, so 128/255
-    /// rounds to 1 and atanh(1) = inf on both sides of the comparison
-    /// (inf - inf = NaN fails the assert). Real libvips promotes
-    /// uchar/const division to float (0.50196..., atanh = 0.5525).
-    /// Needs the float-promoting linear/divide family in the core; out
-    /// of scope for the tests repo.
-    #[ignore = "linear-float-contract remainder: div_const rounds 128/255 to 1, atanh(1) = inf"]
+    /// The core's div_const now promotes uchar/const division to float
+    /// (core PRs #303/#304), so 128/255 = 0.50196... stays representable
+    /// and atanh(0.502) = 0.5525 is finite. The assertion is self-checking:
+    /// `expected` is atanh of the value read back from the divided image,
+    /// so it pins the float-promoted contract without any hand-computed
+    /// literal.
     fn test_atanh() {
         // atanh requires input in (-1, 1)
         let data = vec![128u8; 100 * 100];

--- a/tests/ported_conversion.rs
+++ b/tests/ported_conversion.rs
@@ -679,13 +679,10 @@ fn test_smartcrop() {
 ///
 /// Reference: test_conversion.py::test_smartcrop
 ///
-/// RESIDUAL RED (real-libvips-parity remainder): the core's attention
-/// scoring returns attention_x = 54 on sample.jpg where libvips 8.18
-/// returns 199. The core's own pin
-/// (libviprs tests/extract_ported_surface.rs) deliberately asserts only
-/// coordinate bounds, not the libvips values, so attention parity is a
-/// known core divergence. Not weakened; the libvips literals stay.
-#[ignore = "real-libvips-parity remainder: attention coords 54 vs libvips 199 on sample.jpg"]
+/// The core's attention scoring now matches libvips 8.18 on sample.jpg
+/// (core PR #305): it returns attention_x = 199, attention_y = 234, the
+/// same coordinates the conversion oracle captured from real libvips.
+/// The libvips literals below are pinned unweakened.
 fn test_smartcrop_attention() {
     let im = decode_file(&ref_image("sample.jpg")).unwrap();
     let (result, attention_x, attention_y) =

--- a/tests/ported_infrastructure.rs
+++ b/tests/ported_infrastructure.rs
@@ -302,10 +302,11 @@ mod sequential {
     /// Reference: test_seq.sh
     fn test_seq_thumbnail() {
         let im = decode_file(&ref_image("sample.jpg")).unwrap();
-        // The core has no `Raster::thumbnail`; the aspect-preserving
-        // downscale this shell test exercises is `resize` (scale factor
-        // 0.5 = half width), which is the real core surface for it.
-        let thumb = im.resize(0.5);
+        // The core's aspect-preserving streaming thumbnail is
+        // `thumbnail_image(width)` (in-memory `vips_thumbnail_image`,
+        // core PR #307), the real surface this shell test exercises. It
+        // fits a width x width box, so the result never exceeds half width.
+        let thumb = im.thumbnail_image(im.width() / 2);
         assert!(thumb.width() <= im.width() / 2 + 1);
         assert!(thumb.height() > 0);
     }
@@ -337,9 +338,9 @@ mod sequential {
         unsafe { std::env::set_var("TMPDIR", dir.path()) };
 
         let im = decode_file(&ref_image("sample.jpg")).unwrap();
-        // See test_seq_thumbnail: `resize` is the core's aspect-preserving
-        // downscale (0.25 = quarter width).
-        let _thumb = im.resize(0.25);
+        // See test_seq_thumbnail: `thumbnail_image` is the core's
+        // aspect-preserving streaming thumbnail; quarter-width box here.
+        let _thumb = im.thumbnail_image(im.width() / 4);
 
         let temp_files: Vec<_> = std::fs::read_dir(dir.path())
             .unwrap()

--- a/tests/ported_resample.rs
+++ b/tests/ported_resample.rs
@@ -20,36 +20,6 @@ fn ref_image(name: &str) -> std::path::PathBuf {
     Path::new(REF_IMAGES).join(name)
 }
 
-/// Compile-enablement shim for the libvips `thumbnail` family, which the
-/// core has not ported (grep of `libviprs/src` finds only the
-/// `parse_thumbnail_geometry` CLI helper; there is no shrink-on-load
-/// thumbnail op with aspect, crop, linear, or ICC handling). The four
-/// thumbnail tests below keep their authored `#[ignore]` spec-state and
-/// every assertion intact; this trait exists only so the rest of this
-/// cell compiles and its green tests can run. Delete it when the core
-/// ports `thumbnail` (the inherent methods will then take precedence).
-trait ThumbnailCoreGap {
-    fn thumbnail(path: &Path, width: u32, height: Option<u32>, crop: bool) -> Raster;
-    fn thumbnail_buffer(data: &[u8], width: u32) -> Raster;
-    fn thumbnail_with_options(path: &Path, width: u32, linear: bool) -> Raster;
-    fn thumbnail_with_profile(path: &Path, width: u32, output_profile: &str) -> Raster;
-}
-
-impl ThumbnailCoreGap for Raster {
-    fn thumbnail(_path: &Path, _width: u32, _height: Option<u32>, _crop: bool) -> Raster {
-        unimplemented!("core gap: the libvips thumbnail family is not ported")
-    }
-    fn thumbnail_buffer(_data: &[u8], _width: u32) -> Raster {
-        unimplemented!("core gap: the libvips thumbnail family is not ported")
-    }
-    fn thumbnail_with_options(_path: &Path, _width: u32, _linear: bool) -> Raster {
-        unimplemented!("core gap: the libvips thumbnail family is not ported")
-    }
-    fn thumbnail_with_profile(_path: &Path, _width: u32, _output_profile: &str) -> Raster {
-        unimplemented!("core gap: the libvips thumbnail family is not ported")
-    }
-}
-
 // ---------------------------------------------------------------------------
 // 5.1 Resize
 // ---------------------------------------------------------------------------
@@ -192,13 +162,10 @@ mod affine {
     ///
     /// Reference: test_resample.py::test_affine
     ///
-    /// RESIDUAL RED (core-nohalo remainder): the nearest / bicubic /
-    /// bilinear round-trips pass, but the core does not implement the
-    /// `nohalo` and `lbb` interpolators yet and panics with the typed
-    /// InterpolatorNotImplemented error on the fourth loop entry. That is
-    /// a real core deferral, not a test mis-port; the nohalo/lbb
-    /// assertions stay.
-    #[ignore = "core-nohalo remainder: nohalo/lbb interpolators are typed as not implemented"]
+    /// The core now implements all five interpolators, including the
+    /// `nohalo` and `lbb` minmod-subdivision resamplers (core PR #307), so
+    /// the 4x 90-degree rotation round-trip is exact identity for every
+    /// kernel. All assertions are pinned unweakened.
     fn test_affine() {
         let im = decode_file(&ref_image("sample.jpg")).unwrap();
 
@@ -397,10 +364,9 @@ mod advanced_resampling {
     ///
     /// Reference: test_resample.py::test_thumbnail
     ///
-    /// RESIDUAL RED (core gap): the libvips thumbnail family
-    /// (shrink-on-load with aspect / crop handling) is not ported; the
-    /// calls resolve through the panicking `ThumbnailCoreGap` shim above.
-    #[ignore = "core gap: the libvips thumbnail family is not ported"]
+    /// The core now ports the libvips thumbnail family (shrink-on-load with
+    /// aspect and crop handling) as inherent methods (core PR #307), so the
+    /// calls resolve to the real ops and every assertion is exercised.
     fn test_thumbnail() {
         let path = ref_image("sample.jpg");
         let im = Raster::thumbnail(&path, 100, None, false);
@@ -462,8 +428,8 @@ mod advanced_resampling {
     ///
     /// Reference: test_resample.py::test_thumbnail_uhdr_linear
     ///
-    /// RESIDUAL RED (core gap): see test_thumbnail.
-    #[ignore = "core gap: the libvips thumbnail family is not ported"]
+    /// Enabled by the core thumbnail family port (core PR #307); see
+    /// test_thumbnail.
     fn test_thumbnail_uhdr_linear() {
         let path = ref_image("ultra-hdr.jpg");
         let im = Raster::thumbnail_with_options(&path, 128, true);
@@ -488,8 +454,8 @@ mod advanced_resampling {
     ///
     /// Reference: test_resample.py::test_thumbnail_icc
     ///
-    /// RESIDUAL RED (core gap): see test_thumbnail.
-    #[ignore = "core gap: the libvips thumbnail family is not ported"]
+    /// Enabled by the core thumbnail family port (core PR #307); see
+    /// test_thumbnail. The measured ICC dE00 is ~9.43 (< 10).
     fn test_thumbnail_icc() {
         let im = Raster::thumbnail_with_profile(&ref_image("sample-xyb.jpg"), 442, "srgb");
         assert_eq!(im.width(), 290);

--- a/tools/run_ported_cells.sh
+++ b/tools/run_ported_cells.sh
@@ -6,16 +6,15 @@ set -euo pipefail
 #
 # The ported_* integration tests (feature = "ported_tests") are ports of the
 # libvips reference test suite. Eleven cells compile and run green against
-# the current core (210 tests). Three codec cells (ported_foreign,
-# ported_connection, ported_iofuncs) target an external-decoder surface the
-# core does not expose yet and do not compile, so a blanket
-# `cargo test --features ported_tests` build of every test target fails.
-# This script is the single source of truth for the green-cell list: the
-# Docker mirror (Dockerfile CMD via run-tests.sh), the pre-commit hooks
-# (install-hooks.sh), and .github/workflows/ci.yml all call it, so promoting
-# a cell to green is a one-file change. The deferred remainder (codec cells
-# plus the per-test `#[ignore]` reds inside green cells) is tracked in
-# issue #77.
+# the current core (219 tests, no per-test `#[ignore]` reds remaining).
+# Three codec cells (ported_foreign, ported_connection, ported_iofuncs)
+# target an external-decoder surface the core does not expose yet and do not
+# compile, so a blanket `cargo test --features ported_tests` build of every
+# test target fails. This script is the single source of truth for the
+# green-cell list: the Docker mirror (Dockerfile CMD via run-tests.sh), the
+# pre-commit hooks (install-hooks.sh), and .github/workflows/ci.yml all call
+# it, so promoting a cell to green is a one-file change. The deferred
+# remainder (the three codec cells) is tracked in issue #77.
 #
 # ported_infrastructure runs single-threaded: its tests mutate process-global
 # state (TMPDIR, the max-coord limit) that individual tests save and restore


### PR DESCRIPTION
Final enablement round for #77 and #79 now that the core fixes merged (core main 5ffae90: atanh/divide-float #303/#304, smartcrop #305, resume/queue #306, thumbnail + nohalo/lbb #307).

## COUNTERPART_REV
Bumped to `5ffae90bd01b80ccbd67de0658e1da80c7c28fa6` with an updated human-label comment.

## Un-ignored ported reds (all now green)
- `ported_arithmetic::math_functions::test_atanh`: `div_const` now float-promotes 128/255, so atanh(0.502) is finite (core #303/#304).
- `ported_arithmetic::math_functions::test_sinh` / `test_cosh`: corrected a mis-ported fixture probe. The core sinh/cosh are libvips-faithful (f32 output, overflow to inf above ~88.7, confirmed by the vips oracle on `mono(226)`), but the port probed those overflowing pixels. I moved the probe to the small values the libvips original uses and pinned the real vips-8.18 oracle output: `sinh(3) = 10.017874717712402`, `cosh(5) = 74.209945678710938`. The op is unchanged; only the wrong probe pixel was corrected.
- `ported_conversion::test_smartcrop_attention`: pins the libvips-exact attention crop (199, 234) on sample.jpg (core #305).
- `ported_resample`: deleted the now-dead `ThumbnailCoreGap` shim and un-ignored `test_thumbnail`, `test_thumbnail_uhdr_linear`, `test_thumbnail_icc` (dE00 ~9.43 < 10), and `test_affine` (nohalo/lbb now implemented) (core #307).
- `ported_infrastructure`: `test_seq_thumbnail` / `test_seq_no_temps` now drive the real `thumbnail_image(width)` instance method.

## Verification (foreground, observed)
- Enforced mirror `tools/run_ported_cells.sh --require-fixtures`: 219 passing, 0 ignored across the 11 green cells (was 211). Per-cell: arithmetic 64, colour 9, conversion 44, convolution 7, create 30, draw 8, histogram 12, morphology 5, mosaicing 6, resample 13, infrastructure 21.
- #79 phase3 cells without the tracing feature (`cargo test --test phase3_resume --test phase3_validation_stress --test phase3_tracing -- --test-threads=1`): phase3_resume 10/10, phase3_tracing 7/7, phase3_validation_stress 10/10. The 4 acceptance tests (resume_mode_refuses_if_plan_hash_differs, restart_during_level_generation_resume_completes_output, restart_during_tile_encode_resume_completes_output, queue_pressure_peak_bounded_by_concurrency) are green.
- `cargo fmt` clean; clippy `-D warnings` green across default / s3 / packfile / tracing plus the ported green cells (pre-commit mirror).

No assertion was weakened. The only assertion change (the sinh/cosh probe) corrects a proven mis-port and is documented inline with the oracle-computed values.