### PR TITLE
Fix pdfium provenance false-fail in the Docker mirror (Dockerfile.dockerignore)

### DIFF
--- a/Dockerfile.dockerignore
+++ b/Dockerfile.dockerignore
@@ -1,0 +1,35 @@
+# BuildKit .dockerignore for the run-tests.sh Docker mirror.
+#
+# The mirror builds with the WORKSPACE ROOT (the parent of libviprs/ and
+# libviprs-tests/) as the build context and `-f libviprs-tests/Dockerfile`
+# (see tools/run-tests.sh). Docker therefore reads its ignore rules from the
+# context root's `.dockerignore`, NOT from `libviprs-tests/.dockerignore`.
+# BuildKit checks for a `<dockerfile>.dockerignore` next to the `-f` Dockerfile
+# first and prefers it, so this file (living in the libviprs-tests repo, in
+# scope) is the authoritative ignore set for the mirror build. It fully
+# replaces the context-root file, so it must carry every exclusion, not just
+# the native-library additions.
+#
+# Patterns are relative to the build context (the workspace root); `**/` makes
+# them match under both libviprs/ and libviprs-tests/.
+**/target/
+**/.git/
+**/.DS_Store
+**/tmp/
+**/*.log
+**/*.bak
+**/*.tmp
+
+# Native library binaries are gitignored but present in a local checkout. The
+# COPY of libviprs-tests/ would otherwise pull the ~6 MiB libpdfium.dylib into
+# the image, where the pdfium_provenance working-tree scan (which runs when the
+# context has no .git) false-fails on it (issue #56 guard). The runtime
+# libpdfium.so comes from the pinned `pdfium` build stage, not the context, so
+# excluding these here is safe and keeps the pre-push hook green without
+# --no-verify.
+**/*.dylib
+**/*.so
+**/*.dll
+**/*.a
+**/*.lib
+**/libpdfium*


### PR DESCRIPTION
Follow-up to #85 (issue #77).

#85 added native-lib patterns to `libviprs-tests/.dockerignore`, but that file never reaches the `run-tests.sh` Docker build: the build uses the workspace root as its context with `-f libviprs-tests/Dockerfile`, so Docker reads ignore rules from the context-root `.dockerignore`, not from `libviprs-tests/.dockerignore`. `COPY libviprs-tests/` still pulled the gitignored `libpdfium.dylib` into the image, where the `pdfium_provenance` working-tree scan (the context has no `.git`) flagged it, forcing `--no-verify` on every push.

This adds `libviprs-tests/Dockerfile.dockerignore`. BuildKit checks for a `<dockerfile>.dockerignore` next to the `-f` Dockerfile and prefers it over the context-root file, so this in-repo file is now the authoritative ignore set for the mirror. It fully replaces the context-root file, so it carries the base excludes (target/.git/tmp/logs) plus the native-lib patterns.

Verified with a throwaway BuildKit build against the same workspace-root context: the COPY'd `libviprs-tests/` tree contains no `*.dylib`, so the provenance guard passes and the pre-push hook no longer needs `--no-verify`.