### PR TITLE
style: restore rustfmt import ordering in rotation_libvips_pdfium_parity

### DIFF
--- a/tests/rotation_libvips_pdfium_parity.rs
+++ b/tests/rotation_libvips_pdfium_parity.rs
@@ -26,8 +26,8 @@
 
 #![cfg(feature = "pdfium")]
 
-use libviprs::streaming::StripSource;
 use libviprs::PdfiumStripSource;
+use libviprs::streaming::StripSource;
 
 /// (input PDF, expected libvips+pdfium golden) fixture pairs. The `/Rotate 0`
 /// case (`canonical.pdf`) anchors that the flag-free path is unchanged; the


### PR DESCRIPTION
`cargo fmt -- --check` fails on `main`, so the `lint` job is red independently of anything else.

```
Diff in tests/rotation_libvips_pdfium_parity.rs:26:
-use libviprs::streaming::StripSource;
 use libviprs::PdfiumStripSource;
+use libviprs::streaming::StripSource;
```

Two lines, import ordering only. rustfmt 1.9.0 sorts a module path after a bare type where whatever produced `a253b41` sorted it before. Nothing about the test changed.

This surfaced while fixing #137: the `pre-commit` hook runs `cargo fmt --check`, so it blocked a commit that had nothing to do with this file. Worth clearing so the hook is usable again.

Found while restoring libviprs CI (libviprs#530).
