### PR TITLE
fix(ported): follow decode_svg to its options struct

### DIFF
--- a/COUNTERPART_REV
+++ b/COUNTERPART_REV
@@ -96,4 +96,17 @@
 # zoomify comparisons, bandmean, and the two smartcrop RGBA cells) fail
 # byte-identically against the previous pin too, so this bump neither caused
 # nor fixed them.
-82529c3635c01cea0d0ec463cf7d1587b67e1438
+#
+# Bumped to 4222d7f, which is libviprs #591 (issue #502): the SVG lane. It has
+# to move for this suite to compile at all. `decode_svg` left `foreign_stubs`
+# for the new `crate::svg` module and its second argument went from
+# `Option<f64>` dpi to an `SvgOptions` struct, so the two ported call sites here
+# (ported_connection::test_connection_svg and ported_foreign::test_svgload) no
+# longer type-check against the previous pin, and `SvgOptions` does not exist
+# there to name. The crate-root spelling `libviprs::decode_svg` is unchanged.
+#
+# The deferred contract both cells pin is unchanged too. The rasteriser is real
+# now, but it lives behind the non-default `svg` feature and this suite does not
+# enable it, so `decode_svg` still returns a typed `DecodeError` naming SVG
+# rather than a raster. Both cells still assert exactly that.
+4222d7fddfbc33b9b2562f5fffb5cd852c1f065c

--- a/tests/ported_connection.rs
+++ b/tests/ported_connection.rs
@@ -10,7 +10,8 @@ use std::path::Path;
 
 use libviprs::source::decode_bytes;
 use libviprs::{
-    PixelFormat, Raster, Source, Target, decode_file, decode_source, decode_svg, encode_to_target,
+    PixelFormat, Raster, Source, SvgOptions, Target, decode_file, decode_source, decode_svg,
+    encode_to_target,
 };
 
 /// Path to the libvips reference test images directory.
