### PR TITLE
test(arithmetic): pin float-unsupported diagnostic to a single op name (#339) [skip ci]

### DIFF
--- a/tests/arithmetic_float_error_message.rs
+++ b/tests/arithmetic_float_error_message.rs
@@ -1,0 +1,74 @@
+//! Follow-up to libviprs/libviprs#339 (tracked by #350): the float-unsupported
+//! diagnostic must name the failing op *exactly once*.
+//!
+//! `ArithmeticError::FloatUnsupported` embeds the op name in its `Display`
+//! ("sub does not support float rasters yet ..."), and the panicking op forms
+//! route the error through `expect_arith`, which prefixes `"<op>: "` for the
+//! other, op-less error variants. For `FloatUnsupported` that prefix doubled
+//! the op name, producing "sub: sub does not support float rasters yet ...".
+//!
+//! These tests pin the diagnostic down to a single occurrence of the op name.
+//! They drive only the crate's public panicking surface (`Raster::sub`,
+//! `Raster::add_vec`) on a float raster, which the integer arithmetic ops
+//! reject, and inspect the caught panic payload. They add no shared-file edits
+//! and require no feature flags.
+
+use libviprs::{PixelFormat, Raster};
+
+/// A zeroed single-band 32-bit float raster. The mutating integer arithmetic
+/// ops (`sub`, `add_vec`, ...) reject float input, so these rasters exercise
+/// the `FloatUnsupported` diagnostic path.
+fn float_raster() -> Raster {
+    let fmt = PixelFormat::with_channels(1, 4).expect("FloatF32(1) is a valid format");
+    Raster::zeroed(2, 2, fmt).expect("2x2 float raster allocates")
+}
+
+/// Run `body`, expected to panic, and return its panic message as a `String`
+/// with the default hook silenced so the intentional panic does not spam test
+/// output (mirrors the core crate's own panic-containment tests).
+fn caught_panic_message(body: impl FnOnce() + std::panic::UnwindSafe) -> String {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let payload = std::panic::catch_unwind(body).expect_err("body was expected to panic");
+    std::panic::set_hook(prev);
+    payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&str>().copied())
+        .expect("panic payload is a string")
+        .to_owned()
+}
+
+/// The image-image `sub` on a float raster must panic with the op name once,
+/// not "sub: sub ...". Guards the `binary_map` -> `FloatUnsupported` path.
+#[test]
+fn sub_float_panic_names_op_exactly_once() {
+    let (a, b) = (float_raster(), float_raster());
+    let msg = caught_panic_message(move || {
+        let _ = a.sub(&b);
+    });
+    assert_eq!(
+        msg.matches("sub").count(),
+        1,
+        "sub() float-unsupported panic must name the op exactly once, got: {msg:?}"
+    );
+    assert!(
+        msg.contains("does not support float rasters yet"),
+        "unexpected panic message: {msg:?}"
+    );
+}
+
+/// The per-band `add_vec` on a float raster must likewise name the op once,
+/// not "add_vec: add_vec ...". Guards the `vec_map` -> `FloatUnsupported` path.
+#[test]
+fn add_vec_float_panic_names_op_exactly_once() {
+    let a = float_raster();
+    let msg = caught_panic_message(move || {
+        let _ = a.add_vec(&[1.0]);
+    });
+    assert_eq!(
+        msg.matches("add_vec").count(),
+        1,
+        "add_vec() float-unsupported panic must name the op exactly once, got: {msg:?}"
+    );
+}


### PR DESCRIPTION
DRAFT repro for the op-name double-prefix reported in the review of libviprs/libviprs#339 (tracked by #350).

## What it pins

`ArithmeticError::FloatUnsupported` embeds the failing op in its `Display`, and the panicking arithmetic ops route it through `expect_arith`, which re-prefixes the op name for the other, op-less error variants. For this one variant that doubled the name:

```
sub()     on a float raster -> "sub: sub does not support float rasters yet; ..."
add_vec() on a float raster -> "add_vec: add_vec does not support float rasters yet; ..."
```

New file `tests/arithmetic_float_error_message.rs` drives the public panicking surface (`Raster::sub`, `Raster::add_vec`) on a float raster — which the integer arithmetic ops reject — and asserts the caught panic payload names the op **exactly once**. No shared-file edits, no `COUNTERPART_REV` change, no feature flags.

## RED / GREEN

- **RED** against the pinned counterpart (`COUNTERPART_REV` = `e02e93a`, current core `main`): both tests fail, e.g. `got: "add_vec: add_vec does not support float rasters yet; ..."` (op counted twice, expected once).
- **GREEN** against the core follow-up `libviprs/libviprs#359` (`fix/339b-op-name`): both tests pass.

Kept DRAFT until the core fix lands and `COUNTERPART_REV` is bumped to include it.

`[skip ci]` — local hooks are the gate.