### PR TITLE
test(foreign): index the multipage TIFF cell from zero (libviprs#566)

### DIFF
--- a/tests/ported_foreign.rs
+++ b/tests/ported_foreign.rs
@@ -1038,7 +1038,9 @@ fn test_tiff_load_pixels() {
 /// /// Get the number of pages in a multi-page TIFF.
 /// fn tiff_page_count(path: &Path) -> Result<u32, DecodeError>;
 ///
-/// /// Decode a specific page from a multi-page TIFF (1-indexed).
+/// /// Decode a specific page from a multi-page TIFF. `page` is a zero-based
+/// /// index, so the valid range is `0..tiff_page_count`, matching the libvips
+/// /// `page` argument (libviprs#566).
 /// fn decode_tiff_page(path: &Path, page: u32) -> Result<Raster, DecodeError>;
 /// ```
 ///
@@ -1057,7 +1059,10 @@ fn test_tiff_multipage() {
         "OME TIFF should have multiple pages, got {page_count}"
     );
 
-    for p in 1..=page_count {
+    // `page` is an index and `page_count` is a count, so the range is
+    // `0..page_count`. This used to read `1..=page_count`, which skipped the
+    // first image and ran one past the last (libviprs#566).
+    for p in 0..page_count {
         let raster = decode_tiff_page(&tiff_path, p).unwrap();
         assert!(raster.width() > 0, "Page {p}: width should be positive");
         assert!(raster.height() > 0, "Page {p}: height should be positive");


### PR DESCRIPTION
Companion to libviprs#601, which makes `decode_tiff_page` zero-based to match the libvips `page` argument (libviprs#566). Same branch name so the core repo's integration job clones this pair together.

`test_tiff_multipage` is the only cell that touches `decode_tiff_page`. Its loop read `1..=page_count`, which under the new indexing skips the first image and runs one past the last, and its Required API block documented the old 1-indexed contract. Both are fixed here.

This is not a compile break, which is worth saying out loud given #595 exists to catch those: the signature is unchanged, so `cargo test --features ported_tests --no-run` passes with or without this change. The cell is also `#[ignore]`d, because the OME-TIFF fixture uses a sample format the core decoder does not handle. So nothing was going red, and that is exactly why it is worth correcting now rather than leaving a wrong loop bound for whoever un-ignores it.

I checked it is only the sample format standing in the way, by running the cell with `--ignored` against the real fixture and the core branch from libviprs#601:

```
thread 'test_tiff_multipage' panicked at tests/ported_foreign.rs:1066:54:
called `Result::unwrap()` on an `Err` value: Decode(Decoding(DecodingError { format: Exact(Tiff),
  underlying: Some("unsupported TIFF sample format (only 8- and 16-bit unsigned samples are decoded here)") }))
```

That is the documented `#[ignore]` reason, reached from inside the loop, so `tiff_page_count` and the new `0..page_count` bound both did their job on a real 15-page file (`vipsheader -f n-pages` reports 15 for it).

`COUNTERPART_REV` is deliberately left alone. It still pins `0eb7a75`, where the core is 1-indexed, and this repo's own CI only compiles the cell rather than running it, so that stays green either way. It wants bumping once libviprs#601 merges.

## Local checks

```
cargo fmt -- --check                             ok
cargo test --features ported_tests --no-run      ok (against libviprs#601's branch)
```

## CI on this branch

Seven of eight jobs green. `Ported Cells (green subset)` is red, and it is red for a reason that has nothing to do with this change:

```
thread 'iiif_id_configurable_matches_vips' panicked at tests/common/dzsave_expected.rs:116:17:
iiif-id: pixel mismatch at full/128,/0/default.png row=0 col=63 vips=253 libviprs=254 diff=1 tolerance=0
```

That is a one-count pixel difference in a dzsave IIIF tile, in `tests/core_review_followups.rs`, and it fails identically on `main`. The last four `main` runs (32886336682, 32880104157, 32869673204, 32868734071, back to the GitHub Actions migration in #145) all fail on exactly this test and nothing else. So this branch inherits a standing red rather than causing one. I have left it alone; it wants its own issue.
