### PR TITLE
test: land tier-2 review repro cells + bump COUNTERPART_REV to bd2e3f4

### DIFF
--- a/COUNTERPART_REV
+++ b/COUNTERPART_REV
@@ -28,4 +28,11 @@
 # s3 rename, pdfium rev-pin, ICC precision, de00_sharma sign fix, Nearest
 # premultiply skip, composite output-interpretation tag. The colour/resample/
 # composite review-repro cells below build and pass against this counterpart.
-e02e93a81ac2dd58cea45f004bc074dec7b23bd6
+#
+# Bumped again for the tier-2 review-follow-up fixes (PRs #357 hex dedup,
+# #358 draw(&op) ink guard + try_draw_mask float, #359 op-name single-prefix
+# + 32-bit-safe alloc tests, #360 DecodeLimits #[non_exhaustive] + typed
+# max-coord errors, #361 with_config compose-not-clobber). The draw-op /
+# engine-config / arithmetic-message review-repro cells build and pass
+# against this counterpart.
+bd2e3f4fc6c4c287607aa041d6da82a83b006486

--- a/tests/arithmetic_float_error_message.rs
+++ b/tests/arithmetic_float_error_message.rs
@@ -1,0 +1,74 @@
+//! Follow-up to libviprs/libviprs#339 (tracked by #350): the float-unsupported
+//! diagnostic must name the failing op *exactly once*.
+//!
+//! `ArithmeticError::FloatUnsupported` embeds the op name in its `Display`
+//! ("sub does not support float rasters yet ..."), and the panicking op forms
+//! route the error through `expect_arith`, which prefixes `"<op>: "` for the
+//! other, op-less error variants. For `FloatUnsupported` that prefix doubled
+//! the op name, producing "sub: sub does not support float rasters yet ...".
+//!
+//! These tests pin the diagnostic down to a single occurrence of the op name.
+//! They drive only the crate's public panicking surface (`Raster::sub`,
+//! `Raster::add_vec`) on a float raster, which the integer arithmetic ops
+//! reject, and inspect the caught panic payload. They add no shared-file edits
+//! and require no feature flags.
+
+use libviprs::{PixelFormat, Raster};
+
+/// A zeroed single-band 32-bit float raster. The mutating integer arithmetic
+/// ops (`sub`, `add_vec`, ...) reject float input, so these rasters exercise
+/// the `FloatUnsupported` diagnostic path.
+fn float_raster() -> Raster {
+    let fmt = PixelFormat::with_channels(1, 4).expect("FloatF32(1) is a valid format");
+    Raster::zeroed(2, 2, fmt).expect("2x2 float raster allocates")
+}
+
+/// Run `body`, expected to panic, and return its panic message as a `String`
+/// with the default hook silenced so the intentional panic does not spam test
+/// output (mirrors the core crate's own panic-containment tests).
+fn caught_panic_message(body: impl FnOnce() + std::panic::UnwindSafe) -> String {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let payload = std::panic::catch_unwind(body).expect_err("body was expected to panic");
+    std::panic::set_hook(prev);
+    payload
+        .downcast_ref::<String>()
+        .map(String::as_str)
+        .or_else(|| payload.downcast_ref::<&str>().copied())
+        .expect("panic payload is a string")
+        .to_owned()
+}
+
+/// The image-image `sub` on a float raster must panic with the op name once,
+/// not "sub: sub ...". Guards the `binary_map` -> `FloatUnsupported` path.
+#[test]
+fn sub_float_panic_names_op_exactly_once() {
+    let (a, b) = (float_raster(), float_raster());
+    let msg = caught_panic_message(move || {
+        let _ = a.sub(&b);
+    });
+    assert_eq!(
+        msg.matches("sub").count(),
+        1,
+        "sub() float-unsupported panic must name the op exactly once, got: {msg:?}"
+    );
+    assert!(
+        msg.contains("does not support float rasters yet"),
+        "unexpected panic message: {msg:?}"
+    );
+}
+
+/// The per-band `add_vec` on a float raster must likewise name the op once,
+/// not "add_vec: add_vec ...". Guards the `vec_map` -> `FloatUnsupported` path.
+#[test]
+fn add_vec_float_panic_names_op_exactly_once() {
+    let a = float_raster();
+    let msg = caught_panic_message(move || {
+        let _ = a.add_vec(&[1.0]);
+    });
+    assert_eq!(
+        msg.matches("add_vec").count(),
+        1,
+        "add_vec() float-unsupported panic must name the op exactly once, got: {msg:?}"
+    );
+}

