### PR TITLE
test(colour): drop the three tolerances the sRGB LUT was hiding under

### DIFF
--- a/COUNTERPART_REV
+++ b/COUNTERPART_REV
@@ -118,4 +118,16 @@
 # cannot compile against the old pin. Also carries #598, which fused the
 # convolution inner loop, and #561 and #556, which deliberately moved output bytes
 # for cast and the Lab to LabS store.
-0eb7a753e019b5adce27ba0ab063f4b952c67966
+#
+# Bumped to fix/581-srgb-lut @ d2fe494 (core #610, issue #581) so this repo's own
+# cli-differential job tests the three tolerances below against the fix rather
+# than against main, where they would still be at 1. The core change ports the
+# interpolated Y2v lookup vips uses for the linear -> sRGB store
+# (colour/LabQ2sRGB.c:126-146, :282-353) instead of evaluating the transfer
+# function analytically, which takes `colourspace icc_pcs_lab.v ... srgb` to PNG,
+# `colourspace --source-space lab` to PNG, and `sharpen` from measured 1 to
+# measured 0. It also moves output bytes for EVERY conversion into srgb, rgb16,
+# b-w, grey16 and hsv, and truncates the sRGB -> HSV hue and saturation codes the
+# way sRGB2HSV.c:113-117 does. This is a BRANCH commit, not a main commit: repin
+# to the merge commit once #610 lands.
+d2fe494a59a3f6b0f431489e8ee5748461bf76de

--- a/tests/cli_colour_diff.rs
+++ b/tests/cli_colour_diff.rs
@@ -24,8 +24,8 @@
 //! | `colourspace … xyz`   | `.v` float | 1e-4 | 1.5e-5 |
 //! | `colourspace … scrgb` | `.v` float | 1e-4 | 1.0e-6 |
 //! | `colourspace … lab` → PNG (#36) | PNG uchar | 1 (≤1 LSB) | 0 |
-//! | `colourspace icc_pcs_lab.v … srgb` → PNG (#36 non-round-trip) | PNG uchar | 1 (≤1 LSB) | 1 |
-//! | `colourspace --source-space lab` → PNG | PNG uchar | 1 (≤1 LSB) | 1 |
+//! | `colourspace icc_pcs_lab.v … srgb` → PNG (#36 non-round-trip) | PNG uchar | 0 (EXACT) | 0 |
+//! | `colourspace --source-space lab` → PNG | PNG uchar | 0 (EXACT) | 0 |
 //! | `dE76` | `.v` float | 1e-4 | 6.5e-5 |
 //! | `dE00` | `.v` float | 1e-4 | 6.5e-5 |
 //! | `dECMC` (GOLDEN-ONLY) | `.v` float | 1e-3 | 0 (viprs self-pin) |
@@ -60,9 +60,30 @@ use tempfile::TempDir;
 /// so the two agree to well under 1e-4 (measured ≤6.5e-5).
 const FLOAT_TOL: f64 = 1e-4;
 
-/// BOUNDED-TOL ≤1 LSB for the interpretation-aware PNG saves (`colourspace … lab`
-/// written to an integer sink runs the vips-style LAB→sRGB conversion, #36; and
-/// the `--source-space` override): uchar, measured 0 / 1.
+/// EXACT: bit-exact decode comparison (`CLI_CONTRACT.md` §5). The two
+/// non-round-trip `colourspace … → PNG` cells below used to sit at ≤1 LSB
+/// and now measure 0, because libviprs core #581 ported the interpolated
+/// `Y2v` lookup vips actually uses for the linear → sRGB store
+/// (`colour/LabQ2sRGB.c:126-146`, `:282-353`) instead of evaluating the
+/// transfer function analytically. That was the whole of the deviation:
+/// on the neutral LabS L sweep it moved 16295 of 98304 sRGB codes by one
+/// count, and the two cells here were seeing the tail of it.
+const EXACT: f64 = 0.0;
+
+/// BOUNDED-TOL ≤1 LSB for the ROUND-TRIP interpretation-aware PNG save
+/// (`colourspace … lab` written to an integer sink runs the vips-style
+/// LAB→sRGB conversion, #36): uchar, measured 0.
+///
+/// This is the only ≤1-LSB cell left in the file, and it is deliberate
+/// rather than left over. It measures 0 and always has: the
+/// round trip indexes the `Y2v` table with an exact integer and never
+/// interpolates, so it was never exposed to the #581 mechanism at all.
+/// The band it keeps is the cross-arch one — the table is built with
+/// `powf` in `f32`, and a libm that lands an ULP away on some other host
+/// would shift a table entry and therefore a code. Do NOT fold the two
+/// EXACT cells back into this constant: they are exact for a reason and
+/// sharing a number is how the last conflation happened (see the
+/// `sharpen` note in `cli_convolution_diff.rs`).
 const UCHAR_1LSB: f64 = 1.0;
 
 /// BOUNDED-TOL ≤2 LSB for the device-space ICC round trips (`icc_export`,
