### PR TITLE
test: enable #83 iofuncs cell and gate the per-tile span tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test
+      # The default `cargo test` above builds phase3_tracing WITHOUT the
+      # `tracing` feature, so its per-tile span tests (emits_span_per_tile,
+      # tile_span_carries_coords) are cfg'd out and only the no-tracing counter
+      # tests run. Exercise the span tests explicitly under the feature so the
+      # per-tile `libviprs::tile` span wired in core PR #308 gates CI (issue
+      # #83). This mirrors the run tools/run_ported_cells.sh performs for the
+      # Docker mirror. phase3_tracing reads only the checked-in canonical PNG,
+      # so it needs no reference-suite fixtures.
+      - run: cargo test --features "ported_tests tracing" --test phase3_tracing
 
   test-pdfium:
     name: Integration Tests (pdfium)
@@ -66,12 +75,13 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       # tools/run_ported_cells.sh is the single source of truth for the green
-      # ported_* cells (eleven cells, 210 tests; ported_infrastructure runs
-      # with --test-threads=1 per its header). The test pass runs
-      # fixture_audit first, proving the pinned fetch populated every fixture
-      # the suite needs. Clippy is scoped to the same green targets because
-      # the three deferred codec cells (ported_foreign, ported_connection,
-      # ported_iofuncs) do not compile yet; issue #77 tracks that remainder.
+      # ported_* cells (twelve cells, 224 tests; ported_infrastructure runs
+      # with --test-threads=1 per its header). It also runs phase3_tracing
+      # under the tracing feature so the per-tile span tests gate here too
+      # (issue #83). The test pass runs fixture_audit first, proving the pinned
+      # fetch populated every fixture the suite needs. Clippy is scoped to the
+      # green targets because the two deferred codec cells (ported_foreign,
+      # ported_connection) do not compile yet; issue #77 tracks that remainder.
       - run: ./tools/run_ported_cells.sh --clippy
       - run: ./tools/run_ported_cells.sh --require-fixtures
 
@@ -89,7 +99,7 @@ jobs:
         # type-checked and linted here, not merely conditionally excluded.
         # `pdfium` has its own job above; `ported_tests` has the ported-tests
         # job above (it cannot join this `--all-targets` matrix because the
-        # three deferred codec cells do not compile yet, so its clippy pass is
+        # two deferred codec cells do not compile yet, so its clippy pass is
         # scoped to the green cells via tools/run_ported_cells.sh; issue #77).
         feature: [s3, packfile, tracing]
     steps:

--- a/COUNTERPART_REV
+++ b/COUNTERPART_REV
@@ -10,10 +10,9 @@
 # To bump: set this to a libviprs commit SHA, run the suite against the sibling
 # checkout, and update the label comment below.
 #
-# libviprs main @ 2026-07-12 (+ the final #77/#79 enablement batch: atanh /
-# divide-float promotion core PRs #303/#304, smartcrop attention parity #305,
-# Phase 3 resume + queue-admission #306, and the thumbnail family + nohalo/lbb
-# interpolators #307). Greens the previously-ignored ported reds (atanh, sinh,
-# cosh, smartcrop_attention, thumbnail x3, affine) and keeps the #79 phase3
-# resume/queue cells green.
-5ffae90bd01b80ccbd67de0658e1da80c7c28fa6
+# libviprs main @ 2026-07-12 (+ the #83 iofuncs enablement batch: the per-tile
+# tracing span core PR #308, and iofuncs batch B1 with the bounded LRU load
+# cache core PR #309). Greens the iofuncs cell (new_from_image, new_from_memory,
+# get_fields, write_to_memory, revalidate) and lets the per-tile span tests
+# (emits_span_per_tile, tile_span_carries_coords) run under the tracing feature.
+8b3eba5717a7b72de2edd8a6c919ffb054b20746

--- a/tests/ported_iofuncs.rs
+++ b/tests/ported_iofuncs.rs
@@ -7,8 +7,7 @@
 
 use std::path::Path;
 
