### PR TITLE
test: land Wave-1 review repro cells + bump COUNTERPART_REV to e02e93a

### DIFF
--- a/COUNTERPART_REV
+++ b/COUNTERPART_REV
@@ -21,4 +21,11 @@
 # #316 ZipSink, #317 EngineConfig::skip_blanks + generate_pyramid_region,
 # #318 Zoomify/IIIF DeepZoom layouts, #319 extract_page_image_with_background.
 # The six ported tests enabled here compile and run against this counterpart.
-38a7ff0670bbc93d3dd89aac300516aee7d1babe
+#
+# Bumped for the Wave-1 panel-review fixes + review-driven follow-ups
+# (PRs #331-341, #353-355): op panic-safety, lock precedence, draw ink
+# validation, resample/composite alpha, MAX_COORD->DecodeLimits, hex dedup,
+# s3 rename, pdfium rev-pin, ICC precision, de00_sharma sign fix, Nearest
+# premultiply skip, composite output-interpretation tag. The colour/resample/
+# composite review-repro cells below build and pass against this counterpart.
+e02e93a81ac2dd58cea45f004bc074dec7b23bd6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,7 +893,7 @@ dependencies = [
  "image",
  "lopdf",
  "moxcms 0.8.1",
- "pdfium-render",
+ "pdfium-render 0.9.3 (git+https://github.com/libviprs/pdfium-render.git?rev=1000a1aff1888425004c11432b376d2c36a4d3f2)",
  "rustfft",
  "serde",
  "serde_json",
@@ -914,7 +914,7 @@ dependencies = [
  "image",
  "libviprs",
  "lopdf",
- "pdfium-render",
+ "pdfium-render 0.9.3 (git+https://github.com/libviprs/pdfium-render.git?branch=libviprs%2Fintegration)",
  "proptest",
  "serde_json",
  "sha2 0.10.9",
@@ -1129,6 +1129,31 @@ dependencies = [
 name = "pdfium-render"
 version = "0.9.3"
 source = "git+https://github.com/libviprs/pdfium-render.git?branch=libviprs%2Fintegration#1000a1aff1888425004c11432b376d2c36a4d3f2"
+dependencies = [
+ "bitflags",
+ "bytemuck",
+ "bytes",
+ "chrono",
+ "console_error_panic_hook",
+ "console_log",
+ "image",
+ "itertools",
+ "js-sys",
+ "libloading",
+ "log",
+ "maybe-owned",
+ "once_cell",
+ "utf16string",
+ "vecmath",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "pdfium-render"
+version = "0.9.3"
+source = "git+https://github.com/libviprs/pdfium-render.git?rev=1000a1aff1888425004c11432b376d2c36a4d3f2#1000a1aff1888425004c11432b376d2c36a4d3f2"
 dependencies = [
  "bitflags",
  "bytemuck",

--- a/tests/colour_de00_sharma_reference.rs
+++ b/tests/colour_de00_sharma_reference.rs
@@ -1,0 +1,258 @@
+//! Known-answer golden test for [`Raster::de00_sharma`] against the
+//! **published Sharma 2005 CIEDE2000 reference dataset**.
+//!
+//! This is a *reference* golden, not a vips-differential test:
+//! `de00_sharma` deliberately computes the textbook CIEDE2000 value
+//! (Sharma, Wu & Dalal 2005), which differs from libvips' `vips_col_dE00`
+//! parity path (exposed as `de00`) on asymmetric hue-wrap pairs. The
+//! expected values below are the canonical published dE00 numbers from
+//! Table 1 of:
+//!
+//!   G. Sharma, W. Wu, E. N. Dalal, "The CIEDE2000 Color-Difference
+//!   Formula: Implementation Notes, Supplementary Test Data, and
+//!   Mathematical Observations", Color Research & Application, 30(1),
+//!   pp. 21-30, 2005.
+//!
+//! The dataset is embedded as constants (it is a fixed textbook reference,
+//! not a fixture that can drift). Every pair must reproduce within 1e-3.
+//!
+//! Regression guard for libviprs#332: the original `de00_sharma` copied
+//! `de00`'s delta-hue wrap arm verbatim (`360 - (h1'-h2')`), which has the
+//! wrong sign relative to the `c1' - c2'` chroma-difference convention, so
+//! the RT * dC' * dh' cross term is negated. That is invisible on
+//! symmetric-wrap or dC'=0 pairs, but on asymmetric hue-wrap pairs with
+//! dC' != 0 (e.g. pair 19, Lab [50,2.5,0]/[56,-27,-3]) it returns 21.12
+//! instead of the published 31.9030.
+
+use libviprs::{Interpretation, Raster};
+
+/// Evaluate the public `Raster::de00_sharma` on a single Lab pair.
+fn sharma(lab1: [f64; 3], lab2: [f64; 3]) -> f64 {
+    let a = Raster::constant(2, 2, &lab1, Interpretation::Lab);
+    let b = Raster::constant(2, 2, &lab2, Interpretation::Lab);
+    a.de00_sharma(&b).getpoint(0, 0)[0]
+}
+
+/// Canonical Sharma/Wu/Dalal 2005 CIEDE2000 test data (Table 1): 34 pairs
+/// of `(Lab1, Lab2, published dE00)`.
+const SHARMA_2005: &[([f64; 3], [f64; 3], f64)] = &[
+    (
+        [50.0000, 2.6772, -79.7751],
+        [50.0000, 0.0000, -82.7485],
+        2.0425,
+    ),
+    (
+        [50.0000, 3.1571, -77.2803],
+        [50.0000, 0.0000, -82.7485],
+        2.8615,
+    ),
+    (
+        [50.0000, 2.8361, -74.0200],
+        [50.0000, 0.0000, -82.7485],
+        3.4412,
+    ),
+    (
+        [50.0000, -1.3802, -84.2814],
+        [50.0000, 0.0000, -82.7485],
+        1.0000,
+    ),
+    (
+        [50.0000, -1.1848, -84.8006],
+        [50.0000, 0.0000, -82.7485],
+        1.0000,
+    ),
+    (
+        [50.0000, -0.9009, -85.5211],
+        [50.0000, 0.0000, -82.7485],
+        1.0000,
+    ),
+    (
+        [50.0000, 0.0000, 0.0000],
+        [50.0000, -1.0000, 2.0000],
+        2.3669,
+    ),
+    (
+        [50.0000, -1.0000, 2.0000],
+        [50.0000, 0.0000, 0.0000],
+        2.3669,
+    ),
+    (
+        [50.0000, 2.4900, -0.0010],
+        [50.0000, -2.4900, 0.0009],
+        7.1792,
+    ),
+    (
+        [50.0000, 2.4900, -0.0010],
+        [50.0000, -2.4900, 0.0010],
+        7.1792,
+    ),
+    (
+        [50.0000, 2.4900, -0.0010],
+        [50.0000, -2.4900, 0.0011],
+        7.2195,
+    ),
+    (
+        [50.0000, 2.4900, -0.0010],
+        [50.0000, -2.4900, 0.0012],
+        7.2195,
+    ),
+    (
+        [50.0000, -0.0010, 2.4900],
+        [50.0000, 0.0009, -2.4900],
+        4.8045,
+    ),
+    (
+        [50.0000, -0.0010, 2.4900],
+        [50.0000, 0.0010, -2.4900],
+        4.8045,
+    ),
+    (
+        [50.0000, -0.0010, 2.4900],
+        [50.0000, 0.0011, -2.4900],
+        4.7461,
+    ),
+    (
+        [50.0000, 2.5000, 0.0000],
+        [50.0000, 0.0000, -2.5000],
+        4.3065,
+    ),
+    (
+        [50.0000, 2.5000, 0.0000],
+        [73.0000, 25.0000, -18.0000],
+        27.1492,
+    ),
+    (
+        [50.0000, 2.5000, 0.0000],
+        [61.0000, -5.0000, 29.0000],
+        22.8977,
+    ),
+    (
+        [50.0000, 2.5000, 0.0000],
+        [56.0000, -27.0000, -3.0000],
+        31.9030,
+    ),
+    (
+        [50.0000, 2.5000, 0.0000],
+        [58.0000, 24.0000, 15.0000],
+        19.4535,
+    ),
+    ([50.0000, 2.5000, 0.0000], [50.0000, 3.1736, 0.5854], 1.0000),
+    ([50.0000, 2.5000, 0.0000], [50.0000, 3.2972, 0.0000], 1.0000),
+    ([50.0000, 2.5000, 0.0000], [50.0000, 1.8634, 0.5757], 1.0000),
+    ([50.0000, 2.5000, 0.0000], [50.0000, 3.2592, 0.3350], 1.0000),
+    (
+        [60.2574, -34.0099, 36.2677],
+        [60.4626, -34.1751, 39.4387],
+        1.2644,
+    ),
+    (
+        [63.0109, -31.0961, -5.8663],
+        [62.8187, -29.7946, -4.0864],
+        1.2630,
+    ),
+    (
+        [61.2901, 3.7196, -5.3901],
+        [61.4292, 2.2480, -4.9620],
+        1.8731,
+    ),
+    (
+        [35.0831, -44.1164, 3.7933],
+        [35.0232, -40.0716, 1.5901],
+        1.8645,
+    ),
+    (
+        [22.7233, 20.0904, -46.6940],
+        [23.0331, 14.9730, -42.5619],
+        2.0373,
+    ),
+    (
+        [36.4612, 47.8580, 18.3852],
+        [36.2715, 50.5065, 21.2231],
+        1.4146,
+    ),
+    (
+        [90.8027, -2.0831, 1.4410],
+        [91.1528, -1.6435, 0.0447],
+        1.4441,
+    ),
+    (
+        [90.9257, -0.5406, -0.9208],
+        [88.6381, -0.8985, -0.7239],
+        1.5381,
+    ),
+    (
+        [6.7747, -0.2908, -2.4247],
+        [5.8714, -0.0985, -2.2286],
+        0.6377,
+    ),
+    (
+        [2.0776, 0.0795, -1.1350],
+        [0.9033, -0.0636, -0.5514],
+        0.9082,
+    ),
+];
+
+/// The full published Sharma 2005 dataset must reproduce within 1e-3.
+///
+/// Against the buggy core (pre-#332-followup) this is RED: pair 19
+/// (index 18), Lab [50,2.5,0]/[56,-27,-3], returns 21.12 instead of
+/// 31.9030 — an error of ~10.78.
+#[test]
+fn de00_sharma_matches_published_sharma_2005_dataset() {
+    const TOL: f64 = 1e-3;
+    let mut failures = Vec::new();
+    let mut max_err = 0.0f64;
+
+    for (i, (lab1, lab2, expected)) in SHARMA_2005.iter().enumerate() {
+        let got = sharma(*lab1, *lab2);
+        let err = (got - expected).abs();
+        if err > max_err {
+            max_err = err;
+        }
+        if err > TOL {
+            failures.push(format!(
+                "pair {} {:?}/{:?}: expected {:.4}, got {:.4} (err {:.4})",
+                i + 1,
+                lab1,
+                lab2,
+                expected,
+                got,
+                err
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "de00_sharma deviates from published Sharma 2005 on {} of {} pairs \
+         (max err {:.4}):\n{}",
+        failures.len(),
+        SHARMA_2005.len(),
+        max_err,
+        failures.join("\n")
+    );
+}
+
+/// The specific asymmetric hue-wrap pair from the #332 defect report, in
+/// isolation: Lab [50,2.5,0]/[56,-27,-3] must equal the published 31.9030,
+/// not the sign-flipped 21.12 the buggy wrap arm produced.
+#[test]
+fn de00_sharma_asymmetric_wrap_pair19() {
+    let got = sharma([50.0, 2.5, 0.0], [56.0, -27.0, -3.0]);
+    assert!(
+        (got - 31.9030).abs() < 1e-3,
+        "published Sharma dE00 for [50,2.5,0]/[56,-27,-3] is 31.9030, got {got:.4}"
+    );
+}
+
+/// A high-RT asymmetric-wrap pair outside the standard 34-pair table,
+/// where the negated cross term is most damaging: the buggy arm returns
+/// ~21.84 versus the true ~53.53. Independent published reference value.
+#[test]
+fn de00_sharma_high_rt_asymmetric_wrap() {
+    let got = sharma([78.35, -59.81, -9.59], [69.99, 8.14, 0.04]);
+    assert!(
+        (got - 53.53).abs() < 1e-2,
+        "textbook Sharma dE00 for [78.35,-59.81,-9.59]/[69.99,8.14,0.04] is ~53.53, got {got:.4}"
+    );
+}

--- a/tests/composite_289_primary_path.rs
+++ b/tests/composite_289_primary_path.rs
@@ -1,0 +1,92 @@
+//! Follow-up repro for issue #289 (the mixed-depth compositing fix landed in
+//! libviprs/libviprs#340 / PR #340).
+//!
+//! `composite2` writes a mixed-depth result at the genuine 16-bit scale
+//! whenever a genuine-16 (`Rgb16`/`Grey16`) input is present — so a
+//! half-opaque genuine-16 overlay's alpha correctly survives above the 255
+//! ceiling on the FIRST composite. But the result is tagged with the *base's*
+//! interpretation (`out.meta = self.meta`), not the genuine-16 compositing
+//! space it was actually written at. Chaining that result back through
+//! `composite2` therefore re-reads it on the 255 scale and clamps the alpha
+//! back to the 255 ceiling — silently re-introducing #289 one hop downstream,
+//! and leaving the saved metadata inconsistent with the samples.
+//!
+//! Pure public-API test. It is RED against the current (buggy) core and turns
+//! GREEN once the core follow-up stamps the output interpretation to match its
+//! write-back scale.
+
+use libviprs::{CompositeMode, Interpretation, PixelFormat, Raster};
+
+/// A 1x1 genuine 16-bit RGBA raster explicitly tagged [`Interpretation::Rgb16`]
+/// (0..65535), as distinct from a promoted-8-bit-in-16-bit buffer (which the
+/// crate leaves untagged).
+fn genuine_rgba16(colour: [u16; 3], alpha: u16) -> Raster {
+    let data: Vec<u8> = [colour[0], colour[1], colour[2], alpha]
+        .iter()
+        .flat_map(|v| v.to_ne_bytes())
+        .collect();
+    Raster::new(1, 1, PixelFormat::Rgba16, data)
+        .unwrap()
+        .copy()
+        .interpretation(Interpretation::Rgb16)
+        .build()
+}
+
+/// A genuine-16 composite result must stay usable as a genuine-16 layer when
+/// fed back into `composite2`: its alpha (and colour) must survive on the
+/// 16-bit scale, not collapse back to the 255 ceiling.
+///
+/// Step 1 (already correct under #340): compose a genuine-16 half-opaque
+/// overlay over an 8-bit base with `Source`. The output is `Rgba16` and its
+/// alpha lands near `0x8000` (~32768), far above 255.
+///
+/// Step 2 (the gap): feed that result back as the overlay of another
+/// `Source` composite. If the result carried the genuine-16 tag it was written
+/// at, it re-reads on the 65535 scale and its alpha survives (~0x8000). Under
+/// the bug it is tagged with the 8-bit base's interpretation, so `composite2`
+/// treats it as untagged/non-genuine, re-reads it on the 255 scale, and clamps
+/// the alpha to the 255 ceiling.
+#[test]
+fn genuine_16bit_composite_result_survives_rechain() {
+    // Step 1: 8-bit base + genuine-16 half-opaque overlay.
+    let base8 = Raster::new(1, 1, PixelFormat::Rgba8, vec![40, 50, 60, 255]).unwrap();
+    let overlay = genuine_rgba16([10000, 20000, 30000], 0x8000);
+    let mid = base8.composite(&overlay, CompositeMode::Source);
+    assert_eq!(
+        mid.format(),
+        PixelFormat::Rgba16,
+        "mid format: {:?}",
+        mid.format()
+    );
+    let mpx = mid.getpoint(0, 0);
+    // The #340 fix already honours #289 on the first hop: alpha well above 255.
+    assert!(
+        mpx[3] > 255.0,
+        "first composite alpha must exceed the 255 ceiling: {mpx:?}"
+    );
+    assert!(
+        (mpx[3] - 32768.0).abs() < 256.0,
+        "first composite alpha should be ~0x8000: {mpx:?}"
+    );
+
+    // Step 2: re-chain `mid` as a genuine-16 overlay via Source over any base.
+    let base2 = Raster::new(1, 1, PixelFormat::Rgba8, vec![0, 0, 0, 255]).unwrap();
+    let out = base2.composite(&mid, CompositeMode::Source);
+    let px = out.getpoint(0, 0);
+    assert!(
+        px[3] > 255.0,
+        "re-chained genuine-16 alpha must survive the 255 ceiling, got {px:?} \
+         — the mixed-depth result was written at the 16-bit scale but tagged \
+         with the base's non-genuine-16 interpretation, so composite2 re-read \
+         it at 255 and re-introduced #289"
+    );
+    assert!(
+        (px[3] - 32768.0).abs() < 256.0,
+        "re-chained alpha should stay ~0x8000: {px:?}"
+    );
+    // The overlay blue channel must likewise re-read on the 16-bit scale.
+    assert!(
+        (px[2] - 30000.0).abs() < 256.0,
+        "re-chained blue should stay ~30000 (16-bit scale), got {px:?}"
+    );
+}

--- a/tests/ported_infrastructure.rs
+++ b/tests/ported_infrastructure.rs
@@ -759,6 +759,11 @@ mod cli {
     }
 
     #[test]
+    // The process-global max_coord knobs are deprecated in favour of the
+    // per-decode `DecodeLimits::max_coord` field (core #293); this ported cell
+    // still exercises the retained shims until they are removed (tracked in
+    // libviprs#349). Migrate to `DecodeLimits` when the shims go.
+    #[allow(deprecated)]
     /// Max coordinate limit via CLI flag.
     ///
     /// ## Required API
@@ -798,6 +803,9 @@ mod cli {
     }
 
     #[test]
+    // See the note on `test_cli_max_coord_flag`: deprecated shims, tracked in
+    // libviprs#349.
+    #[allow(deprecated)]
     /// Max coordinate limit via environment variable.
     ///
     /// ## Required API

--- a/tests/resample_nearest_alpha.rs
+++ b/tests/resample_nearest_alpha.rs
@@ -1,0 +1,121 @@
+//! Regression repro for libviprs/libviprs follow-up to #287/#288 (PR #337).
+//!
+//! PR #337 made `reduce_axis` premultiply colour by alpha for *every* alpha
+//! format, unconditionally. That is correct for the averaging kernels (it stops
+//! transparent RGB bleeding into opaque neighbours), but the **Nearest** kernel
+//! is a single-tap pick: it does no averaging, so wrapping it in a
+//! premultiply -> un-premultiply round-trip can only corrupt the straight-alpha
+//! RGB of semi-transparent pixels. Because `premultiply_raster` premultiplies
+//! into a *same-bit-depth integer* raster, the intermediate colour is requantised
+//! (`round(c * a / max)` then `round(c' * max / a)`), which is lossy for low
+//! alpha.
+//!
+//! A single-tap nearest pick must therefore be *exact*: every output pixel must
+//! be byte-identical to the source pixel it selected. `vips resize <rgba>
+//! --kernel nearest` preserves the exact sampled pixels; this is that invariant
+//! stated directly (no libvips needed at runtime, no fixture).
+//!
+//! Proven RED against the buggy core (the premultiply round-trip perturbs the
+//! low-alpha RGB); GREEN once the Nearest single-tap kernel skips premultiply.
+
+use libviprs::{PixelFormat, Raster, ReduceKernel, ResizeOptions};
+
+/// Four semi-transparent RGBA8 colours whose straight-alpha RGB does **not**
+/// survive a premultiply -> un-premultiply integer round-trip. Each corrupts to
+/// a value that is not equal to any colour in this palette, so "output pixel is
+/// one of these four" is a faithful proxy for "the exact source pixel survived".
+///
+/// Round-trip images under the buggy path (max = 255):
+///   (200,100, 50,10) -> (204,102, 51,10)
+///   ( 30,220,140, 3) -> (  0,255,170, 3)
+///   (170, 90,240, 7) -> (182, 73,255, 7)
+///   ( 90,200, 60, 5) -> (102,204, 51, 5)
+/// none of which is a member of the palette.
+const PALETTE: [[u8; 4]; 4] = [
+    [200, 100, 50, 10],
+    [30, 220, 140, 3],
+    [170, 90, 240, 7],
+    [90, 200, 60, 5],
+];
+
+/// A `w` x `h` RGBA8 raster tiled with `PALETTE` on a 2x2 lattice, so *every*
+/// pixel is one of the four fragile semi-transparent colours.
+fn semi_transparent_raster(w: u32, h: u32) -> Raster {
+    let mut data = Vec::with_capacity((w * h) as usize * 4);
+    for y in 0..h {
+        for x in 0..w {
+            let idx = (x % 2) as usize + 2 * (y % 2) as usize;
+            data.extend_from_slice(&PALETTE[idx]);
+        }
+    }
+    Raster::new(w, h, PixelFormat::Rgba8, data).unwrap()
+}
+
+/// Assert every output pixel is byte-identical to one of the source palette
+/// colours. A Nearest single-tap pick can only ever return an exact source
+/// pixel; the buggy premultiply round-trip returns requantised colours that are
+/// absent from the palette.
+fn assert_exact_pick(out: &Raster, label: &str) {
+    let data = out.data();
+    assert_eq!(out.format(), PixelFormat::Rgba8, "{label}: format changed");
+    assert_eq!(data.len() % 4, 0, "{label}: not whole RGBA pixels");
+    for (i, px) in data.chunks_exact(4).enumerate() {
+        let pixel = [px[0], px[1], px[2], px[3]];
+        assert!(
+            PALETTE.contains(&pixel),
+            "{label}: output pixel {i} = {pixel:?} is not an exact source sample; \
+             the Nearest single-tap kernel must not premultiply/round-trip \
+             semi-transparent RGB (follow-up to #287/#288)",
+        );
+    }
+}
+
+#[test]
+fn reduceh_nearest_preserves_exact_alpha_pixels() {
+    let src = semi_transparent_raster(4, 4);
+    let out = src.reduceh(2.0, "nearest");
+    assert_eq!(out.width(), 2);
+    assert_eq!(out.height(), 4);
+    assert_exact_pick(&out, "reduceh 2.0 nearest");
+}
+
+#[test]
+fn reducev_nearest_preserves_exact_alpha_pixels() {
+    let src = semi_transparent_raster(4, 4);
+    let out = src.reducev(2.0, "nearest");
+    assert_eq!(out.width(), 4);
+    assert_eq!(out.height(), 2);
+    assert_exact_pick(&out, "reducev 2.0 nearest");
+}
+
+#[test]
+fn reduce_nearest_preserves_exact_alpha_pixels() {
+    let src = semi_transparent_raster(4, 4);
+    let out = src.reduce(2.0, 2.0, "nearest");
+    assert_eq!(out.width(), 2);
+    assert_eq!(out.height(), 2);
+    assert_exact_pick(&out, "reduce 2.0x2.0 nearest");
+}
+
+#[test]
+fn reduce_nearest_fractional_preserves_exact_alpha_pixels() {
+    // A fractional factor still routes through `reduce_axis` with a single-tap
+    // mask, so the pick must remain exact.
+    let src = semi_transparent_raster(6, 6);
+    let out = src.reduce(1.5, 1.5, "nearest");
+    assert_exact_pick(&out, "reduce 1.5x1.5 nearest");
+}
+
+#[test]
+fn resize_nearest_preserves_exact_alpha_pixels() {
+    // `vips_resize` with the nearest kernel subsamples the integer part then
+    // reduces the fractional residual through `reduce_axis`; the residual pass
+    // must not corrupt the exact pick either.
+    let src = semi_transparent_raster(8, 8);
+    let opts = ResizeOptions {
+        kernel: ReduceKernel::Nearest,
+        ..ResizeOptions::default()
+    };
+    let out = src.resize_with(0.4, opts);
+    assert_exact_pick(&out, "resize 0.4 nearest");
+}


### PR DESCRIPTION
Lands the RED-first review-repro tests (originally drafted in #104 de00_sharma, #105 Nearest alpha, #106 composite #289 primary-path/output-tag), now GREEN against the fixed core, and bumps COUNTERPART_REV to e02e93a (the core SHA carrying the Wave-1 fixes + review follow-ups #331-341, #353-355).

Also keeps the deprecated `max_coord` ported cells green via `#[allow(deprecated)]` (core #293 moved to per-decode DecodeLimits; shims retained one release, migration tracked in libviprs#349).

Local gate green: fmt + clippy (default/s3/packfile/tracing) + run_ported_cells --clippy + the 3 repro tests (3+1+5 passing). Supersedes draft PRs #104/#105/#106.