@@ -203,8 +224,9 @@ fn colourspace_lab_to_png_runs_interpretation_aware_save() {
 // rgb.png), so an identity/no-op colourspace would still pass it; here the
 // reference DIFFERS from the input, so a raw-cast / no-op colourspace would
 // garble the output. This makes the PNG path discriminate the colourspace
-// transform itself, not just the interpretation-aware save. uchar ≤1 LSB
-// (measured 1).
+// transform itself, not just the interpretation-aware save. EXACT (tol 0)
+// since libviprs core #581; it used to be ≤1 LSB at measured 1, and the 1
+// was the interpolated-LUT deviation in the linear → sRGB store.
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -222,7 +244,7 @@ fn colourspace_lab_input_to_png_discriminates_the_transform() {
     decode_compare(
         &out,
         &cli_fixture("colour/colourspace_lab_input_png_expected.png"),
-        UCHAR_1LSB,
+        EXACT,
     );
 }
 
@@ -230,7 +252,7 @@ fn colourspace_lab_input_to_png_discriminates_the_transform() {
 // colourspace --source-space — force the sRGB-tagged input to be read as LAB,
 // then convert to sRGB. Genuinely discriminating: if --source-space were ignored
 // the op would collapse to the srgb->srgb identity (255 apart from this result).
-// uchar ≤1 LSB (measured 1).
+// EXACT (tol 0) since libviprs core #581, same mechanism as the cell above.
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -250,7 +272,7 @@ fn colourspace_source_space_override_matches_vips() {
     decode_compare(
         &out,
         &cli_fixture("colour/colourspace_srcspace_expected.png"),
-        UCHAR_1LSB,
+        EXACT,
     );
 }
 

--- a/tests/cli_convolution_diff.rs
+++ b/tests/cli_convolution_diff.rs
@@ -56,14 +56,18 @@
 //!   nothing about per-pixel error `sum((w_hat - w) * p)`.
 //!   `conv_hostile_mask_matches_vips_exact` uses a mask that gate **accepts**
 //!   and on which the two paths differ by **57**.
-//! * **BOUNDED-TOL ≤1 LSB (tol 1) — `sharpen` ONLY.** This is a separate
-//!   tolerance with a separate cause and it must not be folded back into the
-//!   one above. `sharpen` convolves the L of LabS, which is 16-bit, and the
-//!   vector path is gated on `BandFmt == VIPS_FORMAT_UCHAR` (`convi.c:1151`),
-//!   so `sharpen` takes the portable C path on **both** libvips builds
-//!   (`VIPS_INFO=1` reports "convi: using C path"). #558 cannot be its
-//!   mechanism. The remaining deviation is a real libviprs bug, issue #581,
-//!   which the shared constant was concealing.
+//! * **`sharpen` is EXACT (tol 0) as of libviprs core #581.** It used to
+//!   carry its own ≤1-LSB band. #558 split that off from the integer-`conv`
+//!   constant and showed the vector path could not explain it — the vector
+//!   path is gated on `BandFmt == VIPS_FORMAT_UCHAR` (`convi.c:1151`) and
+//!   `sharpen` convolves the L of LabS, which is 16-bit, so both libvips
+//!   builds take the portable C path (`VIPS_INFO=1` reports "convi: using C
+//!   path"). #581 then found the deviation was never in the convolution at
+//!   all: it was in the `scRGB -> sRGB` store the sharpened LabS comes back
+//!   through, where libviprs evaluated the transfer function analytically
+//!   and vips reads an interpolated integer LUT
+//!   (`colour/LabQ2sRGB.c:126-146`, `:282-353`). With the LUT ported,
+//!   `sharpen` matches vips byte for byte.
 //! * **BOUNDED-TOL float (small eps)** — the large-magnitude float image
 //!   surfaces (`conv`/`compass`/`gaussblur` float, `convsep`, measured ≤1.5e-5
 //!   on the author Mac — the core's two-pass accumulation order differs from
@@ -113,22 +117,6 @@ use tempfile::TempDir;
 /// EXACT: bit-exact decode comparison (CLI_CONTRACT.md §5). Used for the
 /// scale-1 compass, fastcor, and the integer-valued gaussmat/logmat matrices.
 const EXACT: f64 = 0.0;
-
-/// BOUNDED-TOL ≤1 LSB for **`sharpen` and nothing else** (issue #581).
-///
-/// This used to be shared with integer `conv`/`gaussblur`, and sharing it was
-/// hiding two unrelated causes under one number. Integer convolution on uchar
-/// is now EXACT against a `VIPS_NOVECTOR=1` reference (#558); what is left
-/// here is `sharpen`'s own deviation, which #558 demonstrably cannot explain:
-/// `sharpen` runs its unsharp mask on the L of LabS, which is 16-bit, and
-/// `vips_convi`'s vector path is gated on `BandFmt == VIPS_FORMAT_UCHAR`
-/// (`convi.c:1151`), so both libvips builds take the portable C path here —
-/// `VIPS_INFO=1` says "convi: using C path" on the plain binary.
-///
-/// Measured max-abs-diff 1 on this fixture and 44 of 256 samples deviating.
-/// Do NOT reuse this constant for another op: give the next deviation its own
-/// name and its own explanation, or the same conflation happens again.
-const SHARPEN_LSB: f64 = 1.0;
 
 /// BOUNDED-TOL for the large-magnitude float image surfaces
 /// (`conv`/`compass`/`gaussblur` float, `convsep`). Measured ≤1.5e-5 on the
@@ -742,17 +730,17 @@ fn gaussblur_float_matches_vips_bounded_tol() {
 // ---------------------------------------------------------------------------
 // sharpen — S1, LabS unsharp mask. m1/m2 nonzero so it truly sharpens.
 //
-// This is the ONLY remaining tolerance in the cell, it has its own constant,
-// and it is NOT issue #558. sharpen convolves the L of LabS, which is 16-bit,
-// and `vips_convi`'s vector path is gated on `BandFmt == VIPS_FORMAT_UCHAR`
-// (convi.c:1151), so both libvips builds take the portable C path here —
-// confirmed with VIPS_INFO=1. 44 of 256 samples deviate; that is a real
-// libviprs bug, tracked as issue #581, and until #558 it was hiding under a
-// constant shared with integer conv.
+// EXACT (tol 0) as of libviprs core #581. This cell carried the last tolerance
+// in the file, at 44 of 256 samples deviating by 1, and it was never the
+// convolution: #558 ruled the vector path out (16-bit LabS takes the portable
+// C path on both builds, convi.c:1151, confirmed with VIPS_INFO=1), and #581
+// tracked it to the scRGB -> sRGB store on the way back out of LabS, where
+// vips reads an interpolated integer LUT and libviprs was evaluating the
+// curve. Do not re-add a band here without a mechanism to name.
 // ---------------------------------------------------------------------------
 
 #[test]
-fn sharpen_matches_vips_bounded_tol() {
+fn sharpen_matches_vips_exact() {
     if skip_if_no_cli("sharpen") {
         return;
     }
@@ -771,7 +759,7 @@ fn sharpen_matches_vips_bounded_tol() {
     decode_compare(
         &out,
         &cli_fixture("convolution/sharpen_expected.png"),
-        SHARPEN_LSB,
+        EXACT,
     );
 }
 


### PR DESCRIPTION
Companion to libviprs core PR #610 (issue #581). Same branch name, so the core's
integration job pairs the two.

Three tolerances go away, all of them the same mechanism.

vips does not evaluate the sRGB transfer function per pixel. `calcul_tables`
(`colour/LabQ2sRGB.c:126-146`) rounds `range` samples of it to integer codes
once, in `float`, and `vips_col_scRGB2sRGB` (`:282-353`) then interpolates
between two of those already-rounded entries and finishes the chord with
`rintf`, which rounds halves to even. libviprs evaluated the curve analytically
in `f64` and rounded once, so it was missing three quantisations and landed a
whole count away on 16.6% of codes. The core PR ports the table.

That is what all three cells were seeing:

| cell | was | now |
|---|---|---|
| `colourspace icc_pcs_lab.v … srgb` → PNG | ≤1 LSB, measured 1 | EXACT, measured 0 |
| `colourspace --source-space lab` → PNG | ≤1 LSB, measured 1 | EXACT, measured 0 |
| `sharpen` | ≤1 LSB, 44 of 256 samples | EXACT, measured 0 |

`sharpen` is the one worth spelling out, because it spent two issues being
blamed on the convolution. #558 split it off from the integer-`conv` constant
and showed the vector path could not explain it: `vips_convi`'s vector path is
gated on `BandFmt == VIPS_FORMAT_UCHAR` (`convi.c:1151`) and `sharpen` convolves
the L of LabS, which is 16-bit, so both libvips builds take the portable C path.
The deviation was never in the convolution. It was in the `scRGB -> sRGB` store
the sharpened LabS comes back through.

`SHARPEN_LSB` is gone. The convolution cell now has no tolerance constant left
beyond `EXACT` and the float epsilons.

## Not changed

`colourspace … lab` → PNG keeps its ≤1-LSB band. That cell already measured 0
and still does: the round trip indexes the table with an exact integer and never
interpolates, so it was never exposed to this mechanism. Its band is the
cross-arch one. The table is built with `powf` in `f32`, and a libm an ULP away
on another host would shift an entry. I left it rather than fold it in with the
two that are exact for a reason, and said so in the constant's doc.

## Verified

Built the CLI against the core branch and ran both cells locally with the
tolerances already tightened:

```
cli_colour_diff:      19 passed; 0 failed
cli_convolution_diff: 24 passed; 0 failed
```

CI agrees: **CLI Differential (all 17 op families) is green** on this branch.

`COUNTERPART_REV` moves to the core branch head so this repo's own
`cli-differential` job tests against the fix rather than against `main`, where
all three cells would still measure 1. Repin it to the merge commit once core
#610 lands.

## The one red check is not mine

`Ported Cells (green subset)` fails on `test_gifsave`, and it is a stale pin
belonging to a different lane. That cell asserts the GIF encoder is still a
deferred stub:

```rust
let __err = im.encode_gif(gif::SaveOptions::default()).unwrap_err();
assert!(matches!(__err, EncodeError::Unsupported { .. }), ...);
```

Core `261b51d` (#596, issues #570 and #571) implemented it, so `encode_gif` now
returns real GIF bytes and `unwrap_err()` panics on an `Ok`. That commit landed
after `COUNTERPART_REV` was last pinned at `0eb7a75`, so ANY bump past it
surfaces this, whatever the bump is for. Nothing in core #610 touches
`src/gif.rs`.

I have deliberately not touched the cell. Its own docstring already spells out
what the real test should be (save to buffer, reload, check the page count;
interlaced size >= non-interlaced; higher dither, larger file), and writing that
without the GIF lane's oracle work would be inventing an expectation rather than
measuring one. It wants that lane's companion, not this one.

Locally, `ported_colour`, `ported_conversion`, `ported_convolution`,
`ported_foreign`, `ported_resample`, `ported_create`, `ported_draw`,
`ported_histogram` and `ported_arithmetic` come to **269 passed, 1 failed
(`test_gifsave`), 23 ignored** against the core branch, so nothing this change
touches moved a ported cell.