-use libviprs::source::decode_bytes;
-use libviprs::{PixelFormat, Raster, decode_file};
+use libviprs::{Raster, decode_file, decode_file_with_options};
 
 /// Path to the libvips reference test images directory.
 const REF_IMAGES: &str = concat!(
@@ -25,7 +24,6 @@ fn ref_image(name: &str) -> std::path::PathBuf {
 // ===========================================================================
 
 #[test]
-#[ignore]
 /// Create a constant image from an existing image, preserving geometry and metadata.
 ///
 /// ## Required API
@@ -61,7 +59,17 @@ fn test_new_from_image() {
     assert_eq!(im2.width(), im.width());
     assert_eq!(im2.height(), im.height());
     assert_eq!(im2.interpretation(), im.interpretation());
-    assert_eq!(im2.format(), im.format());
+    // libvips `format` is the sample type (BandFormat: uchar/ushort/float)
+    // alone, independent of band count, so its `im2.format == im.format`
+    // holds. libviprs `PixelFormat` instead couples band count with sample
+    // depth: sample.jpg is 3-band `Rgb8`, but the 1-band constant from
+    // `new_from_image(&[12.0])` is `Gray8`, so `im2.format() == im.format()`
+    // is unsatisfiable and mis-transliterates the source. The faithful
+    // BandFormat check is on sample depth alone, which the core preserves.
+    assert_eq!(
+        im2.format().bytes_per_channel(),
+        im.format().bytes_per_channel()
+    );
     assert!((im2.xres() - im.xres()).abs() < 0.001);
     assert!((im2.yres() - im.yres()).abs() < 0.001);
     assert_eq!(im2.xoffset(), im.xoffset());
@@ -84,7 +92,6 @@ fn test_new_from_image() {
 // ===========================================================================
 
 #[test]
-#[ignore]
 /// Construct an image from a raw memory buffer.
 ///
 /// ## Required API
@@ -121,7 +128,6 @@ fn test_new_from_memory() {
 // ===========================================================================
 
 #[test]
-#[ignore]
 /// Read image metadata fields (e.g. EXIF, ICC, XMP).
 ///
 /// ## Required API
@@ -154,7 +160,6 @@ fn test_get_fields() {
 // ===========================================================================
 
 #[test]
-#[ignore]
 /// Write image pixel data back to a memory buffer.
 ///
 /// ## Required API
@@ -185,7 +190,6 @@ fn test_write_to_memory() {
 // ===========================================================================
 
 #[test]
-#[ignore]
 /// Invalidate and revalidate a cached image after the file changes on disk.
 ///
 /// ## Required API

--- a/tools/run_ported_cells.sh
+++ b/tools/run_ported_cells.sh
@@ -5,16 +5,21 @@ set -euo pipefail
 # run_ported_cells.sh — Run the green subset of the ported_* test cells.
 #
 # The ported_* integration tests (feature = "ported_tests") are ports of the
-# libvips reference test suite. Eleven cells compile and run green against
-# the current core (219 tests, no per-test `#[ignore]` reds remaining).
-# Three codec cells (ported_foreign, ported_connection, ported_iofuncs)
-# target an external-decoder surface the core does not expose yet and do not
-# compile, so a blanket `cargo test --features ported_tests` build of every
-# test target fails. This script is the single source of truth for the
-# green-cell list: the Docker mirror (Dockerfile CMD via run-tests.sh), the
-# pre-commit hooks (install-hooks.sh), and .github/workflows/ci.yml all call
-# it, so promoting a cell to green is a one-file change. The deferred
-# remainder (the three codec cells) is tracked in issue #77.
+# libvips reference test suite. Twelve cells compile and run green against
+# the current core (224 tests, no per-test `#[ignore]` reds remaining).
+# Two codec cells (ported_foreign, ported_connection) target an
+# external-decoder surface the core does not expose yet and do not compile,
+# so a blanket `cargo test --features ported_tests` build of every test
+# target fails. This script is the single source of truth for the green-cell
+# list: the Docker mirror (Dockerfile CMD via run-tests.sh), the pre-commit
+# hooks (install-hooks.sh), and .github/workflows/ci.yml all call it, so
+# promoting a cell to green is a one-file change. The deferred remainder (the
+# two codec cells) is tracked in issue #77.
+#
+# After the ported cells this script also runs phase3_tracing under the
+# `tracing` feature so the per-tile span tests (core PR #308, issue #83) are
+# exercised in the mirror; the default no-tracing `cargo test` build cfg's
+# those span tests out.
 #
 # ported_infrastructure runs single-threaded: its tests mutate process-global
 # state (TMPDIR, the max-coord limit) that individual tests save and restore
@@ -44,6 +49,7 @@ PARALLEL_CELLS=(
     ported_create
     ported_draw
     ported_histogram
+    ported_iofuncs
     ported_morphology
     ported_mosaicing
     ported_resample
@@ -111,6 +117,17 @@ cargo test --features ported_tests "${PARALLEL_TARGETS[@]}"
 echo ""
 echo "Running $SERIAL_CELL with --test-threads=1 (mutates process-global state)..."
 cargo test --features ported_tests --test "$SERIAL_CELL" -- --test-threads=1
+
+# Exercise the per-tile tracing spans under the `tracing` feature. The default
+# `cargo test` build compiles phase3_tracing WITHOUT `tracing`, so its span
+# tests (emits_span_per_tile, tile_span_carries_coords) are cfg'd out and never
+# run; only its no-tracing counter tests do. Run the whole cell under the
+# feature here so the per-tile `libviprs::tile` span wired in core PR #308
+# actually gates the mirror (issue #83). phase3_tracing reads only the
+# checked-in canonical PNG, not the reference suite fetched above.
+echo ""
+echo "Running phase3_tracing under --features tracing (per-tile span tests)..."
+cargo test --features "ported_tests tracing" --test phase3_tracing
 
 echo ""
 echo "Green ported cells passed."


### PR DESCRIPTION
## Summary

I close #83 and green the iofuncs ported cell now that the core fixes merged (core main `8b3eba5`: per-tile tracing span PR #308, iofuncs batch B1 with the bounded LRU load cache PR #309).

## Changes

- **COUNTERPART_REV**: I bump the pin to core main `8b3eba5` and relabel the human comment for PR #308 + #309.
- **tests/ported_iofuncs.rs**: I drop the 5 `#[ignore]` markers (test_revalidate, test_new_from_image, test_new_from_memory, test_get_fields, test_write_to_memory) and import `decode_file_with_options` from the crate root.
  - **Mis-port correction in test_new_from_image**: the test asserted `im2.format() == im.format()`, which is unsatisfiable. libvips `format` is the sample type (BandFormat: uchar/ushort/float) alone, independent of band count, so its `format == format` holds. libviprs `PixelFormat` couples band count with sample depth, so the 1-band constant from `new_from_image(&[12.0])` is `Gray8` while the 3-band `sample.jpg` source is `Rgb8`. I compare sample depth via `bytes_per_channel()` instead, the faithful BandFormat transliteration. The core preserves sample depth correctly, so this fixes a test-side defect and does not weaken the test.
- **tools/run_ported_cells.sh**: I add `ported_iofuncs` to the green-cell list, and after the ported cells I run `phase3_tracing` under `--features "ported_tests tracing"` so the per-tile span tests gate the Docker mirror.
- **.github/workflows/ci.yml**: I mirror the tracing phase3 run (the `test` job now runs it explicitly, keeping the existing no-tracing run), and refresh the stale cell-count comments.

## Results (foreground, core @ 8b3eba5)

- **ported_iofuncs: 5 passing** (test_new_from_image, test_new_from_memory, test_get_fields, test_write_to_memory, test_revalidate).
- **Ported green count: 219 to 224 (+5)**. Per-cell: arithmetic 64, colour 9, conversion 44, convolution 7, create 30, draw 8, histogram 12, iofuncs 5, morphology 5, mosaicing 6, resample 13, infrastructure 21.
- **phase3_tracing under `--features "ported_tests tracing"`: 12/12**, including the two span tests `emits_span_per_tile` and `tile_span_carries_coords` (plus emits_pipeline_span, emits_span_per_level, level_span_carries_level_index_field and the 7 counter/queue tests).
- `cargo fmt --check`, green-cell clippy, and `--features tracing` clippy all pass.

Closes #83.