--- a/tests/draw_op_path_validation.rs
+++ b/tests/draw_op_path_validation.rs
@@ -1,0 +1,142 @@
+//! Repro cells for the PR #335 review follow-ups tracked by issue #346.
+//!
+//! PR #335 added ink channel-count validation only to the `Raster::draw_*` /
+//! `try_draw_*` wrappers, but two equally-public routes stayed defective:
+//!
+//! 1. The generic [`Raster::draw`]`(&op)` entry point and the draw-op
+//!    constructors ([`Circle`], [`Rectangle`], [`Mask`], ...) are an *unguarded*
+//!    route to the exact #294 corruption: a wrong-width ink is cycled/truncated
+//!    verbatim through `put_pixel`, silently painting channels from the wrong
+//!    bytes (e.g. an `Rgba8` alpha band from the red byte). The infallible
+//!    `draw(&op)` path cannot return an error, so the intended contract is the
+//!    same documented panic the `draw_*` wrappers already raise.
+//! 2. The *fallible* [`Raster::try_draw_mask`] still panics on a 32-bit-float
+//!    raster (`RgbaF32` / `FloatF32`) even with correct-width ink, because
+//!    `Mask::apply` decodes samples as unsigned integers and hits the
+//!    float-unsupported panic arm. A fallible entry point must return a typed
+//!    `DrawError`, not unwind.
+//!
+//! Both cells are RED against the counterpart core pinned in `COUNTERPART_REV`
+//! and go GREEN once core validates ink on the op-application path and makes
+//! `try_draw_mask` fallible on float rasters. No libvips at runtime: these are
+//! pure in-memory contract checks over the public draw API.
+
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use libviprs::{Circle, Mask, PixelFormat, Raster, Rectangle};
+
+/// A single-band 8-bit stencil that is fully opaque, so the mask blend would
+/// actually touch every covered pixel (isolating the ink/format defect rather
+/// than a no-op mask).
+fn opaque_mask(w: u32, h: u32) -> Raster {
+    let mut m = Raster::zeroed(w, h, PixelFormat::Gray8).unwrap();
+    m.draw_rect_filled(&[255], 0, 0, w as i32, h as i32);
+    m
+}
+
+/// (1a) `Raster::draw(&Rectangle::filled(..))` (the `put_pixel` ink mechanism)
+/// with a 3-byte RGB ink on a 4-byte `Rgba8` pixel must NOT silently corrupt:
+/// the guarded wrappers reject this, so the raw op path must guard it too. The
+/// only contract available on the infallible `draw(&op)` entry point is a
+/// panic, so we assert the call unwinds instead of cycling the ink.
+///
+/// RED against unfixed core: the op cycles `[10,20,30]` across the 4-byte pixel
+/// (alpha painted from red) and returns normally, so no panic is observed.
+#[test]
+fn draw_op_rectangle_path_guards_wrong_width_ink() {
+    let panicked = catch_unwind(AssertUnwindSafe(|| {
+        let mut rgba = Raster::zeroed(4, 4, PixelFormat::Rgba8).unwrap();
+        rgba.draw(&Rectangle::filled(&[10, 20, 30], 0, 0, 2, 2));
+    }))
+    .is_err();
+    assert!(
+        panicked,
+        "draw(&Rectangle::filled) with a 3-byte ink on an Rgba8 raster must be \
+         guarded (documented panic), not cycle the ink and corrupt the alpha band"
+    );
+}
+
+/// (1b) The same defect through the *other* ink mechanism: `Circle` also paints
+/// via `put_pixel`, and directly constructing + applying it bypasses the
+/// wrapper's `check_ink`. A 1-byte ink on a 2-byte `Gray16` pixel would repeat
+/// the low byte; the raw path must guard it.
+///
+/// RED against unfixed core: no panic, the ink is cycled into both bytes.
+#[test]
+fn draw_op_circle_path_guards_wrong_width_ink() {
+    let panicked = catch_unwind(AssertUnwindSafe(|| {
+        let mut g16 = Raster::zeroed(4, 4, PixelFormat::Gray16).unwrap();
+        g16.draw(&Circle::filled(&[200], 2, 2, 1));
+    }))
+    .is_err();
+    assert!(
+        panicked,
+        "draw(&Circle::filled) with a 1-byte ink on a Gray16 raster must be \
+         guarded (documented panic), not repeat the low byte across both channels"
+    );
+}
+
+/// (1c) The `ink_pixel` mechanism (used by `Mask`) is the third unguarded
+/// route: `draw(&Mask::new(..))` with a wrong-width ink on a non-float raster
+/// materialises the ink by cycling it to the pixel width. The raw op path must
+/// guard it like the wrappers do.
+///
+/// RED against unfixed core: no panic; the 3-byte ink is cycled to 4 bytes and
+/// blended, corrupting the alpha band.
+#[test]
+fn draw_op_mask_path_guards_wrong_width_ink() {
+    let mask = opaque_mask(2, 2);
+    let panicked = catch_unwind(AssertUnwindSafe(|| {
+        let mut rgba = Raster::zeroed(4, 4, PixelFormat::Rgba8).unwrap();
+        rgba.draw(&Mask::new(&[10, 20, 30], &mask, 0, 0));
+    }))
+    .is_err();
+    assert!(
+        panicked,
+        "draw(&Mask::new) with a 3-byte ink on an Rgba8 raster must be guarded \
+         (documented panic), not cycle the ink through the blend"
+    );
+}
+
+/// (2) `try_draw_mask` is the *fallible* mask entry point, yet on a 32-bit-float
+/// raster it panics deep inside the unsigned-sample decode instead of returning
+/// `Err`. The ink here is correct width (4 x f32 = 16 bytes), so the only reason
+/// to fail is the unsupported float format, which must surface as a typed
+/// `DrawError` — never a panic — from a `try_` method.
+///
+/// RED against unfixed core: `Mask::apply` -> `channel_at` hits the float panic
+/// arm, unwinding the call rather than returning `Err`.
+#[test]
+fn try_draw_mask_returns_err_on_float_raster_instead_of_panicking() {
+    let mask = opaque_mask(2, 2);
+    // Correct-width ink for RgbaF32 (4 channels * 4 bytes) so ink length is not
+    // the reason for failure.
+    let ink: Vec<u8> = [0.0f32; 4].iter().flat_map(|f| f.to_ne_bytes()).collect();
+
+    // The call itself must not panic: run it under catch_unwind so a panicking
+    // (unfixed) core is reported as a clear assertion failure, and a fixed core
+    // yields a `Result` we can assert on.
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        let mut im = Raster::zeroed(2, 2, PixelFormat::RgbaF32).unwrap();
+        im.try_draw_mask(&ink, &mask, 0, 0)
+    }));
+
+    match outcome {
+        Err(_) => panic!(
+            "try_draw_mask panicked on an RgbaF32 raster; a fallible `try_` entry \
+             point must return a typed DrawError for an unsupported float format"
+        ),
+        Ok(Ok(())) => panic!(
+            "try_draw_mask unexpectedly succeeded on an RgbaF32 raster; the mask \
+             blend decodes unsigned samples and cannot support float targets"
+        ),
+        Ok(Err(err)) => {
+            // GREEN: a typed error naming the unsupported float format.
+            let msg = err.to_string().to_lowercase();
+            assert!(
+                msg.contains("float"),
+                "expected a typed float-unsupported DrawError, got: {err}"
+            );
+        }
+    }
+}

