### PR TITLE
fix(ci-pin): read the Gitea workflow path (closes #137)

### DIFF
--- a/tests/cli_counterpart_pinning.rs
+++ b/tests/cli_counterpart_pinning.rs
@@ -10,6 +10,9 @@
 
 use std::path::{Path, PathBuf};
 
+mod common;
+use common::workflows::read_workflow;
+
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
 }
@@ -66,7 +69,10 @@ fn ci_clones_pinned_cli_counterpart_with_no_branch_fallback() {
         "clone-cli-counterpart action must assert `git rev-parse HEAD` equals the pin"
     );
 
-    let ci = read(".github/workflows/ci.yml");
+    // The workflow itself lives under `.gitea/workflows/` since the Gitea
+    // Actions migration (#135); the composite actions it calls deliberately
+    // stayed under `.github/actions/`, so the `uses:` path below is unchanged.
+    let ci = read_workflow("ci.yml");
     assert!(
         ci.contains("./.github/actions/clone-cli-counterpart"),
         "the CLI-differential job must clone the CLI via the pinned action"
@@ -87,7 +93,7 @@ fn ci_clones_pinned_cli_counterpart_with_no_branch_fallback() {
 /// which makes the harness panic instead of skipping when the CLI is absent.
 #[test]
 fn cli_differential_job_requires_the_cli_to_run() {
-    let ci = read(".github/workflows/ci.yml");
+    let ci = read_workflow("ci.yml");
     assert!(
         ci.contains("VIPRS_REQUIRE_CLI: 1") || ci.contains("VIPRS_REQUIRE_CLI: \"1\""),
         "the cli-differential job must set VIPRS_REQUIRE_CLI=1 so a failure to lay \
@@ -107,7 +113,7 @@ fn cli_differential_job_requires_the_cli_to_run() {
 /// the differential cells while making a forgotten wiring a hard CI failure.
 #[test]
 fn cli_differential_job_runs_every_diff_binary() {
-    let ci = read(".github/workflows/ci.yml");
+    let ci = read_workflow("ci.yml");
     let tests_dir = repo_root().join("tests");
     let mut diff_bins: Vec<String> = std::fs::read_dir(&tests_dir)
         .expect("read tests/ dir")

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,7 +6,8 @@
 //! Cargo treats `tests/common/mod.rs` (directory module) specially — it
 //! isn't compiled as its own integration target.
 //!
-//! The canonical-fixture loader sits in [`fixtures`]. Below it: PDF /
+//! The canonical-fixture loader sits in [`fixtures`], and [`workflows`]
+//! resolves the CI workflow files the pinning guards read. Below them: PDF /
 //! pdfium-specific shared helpers for the streaming-mode integration
 //! tests. The pdfium helpers are gated behind the `pdfium` feature so
 //! the module compiles cleanly with the default feature set.
@@ -20,6 +21,7 @@
 pub mod cli;
 pub mod dzsave_expected;
 pub mod fixtures;
+pub mod workflows;
 
 #[cfg(feature = "pdfium")]
 #[allow(unused_imports)]

--- a/tests/common/workflows.rs
+++ b/tests/common/workflows.rs
@@ -1,0 +1,75 @@
+//! Locates the CI workflow definitions that this repo's pinning guards read.
+//!
+//! Several guard suites (`counterpart_pinning`, `cli_counterpart_pinning`,
+//! `pdfium_ci_policy`, `pdfium_provenance`) pin the *contents* of the CI
+//! workflows: they assert that CI still clones the counterparts at a pinned
+//! rev, still runs every differential binary, still checksum-verifies PDFium,
+//! and so on. Their whole value comes from reading the file CI actually runs.
+//!
+//! The Gitea Actions migration (#135) moved `ci.yml` and `nightly.yml` from
+//! `.github/workflows/` to `.gitea/workflows/` and left the guards pointing at
+//! the old path (#137). A guard that reads the wrong CI file has failed at its
+//! own purpose, and a stale local checkout that still carries the removed file
+//! hides that: it goes green locally and red in CI.
+//!
+//! So resolution lives here, once, and it refuses to guess. [`read_workflow`]
+//! looks for a workflow by name in every directory this repo has kept
+//! workflows in, and panics unless exactly one of them has it, naming all the
+//! candidates either way, so the next migration diagnoses itself.
+
+use std::path::{Path, PathBuf};
+
+/// Every directory this repo has kept CI workflow definitions in, current
+/// location first. Add to this list when the workflows move again; the guards
+/// themselves need no change.
+pub const WORKFLOW_DIRS: &[&str] = &[".gitea/workflows", ".github/workflows"];
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
+}
+
+/// Read the workflow named `name` (e.g. `"ci.yml"`), wherever it currently
+/// lives.
+///
+/// Panics if no known location has it (the workflows moved and this list did
+/// not follow), or if more than one does (the guards would pin whichever copy
+/// they happened to read, which is exactly the silent failure this exists to
+/// prevent).
+pub fn read_workflow(name: &str) -> String {
+    let root = repo_root();
+    let found: Vec<PathBuf> = WORKFLOW_DIRS
+        .iter()
+        .map(|dir| root.join(dir).join(name))
+        .filter(|path| path.is_file())
+        .collect();
+
+    match found.as_slice() {
+        [path] => std::fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display())),
+        [] => panic!(
+            "no CI workflow named {name} in any known location ({}). If the \
+             workflows moved again, add the new directory to WORKFLOW_DIRS in \
+             tests/common/workflows.rs so the pinning guards follow them (#137).",
+            candidate_list(name)
+        ),
+        several => panic!(
+            "{name} exists in {} known locations at once ({}). The pinning \
+             guards would silently pin whichever copy they happened to read, so \
+             drop the stale one before the next migration hides behind it (#137).",
+            several.len(),
+            several
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    }
+}
+
+fn candidate_list(name: &str) -> String {
+    WORKFLOW_DIRS
+        .iter()
+        .map(|dir| format!("{dir}/{name}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}

--- a/tests/counterpart_pinning.rs
+++ b/tests/counterpart_pinning.rs
@@ -9,6 +9,9 @@
 
 use std::path::{Path, PathBuf};
 
+mod common;
+use common::workflows::read_workflow;
+
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
 }
@@ -56,7 +59,10 @@ fn ci_checks_out_pinned_counterpart_with_no_branch_fallback() {
         "clone-counterpart action must check out the exact fetched commit"
     );
 
-    let ci = read(".github/workflows/ci.yml");
+    // The workflow itself lives under `.gitea/workflows/` since the Gitea
+    // Actions migration (#135); the composite actions it calls deliberately
+    // stayed under `.github/actions/`, so the `uses:` path below is unchanged.
+    let ci = read_workflow("ci.yml");
     assert!(
         ci.contains("./.github/actions/clone-counterpart"),
         "every job needing the sibling must clone it via the pinned action"
@@ -98,7 +104,7 @@ fn reference_suite_fetch_is_scripted_and_pinned() {
 
 #[test]
 fn ci_wires_the_pinned_fetch_step() {
-    let ci = read(".github/workflows/ci.yml");
+    let ci = read_workflow("ci.yml");
     assert!(
         ci.contains("tools/fetch_reference_suite.sh"),
         "ci.yml must fetch reference fixtures via the pinned script as a CI step"

--- a/tests/pdfium_ci_policy.rs
+++ b/tests/pdfium_ci_policy.rs
@@ -19,6 +19,9 @@
 
 use std::path::{Path, PathBuf};
 
+mod common;
+use common::workflows::read_workflow;
+
 /// The serial-execution flag whose removal issue #59 pins. Assembled from
 /// fragments so this guard file does not itself match a raw substring scan
 /// for the flag in the workflow / Dockerfile.
@@ -72,7 +75,7 @@ fn assert_no_serial_flag_in_commands(file: &str, contents: &str) {
 
 #[test]
 fn ci_runs_the_pdfium_suite_multi_threaded() {
-    let ci = read(".github/workflows/ci.yml");
+    let ci = read_workflow("ci.yml");
     assert_no_serial_flag_in_commands("ci.yml", &ci);
 }
 
@@ -108,7 +111,7 @@ fn perf_ratio_smoke_is_ignored_out_of_normal_ci() {
 
 #[test]
 fn nightly_workflow_runs_the_ignored_perf_smoke_on_a_schedule() {
-    let nightly = read(".github/workflows/nightly.yml");
+    let nightly = read_workflow("nightly.yml");
     assert!(
         nightly.contains("schedule:") && nightly.contains("cron:"),
         "nightly.yml must run on a cron schedule"

--- a/tests/pdfium_provenance.rs
+++ b/tests/pdfium_provenance.rs
@@ -7,13 +7,17 @@
 //! SHA-256 verification, float the release channel, or let the Docker and CI
 //! pins drift out of lockstep.
 //!
-//! The tests read the checked-in `Dockerfile`, `.github/workflows/ci.yml`,
-//! and `.gitignore` from the crate root and assert structural properties. They
-//! do not require the `pdfium` feature or a native PDFium install, so they run
-//! on every `cargo test` invocation.
+//! The tests read the checked-in `Dockerfile`, the CI workflow (resolved by
+//! name, see `tests/common/workflows.rs`), and `.gitignore` from the crate
+//! root and assert structural properties. They do not require the `pdfium`
+//! feature or a native PDFium install, so they run on every `cargo test`
+//! invocation.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
+
+mod common;
+use common::workflows::read_workflow;
 
 fn root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -225,7 +229,7 @@ fn dockerfile_fetches_pinned_checksummed_binary() {
 /// checksum-verified binary sourced from libviprs-dep, not a floating channel.
 #[test]
 fn ci_fetches_pinned_checksummed_binary() {
-    let ci = read(".github/workflows/ci.yml");
+    let ci = read_workflow("ci.yml");
 
     assert!(
         ci.contains("libviprs/libviprs-dep"),
@@ -261,7 +265,7 @@ fn ci_fetches_pinned_checksummed_binary() {
 #[test]
 fn docker_and_ci_pins_are_in_lockstep() {
     let df = read("Dockerfile");
-    let ci = read(".github/workflows/ci.yml");
+    let ci = read_workflow("ci.yml");
 
     let df_release = values_after(&df, "PDFIUM_RELEASE")
         .into_iter()

--- a/tests/pdfium_streaming_perf_smoke.rs
+++ b/tests/pdfium_streaming_perf_smoke.rs
@@ -32,7 +32,7 @@
 //! turns this into a spurious red on an unrelated PR. Wall-clock ratios
 //! are a nightly-quality signal, not a per-PR gate: both tests carry
 //! `#[ignore]` so the normal `cargo test` run never blocks on them, and
-//! `.github/workflows/nightly.yml` runs them on a schedule via
+//! `.gitea/workflows/nightly.yml` runs them on a schedule via
 //! `cargo test --features pdfium -- --ignored`, where a transient blip
 //! is a retryable nightly, not a merge blocker. Removing `#[ignore]`
 //! from either test re-arms the flake and is guarded by

--- a/tools/run_ported_cells.sh
+++ b/tools/run_ported_cells.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 # BigTIFF/tiled) either assert the typed Unsupported/decode contract or stay
 # `#[ignore]` with a precise reason. This script is the single source of truth
 # for the green-cell list: the Docker mirror (Dockerfile CMD via run-tests.sh),
-# the pre-commit hooks (install-hooks.sh), and .github/workflows/ci.yml all
+# the pre-commit hooks (install-hooks.sh), and .gitea/workflows/ci.yml all
 # call it, so promoting a cell to green is a one-file change.
 #
 # After the ported cells this script also runs phase3_tracing under the


### PR DESCRIPTION
Closes #137.

The Gitea Actions migration (#135) moved `ci.yml` and `nightly.yml` from `.github/workflows/` to `.gitea/workflows/`, but the guards that pin the CI definition kept reading the old path. `read()` panics on a missing file by design, so every one of them died at the read.

## Wider than the issue

The issue names three tests in `cli_counterpart_pinning`. `cargo test` stops at the first failing binary, so it never reached three sibling suites carrying the identical bug. `--no-fail-fast` shows the real blast radius, nine tests in four files:

| file | tests | reads |
| --- | --- | --- |
| `cli_counterpart_pinning.rs` | 3 | `ci.yml` |
| `counterpart_pinning.rs` | 2 | `ci.yml` (the core `COUNTERPART_REV` guard) |
| `pdfium_ci_policy.rs` | 2 | `ci.yml`, `nightly.yml` |
| `pdfium_provenance.rs` | 2 | `ci.yml` |

Fixing only the three named ones would have moved the red one binary down the list.

## Only the path was wrong

I read `.gitea/workflows/ci.yml` and checked every assertion against it rather than assuming the migration was a pure move. All of them still hold:

- the six jobs kept their names and their steps
- `cli-differential` still sets `VIPRS_REQUIRE_CLI: 1`, and its `cargo test` line still wires all 18 `tests/cli_*_diff.rs` binaries
- `PDFIUM_RELEASE` / `PDFIUM_SHA256` are still in lockstep with the `Dockerfile`
- no `--branch` clone and no `|| git clone` fallback survived the move
- `nightly.yml` still carries the cron schedule and the `-- --ignored` run

One thing that looks wrong but is not: the composite actions deliberately stayed under `.github/actions/`, and the Gitea workflows call them from there. So `ci.contains("./.github/actions/clone-counterpart")` is still correct as written, and I left a comment at both sites so the next reader does not "fix" those to `.gitea/` too.

## Guard against the next migration

A test that reads the *wrong* CI file has failed at its own purpose, so resolution now lives in one place instead of four hard-coded string literals. `tests/common/workflows.rs` resolves a workflow by name across every directory this repo has kept workflows in, and refuses to guess:

```
no CI workflow named ci.yml in any known location (.gitea/workflows/ci.yml,
.github/workflows/ci.yml). If the workflows moved again, add the new directory
to WORKFLOW_DIRS in tests/common/workflows.rs so the pinning guards follow them.
```

```
ci.yml exists in 2 known locations at once (...). The pinning guards would
silently pin whichever copy they happened to read, so drop the stale one
before the next migration hides behind it.
```

That covers both ways this hid. A future move fails with an instruction instead of a bare missing-file panic, and the stale-checkout case (an old `.github/workflows/ci.yml` still on disk next to the new one, green locally and red in CI) now fails loudly on the ambiguity. I exercised both panic branches by hand before committing.

## Gate

`cargo test --no-fail-fast`, 125 test binaries:

- before: **730 passed, 10 failed**
- after: **739 passed, 1 failed**

Nine fixed, nothing regressed. Plain `cargo test` goes from stopping at `cli_counterpart_pinning` (347 passed, 3 failed) to running the full suite. `cargo clippy --all-targets` is clean.

The one remaining failure is unrelated and pre-existing: `feature_rename_docs_present::changelog_records_s3_rename_and_deprecation` reads `../libviprs/CHANGELOG.md`, i.e. the path-dependency sibling. It fails only against a local checkout that has drifted past the pin. Against `COUNTERPART_REV` (`ac1d56ff`), which is what CI clones, the topmost changelog entry still carries all four things that guard asserts, so it passes there.

Also refreshed two stale prose references to the old workflow paths.