### PR TITLE
test(foreign): follow the WebP and GIF encode signatures to their options structs

### DIFF
--- a/tests/ported_foreign.rs
+++ b/tests/ported_foreign.rs
@@ -19,8 +19,8 @@ use libviprs::{
     TileFormat, decode_bytes_fail_on, decode_file, decode_file_fail_on, decode_file_sequential,
     decode_file_with_shrink, decode_svg, decode_tiff_page, extract_page_image,
     extract_page_image_dpi, extract_page_image_with_background, extract_page_image_with_password,
-    generate_pyramid_region, magickload, magickload_with, pdf_info, pdf_info_with_password,
-    thumbnail, thumbnail_crop, tiff_page_count,
+    generate_pyramid_region, gif, magickload, magickload_with, pdf_info, pdf_info_with_password,
+    thumbnail, thumbnail_crop, tiff_page_count, webp,
 };
 
 mod common;
@@ -2100,7 +2100,7 @@ fn test_dz_region() {
 /// fn decode_file(path: &Path) -> Result<Raster, DecodeError>; // already exists, needs WebP support
 ///
 /// /// Encode raster as WebP bytes.
-/// fn Raster::encode_webp(&self, quality: u8) -> Result<Vec<u8>, EncodeError>;
+/// fn Raster::encode_webp(&self, options: webp::SaveOptions) -> Result<Vec<u8>, EncodeError>;
 /// ```
 ///
 /// ## Test logic (from libvips test_foreign.py::test_webp)
@@ -2117,7 +2117,7 @@ fn test_webp() {
 
     // Deferred external codec: the encoder returns a typed
     // EncodeError::Unsupported rather than bytes. Pin that contract.
-    let __err = im.encode_webp(80).unwrap_err();
+    let __err = im.encode_webp(webp::SaveOptions::default()).unwrap_err();
     assert!(
         matches!(__err, EncodeError::Unsupported { .. }),
         "deferred encoder must return typed Unsupported, got {__err:?}"
@@ -2132,7 +2132,7 @@ fn test_webp() {
 ///
 /// ```rust,ignore
 /// fn decode_file(path: &Path) -> Result<Raster, DecodeError>; // needs GIF support
-/// fn Raster::encode_gif(&self) -> Result<Vec<u8>, EncodeError>;
+/// fn Raster::encode_gif(&self, options: gif::SaveOptions) -> Result<Vec<u8>, EncodeError>;
 /// ```
 ///
 /// ## Test logic (from libvips test_foreign.py::test_gif)
@@ -2147,7 +2147,7 @@ fn test_gifload() {
     assert!(im.width() > 0);
     assert!(im.height() > 0);
 
-    let buf = im.encode_gif().unwrap();
+    let buf = im.encode_gif(gif::SaveOptions::default()).unwrap();
     let im2 = decode_bytes(&buf).unwrap();
     assert_eq!(im2.width(), im.width());
     assert_eq!(im2.height(), im.height());
@@ -2288,14 +2288,9 @@ fn test_gifload_frame_error() {
 /// ## Required API
 ///
 /// ```rust,ignore
-/// /// Encode raster as GIF bytes with options.
-/// fn Raster::encode_gif(&self) -> Result<Vec<u8>, EncodeError>;
-///
-/// /// Encode raster as interlaced GIF bytes.
-/// fn Raster::encode_gif_interlaced(&self) -> Result<Vec<u8>, EncodeError>;
-///
-/// /// Encode raster as GIF with a specific dither level (0.0 - 1.0).
-/// fn Raster::encode_gif_dither(&self, dither: f64) -> Result<Vec<u8>, EncodeError>;
+/// /// Encode raster as GIF bytes. Interlacing and the dither level (0.0 - 1.0)
+/// /// are fields on the options struct rather than separate methods.
+/// fn Raster::encode_gif(&self, options: gif::SaveOptions) -> Result<Vec<u8>, EncodeError>;
 ///
 /// /// Get the number of pages (frames) in a multi-page image.
 /// fn Raster::get_n_pages(&self) -> u32;
@@ -2312,7 +2307,7 @@ fn test_gifsave() {
     let im = decode_file(&ref_image("trans-x.gif")).unwrap();
     // Deferred external codec: the encoder returns a typed
     // EncodeError::Unsupported rather than bytes. Pin that contract.
-    let __err = im.encode_gif().unwrap_err();
+    let __err = im.encode_gif(gif::SaveOptions::default()).unwrap_err();
     assert!(
         matches!(__err, EncodeError::Unsupported { .. }),
         "deferred encoder must return typed Unsupported, got {__err:?}"

--- a/tests/ported_infrastructure.rs
+++ b/tests/ported_infrastructure.rs
@@ -592,7 +592,7 @@ mod timeout {
     ///
     /// ```rust,ignore
     /// /// Encode raster as GIF bytes.
-    /// fn Raster::encode_gif(&self) -> Result<Vec<u8>, EncodeError>;
+    /// fn Raster::encode_gif(&self, options: gif::SaveOptions) -> Result<Vec<u8>, EncodeError>;
     /// ```
     ///
     /// ## Test logic
@@ -605,8 +605,9 @@ mod timeout {
     fn test_timeout_gifsave() {
         let data = vec![128u8; 1000 * 1000 * 3];
         let im = Raster::new(1000, 1000, PixelFormat::Rgb8, data).unwrap();
-        // The core has no `encode_gif`; its GIF surface is extension-dispatch
-        // in `Raster::save`, which returns a typed
+        // This exercises the GIF surface through `Raster::save`'s extension
+        // dispatch rather than `encode_gif`, because `save` is what a caller
+        // reaches for under a timeout. It returns a typed
         // `SaveError::UnsupportedExtension` (a clean error, never a panic),
         // exactly the graceful-degradation contract this test checks.
         let dir = tempfile::tempdir().unwrap();
@@ -625,7 +626,7 @@ mod timeout {
     /// ## Required API
     ///
     /// ```rust,ignore
-    /// fn Raster::encode_webp(&self, quality: u8) -> Result<Vec<u8>, EncodeError>;
+    /// fn Raster::encode_webp(&self, options: webp::SaveOptions) -> Result<Vec<u8>, EncodeError>;
     /// ```
     ///
     /// ## Test logic


### PR DESCRIPTION
Companion to libviprs#563 / libviprs PR #576. That PR moves the WebP and GIF stubs
into their own modules and gives them the ratified options-struct signatures, which
breaks three call sites here. This is the side that adapts.

**Merge this after libviprs #576, not before.** It does not compile against a
libviprs that still has the old signatures.

## What changed

`encode_webp(quality: u8)` becomes `encode_webp(webp::SaveOptions)`, and the three
GIF stubs `encode_gif()`, `encode_gif_interlaced()`, `encode_gif_dither(f64)`
collapse into one `encode_gif(gif::SaveOptions)`. So:

- `tests/ported_foreign.rs`: `test_webp`, `test_gifload`, `test_gifsave` call sites,
  plus the `Required API` blocks above each.
- `tests/ported_infrastructure.rs`: two `Required API` blocks in the `timeout` module.

Nothing about what these tests assert changes. Both encoders still return a typed
`EncodeError::Unsupported`, and the assertions still pin exactly that.

The WebP break is the one with a reason behind it rather than tidiness. The only
pure-Rust WebP encoder is lossless-only with no quality knob, so a `quality: u8`
would have been accepted and thrown away, and it would have silently started
meaning something the day a lossy encoder landed. Quality is now unrepresentable
instead of ignored.

## Two things slightly wider than the three call sites

I found five `Required API` doc blocks quoting a changed signature, not three:
`ported_foreign.rs:2103` (WebP), `:2135` (GIF), `:2292` (the GIF trio), and
`ported_infrastructure.rs:595` and `:628`. Leaving two of them describing methods
that no longer exist seemed worse than fixing all five, so I fixed all five. Still
nothing beyond the signature change.

Updating `ported_infrastructure.rs:595` also forced the comment right under it. It
said "The core has no `encode_gif`", which was already wrong (the core has had a
`encode_gif` stub throughout) and would have sat two lines below a `Required API`
block naming `encode_gif`. I reworded it to say what the test actually does, which
is exercise the GIF surface through `Raster::save`'s extension dispatch.

## CI

This PR's own CI checks libviprs out at `COUNTERPART_REV`, with no branch fallback
(issue #58), and that pinned commit still has the old signatures. So the integration
job here will be red until `COUNTERPART_REV` is bumped to libviprs #576's merge
commit. That commit does not exist yet, so I could not bump it in this PR. The bump
is the last step before this merges.

The reverse direction already works: libviprs's own workflow clones libviprs-tests
at the matching branch name (`.gitea/workflows/ci.yml:92-96`), and this branch is
named `feat/563-format-prep` to match, so libviprs PR #576's integration job picks
it up with neither repo merged.

## Local results

Run against the libviprs `feat/563-format-prep` branch as the sibling checkout:

- `cargo test` (default features): **740 passed, 0 failed, 11 ignored**
- `cargo fmt -- --check`: clean
- `cargo clippy --all-targets --features ported_tests -- -D warnings`: **0**
- `cargo test --features ported_tests --no-run`: compiles clean

The three edited `ported_tests` cells cannot run in my environment: they need the
libvips reference fixture suite under `tmp/libvips-reference-tests/`, which is not
fetched locally. Three *unedited* tests in the same file (`test_gifload_truncated`,
`test_gifload_frame_error`, `test_gifload_animation_dispose_background`) fail with
the identical `Io(NotFound)` at their `decode_file(&ref_image(..))` line, before any
encoder call, which is what the failure is.

`Cargo.lock` is deliberately not in this commit. It picks up an unrelated
pdfium-render rev change, because the local sibling checkout sits ahead of
`COUNTERPART_REV`.