--- a/tests/engine_builder_config_compose.rs
+++ b/tests/engine_builder_config_compose.rs
@@ -1,0 +1,168 @@
+//! Regression coverage for issue #297 — `EngineBuilder::with_config` must
+//! compose with earlier fine-grained setters instead of clobbering them.
+//!
+//! The panel review (issue #270 → #297) confirmed that `with_config`
+//! historically overwrote **every** field it carries *unconditionally*, so a
+//! coarse `.with_config(cfg)` call silently undid an earlier fine-grained
+//! setter. The two headline traps are exactly the settings whose absence
+//! surfaces in production as a hung job or a bloated output:
+//!
+//!  * `.with_cancel(token).with_config(cfg)` — the config's `cancel` is `None`,
+//!    so the cooperative-cancellation token is dropped and the run can no
+//!    longer be stopped (an unkillable job).
+//!  * `.with_skip_blanks(true).with_config(cfg)` — the config's default
+//!    `skip_blanks` is `false`, so blank tiles are emitted after all (a
+//!    bloated output).
+//!
+//! These tests assert *observable engine behaviour* (a cancelled run actually
+//! cancels; skipped blanks actually vanish from the sink), not builder-field
+//! equality, so they survive the internal fill-if-unset refactor.
+//!
+//! In each clobber test two independent options are set — one via the coarse
+//! `with_config` setter, one via a fine-grained setter, in the clobbering
+//! order — and BOTH must survive on the built engine.
+
+use libviprs::sink::MemorySink;
+use libviprs::{
+    CancelToken, EngineBuilder, EngineConfig, EngineError, Layout, PixelFormat, PyramidPlanner,
+    Raster,
+};
+
+/// A `w`×`h` raster of a single uniform colour. Every extracted tile is
+/// therefore blank (exact uniformity), which is what `skip_blanks` acts on.
+fn solid(w: u32, h: u32, rgb: [u8; 3]) -> Raster {
+    let bpp = PixelFormat::Rgb8.bytes_per_pixel();
+    let mut data = vec![0u8; w as usize * h as usize * bpp];
+    for px in data.chunks_exact_mut(bpp) {
+        px.copy_from_slice(&rgb);
+    }
+    Raster::new(w, h, PixelFormat::Rgb8, data).unwrap()
+}
+
+/// All-white source. The default `background_rgb` is white too, so even the
+/// sub-tile-sized upper pyramid levels — which are padded up to the full tile
+/// with the background colour — stay uniformly white and thus blank. That
+/// makes `skip_blanks` drop *every* tile, giving a clean empty-sink signal.
+const WHITE: [u8; 3] = [255, 255, 255];
+
+fn plan_for(w: u32, h: u32, tile: u32) -> libviprs::planner::PyramidPlan {
+    PyramidPlanner::new(w, h, tile, 0, Layout::DeepZoom)
+        .unwrap()
+        .plan()
+}
+
+/// Trap #1 (hung / unkillable job): a `CancelToken` attached *before*
+/// `with_config` must survive the coarse call.
+///
+/// Two independent options are set in the clobbering order:
+///  * option A (fine setter): a *pre-cancelled* cancel token.
+///  * option B (coarse setter): a non-default `concurrency` carried on the
+///    config — the config legitimately still applies its own fields.
+///
+/// With the token retained, the monolithic engine polls it at the very first
+/// level boundary and returns `EngineError::Cancelled`. Under the old
+/// clobbering `with_config`, `self.cancel = config.cancel` (`None`) wiped the
+/// token, so the run instead completed successfully — the RED failure.
+#[test]
+fn cancel_token_set_before_with_config_survives() {
+    let src = solid(64, 64, [128, 128, 128]);
+    let plan = plan_for(64, 64, 32);
+
+    let token = CancelToken::new();
+    token.cancel();
+
+    // config carries option B (concurrency) but no cancel token of its own.
+    let cfg = EngineConfig::default().with_concurrency(2);
+
+    let result = EngineBuilder::new(&src, plan, MemorySink::new())
+        .with_cancel(token) // option A — fine-grained setter, set first
+        .with_config(cfg) // coarse setter carrying option B; its cancel is None
+        .run();
+
+    assert!(
+        matches!(result, Err(EngineError::Cancelled)),
+        "cancel token set before with_config must survive (option A); with_config \
+         silently cleared it, so the run completed instead of cancelling: {result:?}"
+    );
+}
+
+/// Trap #2 (bloated output): `.with_skip_blanks(true)` attached *before*
+/// `with_config` must survive the coarse call.
+///
+/// Two independent options are set in the clobbering order:
+///  * option A (fine setter): `skip_blanks = true`.
+///  * option B (coarse setter): a non-default `concurrency` on the config
+///    (its default `skip_blanks` is `false`).
+///
+/// The source is a single uniform colour, so every tile at every level is
+/// blank. With option A retained, all blank tiles are dropped and the sink is
+/// empty; the run also completing proves option B (the config's concurrency)
+/// was applied — BOTH survive. Under the old clobbering `with_config`,
+/// `self.skip_blanks = Some(config.skip_blanks)` reset it to `false`, so every
+/// blank tile was emitted — the RED failure.
+#[test]
+fn skip_blanks_set_before_with_config_survives() {
+    let src = solid(64, 64, WHITE);
+    let plan = plan_for(64, 64, 32);
+
+    // config carries option B (concurrency); its skip_blanks is the default false.
+    let cfg = EngineConfig::default().with_concurrency(2);
+
+    let (_result, sink) = EngineBuilder::new(&src, plan, MemorySink::new())
+        .with_skip_blanks(true) // option A — fine-grained setter, set first
+        .with_config(cfg) // coarse setter carrying option B
+        .run_collect()
+        .expect("run must succeed with the config's concurrency applied (option B)");
+
+    assert!(
+        sink.tiles().is_empty(),
+        "skip_blanks(true) set before with_config must survive (option A); with_config's \
+         default skip_blanks=false clobbered it and {} blank tiles were emitted",
+        sink.tiles().len()
+    );
+}
+
+/// Guard: a fine-grained setter applied *after* `with_config` still wins.
+/// This is the documented, intended precedence and the fill-if-unset fix must
+/// preserve it. Passes both before and after the fix.
+#[test]
+fn setter_after_with_config_still_wins() {
+    let src = solid(64, 64, WHITE);
+    let plan = plan_for(64, 64, 32);
+
+    let cfg = EngineConfig::default(); // skip_blanks = false
+
+    let (_result, sink) = EngineBuilder::new(&src, plan, MemorySink::new())
+        .with_config(cfg)
+        .with_skip_blanks(true) // applied after with_config -> wins
+        .run_collect()
+        .unwrap();
+
+    assert!(
+        sink.tiles().is_empty(),
+        "a setter applied after with_config must win; {} tiles were emitted",
+        sink.tiles().len()
+    );
+}
+
+/// Guard: on a clean builder (no prior fine setters) `with_config` still
+/// applies its own fields. Fill-if-unset fills them because every field is
+/// still unset. Passes both before and after the fix.
+#[test]
+fn with_config_applies_its_own_fields_on_clean_chain() {
+    let src = solid(64, 64, WHITE);
+    let plan = plan_for(64, 64, 32);
+
+    let cfg = EngineConfig::default().skip_blanks(true);
+
+    let (_result, sink) = EngineBuilder::new(&src, plan, MemorySink::new())
+        .with_config(cfg)
+        .run_collect()
+        .unwrap();
+
+    assert!(
+        sink.tiles().is_empty(),
+        "with_config's own skip_blanks(true) must apply on a clean chain; {} tiles were emitted",
+        sink.tiles().len()
+    );
+}


### PR DESCRIPTION
Lands the RED-first tier-2 review-repro tests (drafted in #108 draw(&op)/try_draw_mask, #109 with_config compose, #110 arithmetic float message), now GREEN against fixed core, and bumps COUNTERPART_REV to bd2e3f4 (core carrying #357/#358/#359/#360/#361). Local gate green (fmt+clippy variants+ported cells + 3 repros). Supersedes #108/#109/#110.