@@ -363,23 +364,29 @@ fn test_connection_matrix() {
 /// ## Required API
 ///
 /// ```rust,ignore
-/// /// Decode an SVG from bytes into a raster image at an optional DPI.
-/// fn decode_svg(data: &[u8], dpi: Option<f64>) -> Result<Raster, DecodeError>;
+/// /// dpi (default 72.0), scale (default 1.0) and unlimited (default false),
+/// /// which are vips's own svgload defaults.
+/// struct SvgOptions { dpi: f64, scale: f64, unlimited: bool }
+///
+/// /// Decode an SVG from bytes into a raster image under those options.
+/// fn decode_svg(data: &[u8], options: SvgOptions) -> Result<Raster, DecodeError>;
 /// ```
 ///
 /// ## Test logic (from libvips test_connection.py::test_connection_svg)
 ///
-/// SVG rasterisation needs an external `librsvg` path, so the pure-Rust build
-/// defers it: `decode_svg` returns a typed `DecodeError` naming SVG rather than
-/// a raster. Pin that deferred contract here (asserting the typed error, not a
-/// panic); when a rasteriser lands this flips back to the width/height check.
+/// The rasteriser exists now (libviprs#502), but it sits behind the non-default
+/// `svg` feature and this suite does not turn that on, so `decode_svg` still
+/// returns a typed `DecodeError` naming SVG rather than a raster. Pin that
+/// contract here (asserting the typed error, not a panic); enabling the feature
+/// flips this back to the width/height check.
 ///
 /// Reference: test_connection.py::test_connection_svg
 fn test_connection_svg() {
-    // decode_svg takes 2 args (data, dpi); the 1-arg call was the mis-port.
-    // Proof: the foreign cell's 2-arg form is the canonical shared crate export.
+    // decode_svg takes the document plus an `SvgOptions`, and the defaults are
+    // vips's own, so `default()` is the plain `svgload_buffer` call this cell
+    // ports. The old `Option<f64>` dpi argument went away with libviprs#591.
     let svg = b"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"1\" height=\"1\" />";
-    let err = decode_svg(svg, None).expect_err("SVG rasterisation is deferred");
+    let err = decode_svg(svg, SvgOptions::default()).expect_err("SVG rasterisation is deferred");
     assert!(
         err.to_string().contains("SVG"),
         "expected a typed SVG-unavailable decode error, got {err}"

--- a/tests/ported_foreign.rs
+++ b/tests/ported_foreign.rs
@@ -15,12 +15,12 @@ use image::ImageEncoder;
 use libviprs::source::decode_bytes;
 use libviprs::{
     EncodeError, EngineBuilder, EngineConfig, EngineKind, FsSink, JpegSubsample, Layout,
-    MagickLoadOptions, PixelFormat, PyramidPlanner, Raster, SaveError, SinkError, TiffCompression,
-    TileFormat, decode_bytes_fail_on, decode_file, decode_file_fail_on, decode_file_sequential,
-    decode_file_with_shrink, decode_svg, decode_tiff_page, extract_page_image,
-    extract_page_image_dpi, extract_page_image_with_background, extract_page_image_with_password,
-    generate_pyramid_region, gif, magickload, magickload_with, pdf_info, pdf_info_with_password,
-    thumbnail, thumbnail_crop, tiff_page_count, webp,
+    MagickLoadOptions, PixelFormat, PyramidPlanner, Raster, SaveError, SinkError, SvgOptions,
+    TiffCompression, TileFormat, decode_bytes_fail_on, decode_file, decode_file_fail_on,
+    decode_file_sequential, decode_file_with_shrink, decode_svg, decode_tiff_page,
+    extract_page_image, extract_page_image_dpi, extract_page_image_with_background,
+    extract_page_image_with_password, generate_pyramid_region, gif, magickload, magickload_with,
+    pdf_info, pdf_info_with_password, thumbnail, thumbnail_crop, tiff_page_count, webp,
 };
 
 mod common;
@@ -2738,8 +2738,12 @@ fn test_jxlsave() {
 /// ## Required API
 ///
 /// ```rust,ignore
-/// /// Decode an SVG from bytes into a raster image at a given DPI.
-/// fn decode_svg(data: &[u8], dpi: Option<f64>) -> Result<Raster, DecodeError>;
+/// /// dpi (default 72.0), scale (default 1.0) and unlimited (default false),
+/// /// which are vips's own svgload defaults.
+/// struct SvgOptions { dpi: f64, scale: f64, unlimited: bool }
+///
+/// /// Decode an SVG from bytes into a raster image under those options.
+/// fn decode_svg(data: &[u8], options: SvgOptions) -> Result<Raster, DecodeError>;
 /// ```
 ///
 /// ## Test logic (from libvips test_foreign.py::test_svg)
@@ -2750,9 +2754,12 @@ fn test_jxlsave() {
 /// Reference: test_foreign.py::test_svg
 fn test_svgload() {
     let svg = b"<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"100\" height=\"50\"><rect width=\"100\" height=\"50\" fill=\"red\"/></svg>";
-    // SVG rasterisation is deferred (needs librsvg); decode_svg returns a
-    // typed error naming SVG rather than a raster. Pin that contract.
-    let __err = decode_svg(svg, None).unwrap_err();
+    // The rasteriser landed in libviprs#502 behind the non-default `svg`
+    // feature, which this suite does not enable, so decode_svg still returns a
+    // typed error naming SVG rather than a raster. Pin that contract. The old
+    // `Option<f64>` dpi argument became `SvgOptions` in libviprs#591, and the
+    // defaults are vips's own.
+    let __err = decode_svg(svg, SvgOptions::default()).unwrap_err();
     assert!(
         __err.to_string().contains("SVG"),
         "deferred SVG rasteriser must return a typed error, got {__err}"


### PR DESCRIPTION
`decode_svg` moved in libviprs #591 (issue #502): it left `foreign_stubs` for the new `crate::svg` module, and its second argument went from an `Option<f64>` dpi to an `SvgOptions` struct. The two ported call sites here still passed `None`, so this suite does not compile against a core at or past `4222d7f`.

Two call sites, and two `Required API` doc blocks quoting the old signature, one adjacent to each call. That is the whole surface: `decode_svg` appears nowhere else in the repo, and neither do `SvgOptions` or `svgload`.

## What it looked like

Against the sibling core at `4222d7f`, before the fix:

```
error[E0308]: mismatched types
   --> tests/ported_connection.rs:382:31
    |
382 |     let err = decode_svg(svg, None).expect_err("SVG rasterisation is deferred");
    |               ----------      ^^^^ expected `SvgOptions`, found `Option<_>`
    |               |
    |               arguments to this function are incorrect
    |
    = note: expected struct `SvgOptions`
                 found enum `Option<_>`
note: function defined here
   --> ../libviprs/src/svg.rs:214:8
    |
214 | pub fn decode_svg(data: &[u8], options: SvgOptions) -> Result<Raster, DecodeError> {
    |        ^^^^^^^^^^

error[E0308]: mismatched types
    --> tests/ported_foreign.rs:2755:33
     |
2755 |     let __err = decode_svg(svg, None).unwrap_err();
     |                 ----------      ^^^^ expected `SvgOptions`, found `Option<_>`
```

And the same two cells under plain `cargo test`, which is what libviprs's integration job runs:

```
     Running tests/ported_connection.rs
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running tests/ported_foreign.rs
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Both cells are `#![cfg(feature = "ported_tests")]`, so without the feature they compile to nothing and the job reports green on a break that is real. This repo's own `ported-tests` job *does* build them, but against the core pinned in `COUNTERPART_REV`, which was still `82529c3` and predates #591, so it saw nothing either. Neither side was looking at the combination that breaks.

## The pin had to move

`COUNTERPART_REV` goes from `82529c3` to `4222d7f`. Not a convenience: `SvgOptions` does not exist at the old pin, so there is no spelling of the fixed call that also builds against it. `4222d7f` is a straight descendant of `82529c3` and adds exactly two commits, `7b3a78f` (CI files only) and #591 itself.

## The deferred contract is unchanged

The rasteriser is real now, but it sits behind the non-default `svg` feature and this suite does not enable it, so `decode_svg` still returns a typed `DecodeError` naming SVG rather than a raster. Both cells assert exactly what they asserted before. What did change is the prose around them, which claimed SVG "needs an external `librsvg` path" — that stopped being true with #591, so it now names the feature gate as the reason instead.

## Checks

Run with the sibling core at `4222d7f`:

```
cargo fmt -- --check                                  clean
cargo clippy --all-targets -- -D warnings             clean
cargo clippy --all-targets --features s3              clean
cargo clippy --all-targets --features packfile        clean
cargo clippy --all-targets --features tracing         clean
./tools/run_ported_cells.sh --clippy                  clean
cargo test --features ported_tests --no-run           ok (was E0308 x2)
cargo test --features ported_tests --test ported_connection test_connection_svg
                                                      1 passed
cargo test --features ported_tests --test ported_foreign test_svgload
                                                      1 passed
cargo test --test counterpart_pinning                 4 passed
```

`Cargo.lock` is byte-identical to `main` and is not in the diff.

## CI on this branch

[Run 32878282364](https://github.com/libviprs/libviprs-tests/actions/runs/32878282364). Seven of the eight jobs are green. `Ported Cells (green subset)` is red, and it is red on `main` too:

- `./tools/run_ported_cells.sh --clippy` — **passes**. That is the step that compiles the cells against the counterpart, and it is what this PR is for.
- `./tools/run_ported_cells.sh --require-fixtures` — fails on `iiif_id_configurable_matches_vips`, panicking at `tests/common/dzsave_expected.rs:116`. Byte-identical to [run 32869673204](https://github.com/libviprs/libviprs-tests/actions/runs/32869673204) on `main`, which is #146 and #148. The pin bump neither caused it nor fixed it.

## Not changed

I did not run the full ported suite. It needs the libvips reference fixtures, which are not present locally, and the six pre-existing reds tracked in #148 are unrelated to this. Compiling the cells is the deliverable here.

Companion to the libviprs PR for libviprs#594, which adds `cargo test --features ported_tests --no-run` to the integration job so the next signature change fails loudly. The two branches share a name so that job picks this one up.
