### PR TITLE
test(ported): follow WebP encode to a real lossless codec

### DIFF
--- a/tests/ported_foreign.rs
+++ b/tests/ported_foreign.rs
@@ -2112,16 +2112,21 @@ fn test_dz_region() {
 /// Reference: test_foreign.py::test_webp
 fn test_webp() {
     let im = decode_file(&ref_image("1.webp")).unwrap();
-    assert!(im.width() > 0);
-    assert!(im.height() > 0);
+    assert_eq!((im.width(), im.height()), (550, 368));
+    assert_eq!(im.format(), PixelFormat::Rgb8);
 
-    // Deferred external codec: the encoder returns a typed
-    // EncodeError::Unsupported rather than bytes. Pin that contract.
-    let __err = im.encode_webp(webp::SaveOptions::default()).unwrap_err();
-    assert!(
-        matches!(__err, EncodeError::Unsupported { .. }),
-        "deferred encoder must return typed Unsupported, got {__err:?}"
-    );
+    // The encoder is lossless-only, so step 3 needs no tolerance at all:
+    // there is no quantisation anywhere in it and the round trip is the
+    // identity. `Q` is not a tolerance question here, it is unrepresentable
+    // (libviprs#568): `webp::SaveOptions` carries a `Compression` whose one
+    // variant is `Lossless`.
+    let bytes = im.encode_webp(webp::SaveOptions::default()).unwrap();
+    assert_eq!(&bytes[..4], b"RIFF");
+    assert_eq!(&bytes[8..12], b"WEBP");
+    let back = decode_bytes(&bytes).unwrap();
+    assert_eq!((back.width(), back.height()), (im.width(), im.height()));
+    assert_eq!(back.format(), im.format());
+    assert_eq!(back.data(), im.data(), "lossless WebP is an exact identity");
 }
 
 #[test]


### PR DESCRIPTION
Companion to libviprs#597 (issues #567 and #568), which makes still-image
WebP real: load with the ICC/EXIF/XMP chunks attached, and lossless save.

`ported_foreign::test_webp` pins the deferred contract — `encode_webp`
returning a typed `EncodeError::Unsupported` — and that contract is gone. The
cell now does what the libvips cell it was ported from does, and what its own
docstring already described: load the reference WebP, verify the geometry,
encode, decode back, verify lossless.

Step 3 needs no tolerance. There is no lossy WebP encoder reachable in pure
Rust, so the round trip is the exact identity rather than a bounded one, and
`Q` is not a tolerance question at all: it is unrepresentable. The core's
`webp::SaveOptions` carries a `Compression` whose only variant is `Lossless`,
so quality has nowhere to be written down. The signature the cell calls is
unchanged from the current pin — libviprs#576 already moved `encode_webp` to
an options struct — so this is a behaviour follow-up, not a compile fix.

`ported_infrastructure::timeout::test_timeout_webpsave` needs no change: it
already branches on `Ok`, and asserts the file is non-empty when the save
succeeds. It does now, and it passes.

Verified against the core branch: `test_webp` passes, and `ported_foreign`
goes back to exactly the four failures it already has on `origin/main`
(`test_analyzeload`, `test_dz_layout_zoomify`, `test_dz_layout_iiif`,
`test_rad`). None of them is this lane's.

`COUNTERPART_REV` is deliberately not bumped here. libviprs#597 is still a
draft, so there is no squash SHA to pin, and the one-line `Cargo.lock` edge it
brings (`image-webp` becomes a direct dependency of `libviprs`, a crate
already in the graph behind `image`'s `webp` feature) belongs with that bump
rather than ahead of it. Bump both when the core PR merges.
