### PR TITLE
test: Wave-3 review-followup suites + phase3 s3_restart rewrite + COUNTERPART_REV -> 10db4b7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,12 @@ jobs:
       # Docker mirror. phase3_tracing reads only the checked-in canonical PNG,
       # so it needs no reference-suite fixtures.
       - run: cargo test --features "ported_tests tracing" --test phase3_tracing
+      # The object-store sink integration tests (phase3_object_store_sink, the
+      # S3 leg of phase3_validation_stress, and sink_object_store_stub_contract)
+      # are gated behind `object-store-sink`, so the default `cargo test` above
+      # compiles them out. Exercise the feature so they actually run in CI
+      # (issue #382).
+      - run: cargo test --features object-store-sink --test phase3_object_store_sink --test phase3_validation_stress --test sink_object_store_stub_contract
 
   test-pdfium:
     name: Integration Tests (pdfium)
@@ -92,16 +98,16 @@ jobs:
       fail-fast: false
       matrix:
         # One cell per non-default feature so a build/lint regression under a
-        # feature-gated module (the `s3` object-store sink, the `packfile`
-        # archive sink, the `tracing` span instrumentation) can no longer ship
-        # green just because the default harness never compiled that code.
-        # `-Dwarnings` (via RUSTFLAGS) means every gated test target is fully
-        # type-checked and linted here, not merely conditionally excluded.
+        # feature-gated module (the `object-store-sink` object-store sink, the
+        # `packfile` archive sink, the `tracing` span instrumentation) can no
+        # longer ship green just because the default harness never compiled that
+        # code. `-Dwarnings` (via RUSTFLAGS) means every gated test target is
+        # fully type-checked and linted here, not merely conditionally excluded.
         # `pdfium` has its own job above; `ported_tests` has the ported-tests
         # job above (it cannot join this `--all-targets` matrix because the
         # two deferred codec cells do not compile yet, so its clippy pass is
         # scoped to the green cells via tools/run_ported_cells.sh; issue #77).
-        feature: [s3, packfile, tracing]
+        feature: [object-store-sink, packfile, tracing]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/clone-counterpart

--- a/COUNTERPART_REV
+++ b/COUNTERPART_REV
@@ -45,4 +45,4 @@
 # (they never had prior state; the stopgap now refuses resume+dedupe/checksum),
 # and the new resume_dedupe_unsupported / dedupe_deterministic_layout cells
 # build and pass against this counterpart.
-8372fbb8169db84813550d247472f3141137ebc5
+10db4b71a4d95415e665d60d706d30de4f417029

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,15 @@ publish = false
 default = []
 pdfium = ["libviprs/pdfium", "dep:pdfium-render"]
 ported_tests = []
-s3 = ["libviprs/s3"]
+# Enables the Phase 3 object-store sink integration tests
+# (`tests/sink_object_store_stub_contract.rs` and the S3 leg of
+# `tests/phase3_validation_stress.rs`). Activates the `object-store-sink`
+# feature on the core `libviprs` crate so that `libviprs::sink::ObjectStoreSink`
+# and `libviprs::sink::ObjectStoreConfig` are exposed.
+object-store-sink = ["libviprs/object-store-sink"]
+# Deprecated alias for `object-store-sink`, retained so consumers that pinned the
+# old `s3` feature name keep building. Prefer `object-store-sink`.
+s3 = ["object-store-sink"]
 # Enables Phase 3 packfile archive-sink integration tests in
 # `tests/phase3_packfile.rs`. Activates the `packfile` feature on the
 # core `libviprs` crate so that `libviprs::sink::PackfileSink` and
@@ -66,11 +74,22 @@ proptest = "1"
 # Mirror the core crate's `pdfium-render` thread-safety fork. `[patch]`
 # tables apply only from the build-root manifest, so the pin in
 # `../libviprs/Cargo.toml` does not reach this crate when it is the
-# build root — this crate resolves the unpatched `pdfium-render 0.9.x`
-# from crates.io, whose `ThreadSafePdfiumBindings` acquires the pdfium
-# global mutex only once on `FPDF_InitLibrary` and bypasses it for
-# every other call, segfaulting under concurrent access to a shared
-# `Pdfium`. Keep this pin in lockstep with `../libviprs/Cargo.toml`;
-# drop both once the fork is upstreamed and released.
+# build root — without this override this crate would resolve the
+# unpatched `pdfium-render 0.9.x` from crates.io, whose
+# `ThreadSafePdfiumBindings` acquires the pdfium global mutex only once
+# on `FPDF_InitLibrary` and bypasses it for every other call,
+# segfaulting under concurrent access to a shared `Pdfium`.
+#
+# HONESTY / pin strength: this override pins the MUTABLE
+# `libviprs/integration` branch, NOT the immutable commit `rev` the core
+# crate (`../libviprs/Cargo.toml`) pins. A force-push or rebase of that
+# branch silently changes what this patch resolves on the next fetch, so
+# this override is not reproducible the way the core `rev` pin is — it
+# only tracks the branch head. Do not read "mirror" / "lockstep" above as
+# a claim of matching immutability: today the two differ, and converting
+# this patch to the same immutable `rev` (genuine lockstep) is deferred as
+# a follow-up under the fork-pinning epic #344. Until then, keep this
+# branch pointed at the fork the core `rev` was cut from, and drop both
+# once the fork is upstreamed and released.
 [patch.crates-io]
 pdfium-render = { git = "https://github.com/libviprs/pdfium-render.git", branch = "libviprs/integration" }

