### PR TITLE
test(webp): follow the still-image WebP surface and bump the counterpart pin

### DIFF
--- a/COUNTERPART_REV
+++ b/COUNTERPART_REV
@@ -109,4 +109,13 @@
 # now, but it lives behind the non-default `svg` feature and this suite does not
 # enable it, so `decode_svg` still returns a typed `DecodeError` naming SVG
 # rather than a raster. Both cells still assert exactly that.
-4222d7fddfbc33b9b2562f5fffb5cd852c1f065c
+# Bumped for the format wave: #563 (one sniff table and per-format codec modules,
+# which takes the path extension out of the format decision entirely), #591 (SVG
+# rasterise behind a non-default svg feature), #593 (Radiance HDR load and save),
+# and #597 (WebP still load and lossless save). #597 is the one that forces this
+# bump: encode_webp's quality argument became an unrepresentable Compression enum,
+# because the only pure-Rust encoder is lossless-only, so the ported webp cell
+# cannot compile against the old pin. Also carries #598, which fused the
+# convolution inner loop, and #561 and #556, which deliberately moved output bytes
+# for cast and the Lab to LabS store.
+0eb7a753e019b5adce27ba0ab063f4b952c67966

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -891,6 +891,7 @@ dependencies = [
  "blake3",
  "flate2",
  "image",
+ "image-webp",
  "lopdf",
  "moxcms 0.8.1",
  "pdfium-render 0.9.3 (git+https://github.com/libviprs/pdfium-render.git?rev=3b03093295b85486c2e42f514cef9647eb629c63)",

--- a/tests/ported_foreign.rs
+++ b/tests/ported_foreign.rs
@@ -2112,16 +2112,21 @@ fn test_dz_region() {
 /// Reference: test_foreign.py::test_webp
 fn test_webp() {
     let im = decode_file(&ref_image("1.webp")).unwrap();
-    assert!(im.width() > 0);
-    assert!(im.height() > 0);
+    assert_eq!((im.width(), im.height()), (550, 368));
+    assert_eq!(im.format(), PixelFormat::Rgb8);
 
-    // Deferred external codec: the encoder returns a typed
-    // EncodeError::Unsupported rather than bytes. Pin that contract.
-    let __err = im.encode_webp(webp::SaveOptions::default()).unwrap_err();
-    assert!(
-        matches!(__err, EncodeError::Unsupported { .. }),
-        "deferred encoder must return typed Unsupported, got {__err:?}"
-    );
+    // The encoder is lossless-only, so step 3 needs no tolerance at all:
+    // there is no quantisation anywhere in it and the round trip is the
+    // identity. `Q` is not a tolerance question here, it is unrepresentable
+    // (libviprs#568): `webp::SaveOptions` carries a `Compression` whose one
+    // variant is `Lossless`.
+    let bytes = im.encode_webp(webp::SaveOptions::default()).unwrap();
+    assert_eq!(&bytes[..4], b"RIFF");
+    assert_eq!(&bytes[8..12], b"WEBP");
+    let back = decode_bytes(&bytes).unwrap();
+    assert_eq!((back.width(), back.height()), (im.width(), im.height()));
+    assert_eq!(back.format(), im.format());
+    assert_eq!(back.data(), im.data(), "lossless WebP is an exact identity");
 }
 
 #[test]


### PR DESCRIPTION
Supersedes #150, which had the cell fix but deliberately left `COUNTERPART_REV` alone because libviprs #597 had no squash SHA yet. It does now: `0eb7a75`.

`ported_foreign::test_webp` pinned the deferred `Unsupported` contract, which #597 retired. It now does what its own docstring already described: load, verify, encode, decode back, verify lossless. `ported_infrastructure::test_timeout_webpsave` needed nothing, since it already branches on `Ok`.

The pin moves `4222d7f` to `0eb7a75`, which carries the whole format wave: #563 (one sniff table, taking the path extension out of the format decision), #591 (SVG), #593 (Radiance), #597 (WebP) and #598 (the fused convolution inner loop). It also carries #561 and #556, both of which deliberately moved output bytes.

The one `Cargo.lock` line is `image-webp` becoming a direct dependency of libviprs, which is part of #597 rather than the unrelated pdfium drift the staging hazard warns about.

Verified `cargo test --features ported_tests --no-run` compiles clean against the new pin, which is the check libviprs #595 just added to the integration job.