### PR TITLE
style: restore rustfmt import ordering in rotation_libvips_pdfium_parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,7 +893,7 @@ dependencies = [
  "image",
  "lopdf",
  "moxcms 0.8.1",
- "pdfium-render 0.9.3 (git+https://github.com/libviprs/pdfium-render.git?rev=48f0aa5d82871c1854a976fcbb8a0b1c366a739f)",
+ "pdfium-render 0.9.3 (git+https://github.com/libviprs/pdfium-render.git?rev=3b03093295b85486c2e42f514cef9647eb629c63)",
  "rustfft",
  "serde",
  "serde_json",
@@ -1153,7 +1153,7 @@ dependencies = [
 [[package]]
 name = "pdfium-render"
 version = "0.9.3"
-source = "git+https://github.com/libviprs/pdfium-render.git?rev=48f0aa5d82871c1854a976fcbb8a0b1c366a739f#48f0aa5d82871c1854a976fcbb8a0b1c366a739f"
+source = "git+https://github.com/libviprs/pdfium-render.git?rev=3b03093295b85486c2e42f514cef9647eb629c63#3b03093295b85486c2e42f514cef9647eb629c63"
 dependencies = [
  "bitflags",
  "bytemuck",

--- a/tests/rotation_libvips_pdfium_parity.rs
+++ b/tests/rotation_libvips_pdfium_parity.rs
@@ -26,8 +26,8 @@
 
 #![cfg(feature = "pdfium")]
 
-use libviprs::streaming::StripSource;
 use libviprs::PdfiumStripSource;
+use libviprs::streaming::StripSource;
 
 /// (input PDF, expected libvips+pdfium golden) fixture pairs. The `/Rotate 0`
 /// case (`canonical.pdf`) anchors that the flag-free path is unchanged; the


### PR DESCRIPTION
`cargo fmt -- --check` fails on `main`, so the `lint` job is red independently of anything else.

```
Diff in tests/rotation_libvips_pdfium_parity.rs:26:
-use libviprs::streaming::StripSource;
 use libviprs::PdfiumStripSource;
+use libviprs::streaming::StripSource;
```

Two lines, import ordering only. rustfmt 1.9.0 sorts a module path after a bare type where whatever produced `a253b41` sorted it before. Nothing about the test changed.

This surfaced while fixing #137: the `pre-commit` hook runs `cargo fmt --check`, so it blocked a commit that had nothing to do with this file. Worth clearing so the hook is usable again.

Found while restoring libviprs CI (libviprs#530).
