### PR TITLE
test(#113): migrate resume+dedupe/checksum tests to Overwrite; bump COUNTERPART_REV to 6583ad5

### DIFF
--- a/COUNTERPART_REV
+++ b/COUNTERPART_REV
@@ -35,4 +35,14 @@
 # max-coord errors, #361 with_config compose-not-clobber). The draw-op /
 # engine-config / arithmetic-message review-repro cells build and pass
 # against this counterpart.
-bd2e3f4fc6c4c287607aa041d6da82a83b006486
+#
+# Bumped for the resume/dedupe determinism fixes: #450 (#272 stopgap:
+# hard-error resume combined with dedupe/checksum until sink-side manifest
+# seeding lands) and #451 (#275: content-addressed deterministic dedupe
+# placement — finish() canonicalises the full-payload holder to the
+# coordinate-minimal occurrence). The three fresh-dir resume+dedupe/checksum
+# pipeline tests in phase3_validation_stress.rs are migrated Resume->Overwrite
+# (they never had prior state; the stopgap now refuses resume+dedupe/checksum),
+# and the new resume_dedupe_unsupported / dedupe_deterministic_layout cells
+# build and pass against this counterpart.
+6583ad58b77a15b916bbdd2f14c1a9a48af74b58

--- a/tests/phase3_validation_stress.rs
+++ b/tests/phase3_validation_stress.rs
@@ -876,7 +876,8 @@ fn multithreaded_stress_100_small_pyramids() {
 /// * `DedupeStrategy::Blanks` (canonicalise blank tiles)
 /// * `FailurePolicy::RetryThenFail` with 2 retries and 1 ms backoff
 /// * `BlankTileStrategy::PlaceholderWithTolerance { max_channel_delta: 3 }`
-/// * `ResumeMode::Resume` (no prior state, so behaves like a fresh run)
+/// * `ResumeMode::Overwrite` (fresh run; the #272 stopgap refuses
+///   resume combined with dedupe/checksum, and this test never had prior state)
 /// * `ManifestBuilder::new().with_checksums(Blake3)` for versioned manifest
 ///
 /// The run must complete without error.
@@ -904,7 +905,7 @@ fn full_phase3_pipeline_integration() {
                 .with_jitter(false),
         ));
 
-    run_resumable(&src, &plan, &sink, &cfg, ResumeMode::Resume).unwrap();
+    run_resumable(&src, &plan, &sink, &cfg, ResumeMode::Overwrite).unwrap();
 
     // Belt-and-braces: the manifest must exist and parse.
     let m_bytes = std::fs::read(root.path().join("pyramid.manifest.json")).unwrap();
@@ -952,7 +953,7 @@ fn verify_mode_on_output_of_full_pipeline() {
                 .with_jitter(false),
         ));
 
-    run_resumable(&src, &plan, &sink, &cfg, ResumeMode::Resume).unwrap();
+    run_resumable(&src, &plan, &sink, &cfg, ResumeMode::Overwrite).unwrap();
 
     let report = verify_output(&base).expect("verify_output must pass on full-pipeline output");
     assert!(
@@ -1012,7 +1013,7 @@ fn verify_mode_on_dedupe_blanks_with_default_emit_strategy() {
         cfg.blank_tile_strategy
     );
 
-    run_resumable(&src, &plan, &sink, &cfg, ResumeMode::Resume).unwrap();
+    run_resumable(&src, &plan, &sink, &cfg, ResumeMode::Overwrite).unwrap();
 
     // Non-vacuity guard: the whole point of this case is the dedupe-reference
     // path, so at least one 1-byte reference file must exist on disk. Without


### PR DESCRIPTION
## What

Counterpart update for the resume/dedupe determinism fixes now on core `main`:

- **#450** (#272 stopgap) — a resuming `ResumePolicy` combined with `DedupeStrategy != None` or `ChecksumMode != None` now returns a typed hard error (`EngineError::ResumeUnsupportedWith`), until resume can seed sink-side manifest state.
- **#451** (#275) — content-addressed deterministic dedupe placement; `finish()` canonicalises the full-payload holder to the coordinate-minimal occurrence.

## Changes

1. **Migrate 3 fresh-dir tests `Resume` → `Overwrite`** in `tests/phase3_validation_stress.rs` — `full_phase3_pipeline_integration`, `verify_mode_on_output_of_full_pipeline`, `verify_mode_on_dedupe_blanks_with_default_emit_strategy`. Each drove `ResumeMode::Resume` on a **fresh** dir purely to exercise the dedupe + checksum + manifest pipeline (the file's own comment: "no prior state, so behaves like a fresh run"); with the #272 stopgap that combo is now a typed hard error, so the tests failed on `.unwrap()`. `Overwrite` is semantically identical for a run with no prior state and preserves each test's intent (pipeline + `verify_output` assertions). The guard is **not** weakened — resume + dedupe/checksum stays unsupported until the #272 seeding fix lands. As a bonus these tests now also exercise the #451 canonicalize path (dedupe + `ChecksumMode::Verify` under `concurrency(4)`, asserting `verify_output` is clean).

2. **Bump `COUNTERPART_REV`** `bd2e3f4` → `6583ad5` (core `main` with #450 + #451).

The other `ResumeMode::Resume` sites in the file — the genuine crash-then-resume tests — are untouched.

## Verification

Full default suite green against core@`6583ad5`: `cargo fmt --check` clean, every test binary `0 failed`, the 3 migrated tests pass, `phase3_validation_stress` 11/11.

Closes #113.