--- a/tests/cargo_metadata_pins.rs
+++ b/tests/cargo_metadata_pins.rs
@@ -1,0 +1,304 @@
+//! Cargo.toml metadata / provenance guards (issues #375, #376, #377, #378, #391).
+//!
+//! These pin the *documentation accuracy* of the core `libviprs/Cargo.toml`
+//! dependency-provenance block. They are not vips-differential: every finding
+//! is about a manifest comment or feature-alias claim that Cargo itself cannot
+//! express or enforce, so there is no image operation to diff against a libvips
+//! reference (vips_diff_applicable = false).
+//!
+//! The single behavioural fact Cargo *can* enforce — that the pdfium-render
+//! fork is pinned to an immutable commit `rev` rather than a bare, force-
+//! pushable `branch` — is asserted structurally against the manifest so a
+//! future edit cannot silently regress the pin back to a mutable branch.
+//!
+//! The core manifest is read from `../libviprs/Cargo.toml`, the same path this
+//! crate's `libviprs = { path = "../libviprs" }` dependency resolves from, so
+//! the test always inspects the exact core crate it compiles against. A second
+//! group guards this crate's own `Cargo.toml`: its `[patch.crates-io]` override
+//! mirrors the pdfium fork but pins the MUTABLE `libviprs/integration` branch
+//! rather than the core crate's immutable `rev`, so the comment there must not
+//! let "mirror"/"lockstep" imply matching immutability. Both are checked-in
+//! repository files needing no feature or native install, so this runs under
+//! the default `cargo test`.
+
+use std::path::PathBuf;
+
+/// Path to the core crate's manifest, resolved the same way as the
+/// `path = "../libviprs"` dependency edge in this crate's own `Cargo.toml`.
+fn core_manifest_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../libviprs/Cargo.toml")
+}
+
+fn read_core_manifest() -> String {
+    let p = core_manifest_path();
+    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("failed to read {}: {e}", p.display()))
+}
+
+/// Path to this (tests) crate's own manifest, which carries the
+/// `[patch.crates-io]` override that mirrors the core crate's pdfium fork.
+fn tests_manifest_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml")
+}
+
+fn read_tests_manifest() -> String {
+    let p = tests_manifest_path();
+    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("failed to read {}: {e}", p.display()))
+}
+
+/// Extract the `[patch.crates-io]` pdfium-render override line from this
+/// crate's manifest — the git-sourced declaration, not the crates-io
+/// `[dependencies]` entry of the same name.
+fn tests_pdfium_patch_line(manifest: &str) -> String {
+    for line in manifest.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('#') {
+            continue;
+        }
+        if trimmed.starts_with("pdfium-render") && trimmed.contains("git") {
+            return trimmed.to_string();
+        }
+    }
+    String::new()
+}
+
+/// Collapse every `#`-comment line in the manifest into one whitespace-
+/// normalised string. Comment bodies wrap across many physical lines with a
+/// `# ` prefix; folding them lets a single substring check match a phrase that
+/// spans line breaks without being brittle about exact wrapping.
+fn folded_comments(manifest: &str) -> String {
+    let mut words: Vec<&str> = Vec::new();
+    for line in manifest.lines() {
+        let trimmed = line.trim_start();
+        if let Some(body) = trimmed.strip_prefix('#') {
+            words.extend(body.split_whitespace());
+        }
+    }
+    words.join(" ")
+}
+
+/// Extract the single-line `pdfium-render = { ... }` workspace-dependency
+/// declaration (the actual key/value line, not the surrounding comments).
+fn pdfium_dep_line(manifest: &str) -> String {
+    let mut in_dep = false;
+    let mut collected = String::new();
+    for line in manifest.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('#') {
+            continue;
+        }
+        if !in_dep {
+            if trimmed.starts_with("pdfium-render") && trimmed.contains('=') {
+                in_dep = true;
+                collected.push_str(trimmed);
+            }
+        } else {
+            collected.push(' ');
+            collected.push_str(trimmed);
+        }
+        // The declaration closes on the line carrying the final `}`.
+        if in_dep && trimmed.contains('}') {
+            break;
+        }
+    }
+    assert!(
+        !collected.is_empty(),
+        "no `pdfium-render = {{ ... }}` dependency line found in core Cargo.toml"
+    );
+    collected
+}
+
+/// A 40-char lowercase hex commit SHA, e.g. the value of a git `rev` pin.
+fn is_full_commit_sha(v: &str) -> bool {
+    v.len() == 40 && v.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Pull the `rev = "..."` value out of the pdfium dependency line.
+fn pdfium_rev(dep_line: &str) -> Option<String> {
+    let after = dep_line.split("rev").nth(1)?;
+    // Skip `=`, whitespace and the opening quote, then read to the close quote.
+    let after = after.trim_start().strip_prefix('=')?.trim_start();
+    let after = after.strip_prefix('"')?;
+    let end = after.find('"')?;
+    Some(after[..end].to_string())
+}
+
+// ---------------------------------------------------------------------------
+// #375 — the pin must be an immutable rev, and the comment must state the
+// reachability precondition rather than claim unconditional immutability.
+// ---------------------------------------------------------------------------
+
+/// The fork dependency is pinned to a full immutable commit `rev`, never a
+/// bare `branch`. A `branch` pin re-resolves on every fetch and lets a
+/// force-push silently swap the dependency, so a regression to `branch = ...`
+/// must fail this guard.
+#[test]
+fn pdfium_dep_is_pinned_to_immutable_rev() {
+    let manifest = read_core_manifest();
+    let dep = pdfium_dep_line(&manifest);
+
+    assert!(
+        !dep.contains("branch"),
+        "pdfium-render must not be pinned to a mutable `branch`; found: {dep}"
+    );
+    let rev = pdfium_rev(&dep)
+        .unwrap_or_else(|| panic!("pdfium-render dependency has no `rev = \"...\"` pin: {dep}"));
+    assert!(
+        is_full_commit_sha(&rev),
+        "pdfium-render `rev` must be a full 40-char commit SHA (immutable pin), got {rev:?}"
+    );
+}
+
+/// The pin comment must not oversell durability: it has to state the
+/// reachability precondition (GitHub only serves a bare SHA that stays
+/// reachable from an advertised ref), so a cold-cache fetch failure after the
+/// branch is force-pushed past the commit is documented, not a surprise.
+#[test]
+fn pdfium_pin_comment_states_reachability_precondition() {
+    let comments = folded_comments(&read_core_manifest()).to_ascii_lowercase();
+    assert!(
+        comments.contains("reachable"),
+        "the pdfium pin comment must state the reachability precondition \
+         (the immutable-rev pin only holds while the commit stays reachable \
+         from an advertised ref) instead of claiming unconditional immutability"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #376 / #378 — the lead / top-of-block provenance comment must not claim the
+// dependency is "pinned to its libviprs/integration branch", which the rev pin
+// makes false. The branch may only appear as named provenance.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pdfium_provenance_comment_does_not_claim_branch_pin() {
+    let comments = folded_comments(&read_core_manifest());
+    assert!(
+        !comments.contains("pinned to its `libviprs/integration` branch"),
+        "the provenance comment must not claim the dependency is `pinned to its \
+         libviprs/integration branch`; the actual pin is an immutable rev and \
+         the branch is only provenance (#376/#378)"
+    );
+    // The branch must still be documented as provenance so the pin's origin is
+    // traceable when advancing the fork.
+    assert!(
+        comments.contains("provenance") && comments.contains("libviprs/integration"),
+        "the comment must still name `libviprs/integration` as the pin's provenance"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #377 — the descoped published-crate soundness leg must not point at the
+// already-closed issue #149 as its live tracker; it must name the descoping
+// and route renewed work to an open tracker.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pdfium_soundness_divergence_names_descope_and_open_tracker() {
+    let comments = folded_comments(&read_core_manifest());
+    assert!(
+        comments.contains("descoped"),
+        "the comment must state that PR #333 descoped the published-crate \
+         soundness leg (#377), not silently defer it to a closed tracker"
+    );
+    assert!(
+        comments.contains("#344"),
+        "renewed published-crate soundness work must be routed to the open \
+         follow-up epic #344, since #149 is closed (#377)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #391 — the `s3` feature is deprecated only by comment; Cargo emits no
+// warning. The comment must make that absence of a build-time signal explicit
+// and unambiguously point migrators at `object-store-sink`.
+// ---------------------------------------------------------------------------
+
+/// Locate the comment block immediately preceding the `s3 = [...]` feature.
+fn s3_feature_comment(manifest: &str) -> String {
+    let mut block: Vec<&str> = Vec::new();
+    for line in manifest.lines() {
+        let trimmed = line.trim_start();
+        if let Some(body) = trimmed.strip_prefix('#') {
+            block.push(body.trim());
+        } else if trimmed.starts_with("s3") && trimmed.contains('=') {
+            // The accumulated run of comment lines directly above the `s3`
+            // feature line is its documentation.
+            return block.join(" ");
+        } else if !trimmed.is_empty() {
+            // Any non-comment, non-`s3` line breaks the contiguous comment run.
+            block.clear();
+        }
+    }
+    String::new()
+}
+
+#[test]
+fn s3_alias_comment_states_no_build_time_signal() {
+    let manifest = read_core_manifest();
+    let comment = s3_feature_comment(&manifest).to_ascii_lowercase();
+    assert!(
+        !comment.is_empty(),
+        "the `s3` feature must carry an explanatory comment"
+    );
+    assert!(
+        comment.contains("object-store-sink"),
+        "the `s3` deprecation comment must point migrators at `object-store-sink`"
+    );
+    assert!(
+        comment.contains("no build-time warning")
+            || comment.contains("emits no")
+            || comment.contains("cargo has no mechanism"),
+        "the `s3` comment must make explicit that Cargo emits no deprecation \
+         warning for the feature alias, so consumers get no automated signal (#391)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// tests-crate `[patch.crates-io]` honesty — this crate's own override pins the
+// MUTABLE `libviprs/integration` branch, not the core crate's immutable `rev`.
+// The comment must state that plainly (so "mirror"/"lockstep" is not read as a
+// claim of matching immutability) and route the immutable-rev follow-up to an
+// open tracker, mirroring the honesty guards applied to the core manifest.
+// ---------------------------------------------------------------------------
+
+/// The override really is a `branch` pin today — guard that actual state so the
+/// prose below is checked against reality, not an aspirational description.
+#[test]
+fn tests_pdfium_patch_is_a_branch_pin() {
+    let manifest = read_tests_manifest();
+    let patch = tests_pdfium_patch_line(&manifest);
+    assert!(
+        !patch.is_empty(),
+        "no git-sourced `pdfium-render` `[patch.crates-io]` override found in tests Cargo.toml"
+    );
+    assert!(
+        patch.contains("branch"),
+        "the tests `[patch.crates-io]` override is expected to be a `branch` pin; \
+         if it was upgraded to an immutable `rev`, update the honesty comment and \
+         this guard together. Found: {patch}"
+    );
+}
+
+/// The patch comment must not let "mirror"/"lockstep" imply the tests override
+/// shares the core crate's immutable pin: it has to state the override is a
+/// MUTABLE branch pin and route the immutable-rev upgrade to the open #344
+/// follow-up.
+#[test]
+fn tests_pdfium_patch_comment_admits_mutable_branch_and_routes_follow_up() {
+    let comments = folded_comments(&read_tests_manifest()).to_ascii_lowercase();
+    assert!(
+        comments.contains("mutable"),
+        "the tests `[patch.crates-io]` comment must state that it pins a MUTABLE \
+         branch (not the core crate's immutable rev)"
+    );
+    assert!(
+        comments.contains("immutable") && comments.contains("rev"),
+        "the tests patch comment must contrast the mutable branch pin against the \
+         core crate's immutable `rev`, so the divergence is explicit"
+    );
+    assert!(
+        comments.contains("#344"),
+        "the immutable-rev upgrade for the tests patch must be routed to the open \
+         fork-pinning follow-up epic #344"
+    );
+}

--- a/tests/feature_rename_docs_present.rs
+++ b/tests/feature_rename_docs_present.rs
@@ -1,0 +1,192 @@
+//! Documentation guards for the `s3` -> `object-store-sink` cargo-feature
+//! rename (libviprs#385/#386/#387/#388/#389/#390).
+//!
+//! The feature that gates the `sink_object_store` module (`ObjectStoreSink`)
+//! was renamed from `s3` to `object-store-sink`, with `s3` retained as a
+//! deprecated alias (`s3 = ["object-store-sink"]` in `Cargo.toml`). The code
+//! already gates on the new name; these guards pin the *documentation* to the
+//! same story so the README, the crate-root "Feature flags" rustdoc, and the
+//! CHANGELOG stop steering users to the deprecated alias.
+//!
+//! This is a pure documentation/packaging change: there is no pixel behaviour
+//! to express as a vips differential, so — in the style of
+//! `colour_de00_dedup_reference.rs`, `counterpart_pinning.rs`, and
+//! `fixture_audit.rs` — the guards assert on the core crate's source text
+//! directly. The one behavioural anchor is the `Cargo.toml` `[features]`
+//! table: both feature names must still gate the same module, which
+//! `both_feature_names_gate_the_object_store_sink` pins.
+
+use std::path::PathBuf;
+
+/// Absolute path to a file in the core `libviprs` crate (the path-dep this
+/// test crate compiles against).
+fn core_path(rel: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../libviprs")
+        .join(rel)
+}
+
+/// Read a core-crate file, lowercase it, and collapse all runs of whitespace
+/// to a single space so substring checks are robust to line wrapping.
+fn normalised(rel: &str) -> String {
+    let path = core_path(rel);
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+    raw.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+/// Extract only the crate-root inner-doc (`//!`) lines from `src/lib.rs`,
+/// with the `//!` prefix stripped, joined and whitespace-collapsed. This
+/// isolates the "Feature flags" rustdoc prose from the `#[cfg(...)]` code
+/// gates (which already name `object-store-sink`), so the assertions below
+/// speak to the documentation a reader sees, not the compiled gate.
+fn lib_rustdoc_normalised() -> String {
+    let path = core_path("src/lib.rs");
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+    let doc: String = raw
+        .lines()
+        .filter_map(|line| line.trim_start().strip_prefix("//!"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    doc.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+/// Slice the `## [Unreleased]` section out of `CHANGELOG.md` (up to the next
+/// released-version heading), whitespace-collapsed and lowercased, so the
+/// rename entry is asserted in the *unreleased* section specifically.
+fn changelog_unreleased_normalised() -> String {
+    let path = core_path("CHANGELOG.md");
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+    let mut in_unreleased = false;
+    let mut section = String::new();
+    for line in raw.lines() {
+        let t = line.trim_start();
+        if t.starts_with("## [Unreleased]") {
+            in_unreleased = true;
+            continue;
+        }
+        if in_unreleased && t.starts_with("## [") {
+            break; // reached the first released version heading
+        }
+        if in_unreleased {
+            section.push_str(line);
+            section.push(' ');
+        }
+    }
+    assert!(
+        !section.trim().is_empty(),
+        "CHANGELOG.md has no non-empty [Unreleased] section"
+    );
+    section
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+/// #385/#389: the README must document `object-store-sink` as the canonical
+/// feature name and present `s3` only as a deprecated alias — not as the sole
+/// / canonical feature name it historically advertised.
+#[test]
+fn readme_documents_object_store_sink_as_canonical() {
+    let readme = normalised("README.md");
+    assert!(
+        readme.contains("object-store-sink"),
+        "README does not document the canonical `object-store-sink` feature (#385/#389)"
+    );
+    assert!(
+        readme.contains("deprecated alias"),
+        "README does not mark `s3` as a deprecated alias of `object-store-sink` (#385/#389)"
+    );
+    // The module table must gate `sink_object_store` on the new name.
+    assert!(
+        readme.contains("gated by `object-store-sink`"),
+        "README module table still gates `sink_object_store` on the old feature name (#389)"
+    );
+}
+
+/// #386/#388: the crate-root "Feature flags" rustdoc must advertise
+/// `object-store-sink` as the gating feature and mention `s3` only as a
+/// deprecated alias, instead of steering users to the deprecated name.
+#[test]
+fn lib_rs_feature_flags_rustdoc_advertises_object_store_sink() {
+    let doc = lib_rustdoc_normalised();
+    assert!(
+        doc.contains("## feature flags"),
+        "src/lib.rs crate-root rustdoc no longer has a Feature flags section"
+    );
+    assert!(
+        doc.contains("`object-store-sink`"),
+        "Feature flags rustdoc does not advertise the canonical `object-store-sink` gate (#386/#388)"
+    );
+    assert!(
+        doc.contains("deprecated alias"),
+        "Feature flags rustdoc does not mark `s3` as a deprecated alias (#386/#388)"
+    );
+}
+
+/// #387/#390: the CHANGELOG must record the `s3` -> `object-store-sink` rename
+/// and the `s3` deprecation in the [Unreleased] section, as the crate declares
+/// adherence to Keep a Changelog and SemVer.
+#[test]
+fn changelog_records_s3_rename_and_deprecation() {
+    let unreleased = changelog_unreleased_normalised();
+    assert!(
+        unreleased.contains("object-store-sink"),
+        "CHANGELOG [Unreleased] does not mention the new `object-store-sink` feature (#387/#390)"
+    );
+    assert!(
+        unreleased.contains("`s3`") || unreleased.contains(" s3 "),
+        "CHANGELOG [Unreleased] does not mention the old `s3` feature name (#387/#390)"
+    );
+    assert!(
+        unreleased.contains("renamed"),
+        "CHANGELOG [Unreleased] does not record the feature *rename* (#387/#390)"
+    );
+    assert!(
+        unreleased.contains("deprecated"),
+        "CHANGELOG [Unreleased] does not record the `s3` deprecation (#387/#390)"
+    );
+}
+
+/// Behavioural anchor: both feature names must still gate the same
+/// `sink_object_store` module. `s3` is kept as a pure alias
+/// (`s3 = ["object-store-sink"]`), so a consumer pinned to either name keeps
+/// building. This is the one guard that is not merely prose — it pins the
+/// packaging contract in `Cargo.toml`.
+#[test]
+fn both_feature_names_gate_the_object_store_sink() {
+    let path = core_path("Cargo.toml");
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+    // Canonical feature exists.
+    assert!(
+        raw.lines()
+            .any(|l| l.trim_start().starts_with("object-store-sink = [")),
+        "Cargo.toml has no `object-store-sink` feature"
+    );
+    // `s3` survives only as an alias that pulls in `object-store-sink`.
+    let s3_line = raw
+        .lines()
+        .find(|l| l.trim_start().starts_with("s3 = ["))
+        .expect("Cargo.toml has no `s3` alias feature");
+    assert!(
+        s3_line.contains("object-store-sink"),
+        "`s3` feature must alias `object-store-sink` (s3 = [\"object-store-sink\"]), got: {s3_line}"
+    );
+
+    // Sanity: the gated module source is present in the core crate, so the
+    // feature actually has something to gate.
+    assert!(
+        core_path("src/sink_object_store.rs").exists(),
+        "core crate is missing src/sink_object_store.rs"
+    );
+}

--- a/tests/phase3_object_store_sink.rs
+++ b/tests/phase3_object_store_sink.rs
@@ -1,13 +1,15 @@
 //! Integration tests for the Phase 3 S3-compatible object-storage sink.
 //!
-//! These tests target the *planned* API introduced under the `s3` feature flag:
+//! These tests target the object-storage sink API introduced under the
+//! `object-store-sink` feature flag (with `s3` kept as a deprecated alias):
 //!
 //! ```ignore
 //! use libviprs::sink::{ObjectStoreSink, ObjectStoreConfig, RetryPolicy, ObjectStore};
 //! ```
 //!
-//! The whole file is gated behind `#[cfg(feature = "s3")]` so that builds that
-//! don't enable the feature simply don't compile this file. When the feature
+//! The whole file is gated behind `#[cfg(feature = "object-store-sink")]` so
+//! that builds that don't enable the feature simply don't compile it. When the
+//! feature
 //! *is* enabled and the planned API does not yet exist, compilation must fail
 //! — that is the TDD signal the implementation still needs to be written.
 //!
@@ -23,7 +25,7 @@
 //! `tempfile::tempdir()` for any filesystem needs, and a short docblock on
 //! every `#[test]` explaining what it proves.
 
-#![cfg(feature = "s3")]
+#![cfg(feature = "object-store-sink")]
 
 use libviprs::sink::{ObjectStore, ObjectStoreConfig, ObjectStoreSink};
 use libviprs::{

--- a/tests/phase3_validation_stress.rs
+++ b/tests/phase3_validation_stress.rs
@@ -1103,55 +1103,104 @@ fn checkpoint_written_frequently_enough_to_bound_rework() {
 }
 
 // =============================================================================
-// 10. s3_restart_resumes (feature-gated; env-gated)
+// 10. s3_restart_resumes (feature-gated)
 // =============================================================================
 
-/// End-to-end Resume against a real S3 endpoint. Skipped unless both the
-/// `s3` feature is enabled *and* `LIBVIPRS_TEST_S3_ENDPOINT` is set in
-/// the environment. Mirrors test 1 but across a network sink.
-#[cfg(feature = "s3")]
+/// In-memory object-store double for the restart-resume test. Shared across
+/// both sink constructions via a cloned `Arc`, so it models an object store
+/// whose objects survive the first run's crash.
+#[cfg(feature = "object-store-sink")]
+#[derive(Default)]
+struct RestartRecordingStore {
+    puts: Mutex<Vec<(String, Vec<u8>)>>,
+}
+
+#[cfg(feature = "object-store-sink")]
+impl RestartRecordingStore {
+    fn keys(&self) -> Vec<String> {
+        self.puts
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(k, _)| k.clone())
+            .collect()
+    }
+}
+
+#[cfg(feature = "object-store-sink")]
+impl libviprs::sink::ObjectStore for RestartRecordingStore {
+    fn put(&self, key: &str, bytes: &[u8]) -> Result<(), SinkError> {
+        self.puts
+            .lock()
+            .unwrap()
+            .push((key.to_string(), bytes.to_vec()));
+        Ok(())
+    }
+}
+
+/// Crash-then-resume against the object-store sink, verified honestly.
+///
+/// This was previously a permanently-skipped, latently-broken test (#381): it
+/// built `ObjectStoreSink::new` from a config with **no** injected backend
+/// (which errors, so `.unwrap()` would have panicked) and asserted over
+/// `list_objects()`, an unimplemented stub. It only stayed green by
+/// early-returning whenever `LIBVIPRS_TEST_S3_ENDPOINT` was unset, giving false
+/// confidence in resume coverage across an object store.
+///
+/// This version runs unconditionally: it injects a shared in-memory backend
+/// (modelling a bucket that survives the crash), crashes the first run
+/// mid-upload, resumes to completion against the same backend + checkpoint, and
+/// verifies the backend captured an object for every filesystem-reference tile.
+/// Because the [`libviprs::sink::ObjectStore`] trait cannot enumerate, it
+/// inspects the injected backend directly instead of the unsupported
+/// `list_objects()` — and pins that `list_objects()` fails loud rather than
+/// masquerading the populated backend as an empty set.
+#[cfg(feature = "object-store-sink")]
 #[test]
 fn s3_restart_resumes() {
-    use libviprs::sink::{ObjectStoreConfig, ObjectStoreSink};
-    use std::time::SystemTime;
-
-    let Ok(endpoint) = std::env::var("LIBVIPRS_TEST_S3_ENDPOINT") else {
-        eprintln!("skipping s3_restart_resumes: LIBVIPRS_TEST_S3_ENDPOINT unset");
-        return;
-    };
-    let bucket =
-        std::env::var("LIBVIPRS_TEST_S3_BUCKET").unwrap_or_else(|_| "libviprs-test".to_string());
-    let access_key =
-        std::env::var("LIBVIPRS_TEST_S3_ACCESS_KEY").unwrap_or_else(|_| "minio".to_string());
-    let secret_key =
-        std::env::var("LIBVIPRS_TEST_S3_SECRET_KEY").unwrap_or_else(|_| "minio123".to_string());
+    use libviprs::sink::{ObjectStore, ObjectStoreConfig, ObjectStoreSink};
 
     let root = tempfile::tempdir().unwrap();
     let src = whitespace_heavy_raster(512, 384);
     let plan = standard_planner(512, 384, 128);
 
-    // Reference filesystem run for comparison.
+    // Reference filesystem run: same plan, so the same tile coordinate set.
+    // FsSink lays tiles out as `<base>/<level>/<x>_<y>.png`; we key the
+    // comparison on the `<level>/<x>_<y>.png` tail so it is independent of the
+    // differing prefix/layout roots between the two sinks.
     let ref_dir = tempfile::tempdir_in(root.path()).unwrap();
-    let ref_base = run_golden_pyramid(
+    let _ref_base = run_golden_pyramid(
         &src,
         &plan,
         ref_dir.path(),
         TileFormat::Png,
         &EngineConfig::default().with_concurrency(4),
     );
+    let expected: HashSet<String> = list_files_relative(ref_dir.path())
+        .into_iter()
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("png"))
+        .filter_map(|p| {
+            // Drop the leading `<base>/` component, keeping `<level>/<x>_<y>.png`.
+            let mut comps = p.components();
+            comps.next();
+            let tail = comps.as_path();
+            (!tail.as_os_str().is_empty()).then(|| tail.to_string_lossy().into_owned())
+        })
+        .collect();
+    assert!(!expected.is_empty(), "reference run produced no tiles");
 
-    // Unique prefix per test run to avoid cross-run interference.
-    let prefix = format!(
-        "libviprs-phase3-{}",
-        SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap()
-            .as_millis()
-    );
-
-    let cfg = ObjectStoreConfig::s3(&endpoint, &bucket)
-        .with_access_key(&access_key, &secret_key)
-        .with_key_prefix(&prefix);
+    // Shared object-store backend + checkpoint dir: both survive the crash so
+    // the second run resumes instead of restarting from scratch.
+    let backend = Arc::new(RestartRecordingStore::default());
+    let checkpoint = tempfile::tempdir_in(root.path()).unwrap();
+    let cfg = ObjectStoreConfig::s3("http://object-store.invalid", "libviprs-test")
+        .with_key_prefix("libviprs-phase3")
+        .with_image_name("pyramid")
+        .with_object_store(backend.clone() as Arc<dyn ObjectStore>);
+    let engine = EngineConfig::default()
+        .with_concurrency(4)
+        .with_checkpoint_every(1)
+        .with_checkpoint_root(checkpoint.path().to_path_buf());
 
     // First run: crash mid-upload.
     let inner = ObjectStoreSink::new(cfg.clone(), plan.clone(), TileFormat::Png).unwrap();
@@ -1160,40 +1209,30 @@ fn s3_restart_resumes() {
         PanicTrigger::NthWrite(plan.total_tile_count() as usize / 3),
     );
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        run_resumable(
-            &src,
-            &plan,
-            &panicking,
-            &EngineConfig::default().with_concurrency(4),
-            ResumeMode::Resume,
-        )
+        run_resumable(&src, &plan, &panicking, &engine, ResumeMode::Resume)
     }));
 
-    // Second run: resume and finish.
+    // Second run: resume and finish against the same backend + checkpoint.
     let resume_sink = ObjectStoreSink::new(cfg.clone(), plan.clone(), TileFormat::Png).unwrap();
-    run_resumable(
-        &src,
-        &plan,
-        &resume_sink,
-        &EngineConfig::default().with_concurrency(4),
-        ResumeMode::Resume,
-    )
-    .unwrap();
+    run_resumable(&src, &plan, &resume_sink, &engine, ResumeMode::Resume).unwrap();
 
-    // Server-side listing must match the filesystem reference. We compare
-    // only the set of relative keys — byte equality for S3 objects is
-    // covered by the checksum-verifying tests in `phase3_object_store_sink`.
-    let listed: HashSet<String> = resume_sink.list_objects().unwrap().into_iter().collect();
-    let expected: HashSet<String> = list_files_relative(&ref_base)
-        .into_iter()
-        .map(|p| p.to_string_lossy().into_owned())
-        .collect();
-
-    // Every reference file name should show up as an object key suffix.
+    // Inspect the injected backend directly (the sink cannot enumerate). Every
+    // filesystem-reference tile must have a matching uploaded object key.
+    let uploaded: HashSet<String> = backend.keys().into_iter().collect();
     for key in &expected {
         assert!(
-            listed.iter().any(|k| k.ends_with(key)),
-            "expected S3 object for reference file {key}"
+            uploaded.iter().any(|k| k.ends_with(key)),
+            "expected an uploaded object for reference tile {key}"
         );
     }
+
+    // The sink still cannot enumerate server state: list_objects must fail loud
+    // rather than masquerade the populated backend as an empty set.
+    let err = resume_sink
+        .list_objects()
+        .expect_err("list_objects must not report success while unimplemented");
+    assert!(
+        matches!(err, SinkError::Unsupported(_)),
+        "expected SinkError::Unsupported, got {err:?}"
+    );
 }

--- a/tests/sink_object_store_stub_contract.rs
+++ b/tests/sink_object_store_stub_contract.rs
@@ -1,0 +1,121 @@
+//! Integration contract for the `ObjectStoreSink` LIST stub.
+//!
+//! `ObjectStoreSink::list_objects()` is an as-yet-unbuilt object-store
+//! transport: the injectable [`ObjectStore`] trait exposes only `put`, so the
+//! sink structurally cannot enumerate what it uploaded. The historical stub
+//! returned `Ok(Vec::new())` unconditionally — a silent-wrong-answer footgun
+//! (issues #379/#384): a caller diffing server-side keys against a filesystem
+//! reference could not tell "empty because nothing was uploaded" apart from
+//! "empty because the stub ignores server state", so the diff either passed
+//! falsely or failed spuriously.
+//!
+//! This test pins the *honest* contract: after uploading real tiles through the
+//! sink (a recording backend captures every `put`), `list_objects()` must fail
+//! loud with [`SinkError::Unsupported`] rather than masquerade the populated
+//! backend as an empty list. It also confirms the sink genuinely uploads, so
+//! the empty-listing behaviour cannot be mistaken for the sink doing nothing.
+//!
+//! This is a stub-*contract* assertion, not a pixel-level golden: there is no
+//! image output to diff against a vips reference, so no vips fixture is used.
+//! Gated behind the `object-store-sink` feature (with `s3` kept as a deprecated
+//! alias) since the module it exercises is feature-gated in the core crate.
+
+#![cfg(feature = "object-store-sink")]
+
+use std::sync::{Arc, Mutex};
+
+use libviprs::sink::{ObjectStore, ObjectStoreConfig, ObjectStoreSink};
+use libviprs::{
+    Layout, PixelFormat, PyramidPlanner, Raster, SinkError, Tile, TileCoord, TileFormat, TileSink,
+};
+
+/// A backend that records every `(key, bytes)` handed to `put`, so the test can
+/// prove the sink actually uploaded and then confront that with what
+/// `list_objects` reports.
+#[derive(Default)]
+struct RecordingStore {
+    puts: Mutex<Vec<(String, Vec<u8>)>>,
+}
+
+impl RecordingStore {
+    fn keys(&self) -> Vec<String> {
+        self.puts
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(k, _)| k.clone())
+            .collect()
+    }
+}
+
+impl ObjectStore for RecordingStore {
+    fn put(&self, key: &str, bytes: &[u8]) -> Result<(), SinkError> {
+        self.puts
+            .lock()
+            .unwrap()
+            .push((key.to_string(), bytes.to_vec()));
+        Ok(())
+    }
+}
+
+/// Upload several tiles through the sink, then assert `list_objects` fails loud
+/// with `SinkError::Unsupported` — even though the backend really did record
+/// those uploads. Locks in the "even when objects exist" half of the contract
+/// that the old vacuous `list_objects() == []` test never exercised.
+#[test]
+fn list_objects_is_unsupported_even_after_writes() {
+    let store = Arc::new(RecordingStore::default());
+    let cfg = ObjectStoreConfig::s3("http://localhost:9000", "bucket")
+        .with_key_prefix("run-1")
+        .with_image_name("contract")
+        .with_object_store(store.clone());
+
+    let plan = PyramidPlanner::new(512, 512, 256, 0, Layout::DeepZoom)
+        .expect("planner params are valid")
+        .plan();
+    let sink = ObjectStoreSink::new(cfg, plan.clone(), TileFormat::Png)
+        .expect("sink constructs once a backend is injected");
+
+    // Drive every tile of the pyramid through the sink so the backend ends up
+    // holding real uploaded objects (more than one, across levels).
+    let mut uploaded = 0usize;
+    for level in &plan.levels {
+        for row in 0..level.rows {
+            for col in 0..level.cols {
+                let tile = Tile {
+                    coord: TileCoord::new(level.level, col, row),
+                    raster: Raster::zeroed(256, 256, PixelFormat::Rgb8).unwrap(),
+                    blank: false,
+                };
+                sink.write_tile(&tile).expect("tile upload succeeds");
+                uploaded += 1;
+            }
+        }
+    }
+    assert!(uploaded > 1, "test must drive more than one tile");
+
+    // The backend really captured every upload...
+    let recorded = store.keys();
+    assert_eq!(
+        recorded.len(),
+        uploaded,
+        "backend must record one put per uploaded tile, got {recorded:?}"
+    );
+
+    // ...yet the sink cannot enumerate them: the stub fails loud instead of
+    // returning a misleading empty list that would make a server-vs-reference
+    // diff pass falsely (empty) or fail spuriously.
+    let err = sink
+        .list_objects()
+        .expect_err("list_objects must not report success while unimplemented");
+    assert!(
+        matches!(err, SinkError::Unsupported(_)),
+        "expected SinkError::Unsupported, got {err:?}"
+    );
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("list_objects") && msg.contains("LIST"),
+        "error must name the operation and the missing transport: {msg}"
+    );
+}


### PR DESCRIPTION
Paired tests for the Wave-3 core fixes: sink_object_store_stub_contract (#379-384), feature_rename_docs_present (#385-390,398), cargo_metadata_pins (#375-378,391); rewrites the dead phase3 s3_restart_resumes into a genuine crash+resume with an injected backend (#381); wires object-store-sink into CI. COUNTERPART_REV -> 10db4b7. Full suite green (default + object-store-sink feature).