### PR TITLE
test(ported): un-ignore the two smartcrop RGBA cells (libviprs#603)

### DIFF
--- a/tests/ported_conversion.rs
+++ b/tests/ported_conversion.rs
@@ -735,23 +735,25 @@ fn test_smartcrop_attention() {
 ///
 /// The literals are right: `vips smartcrop rgba.png out.png 80 60 --interesting
 /// attention --attention-x --attention-y` on vips 8.18.4 prints 20 then 124.
-/// libviprs returns (124, 84), and that is a core parity gap, not a stale
-/// expectation, so this stays `#[ignore]` rather than being re-pinned to the
-/// wrong answer. Mechanism: `vips_smartcrop_build` premultiplies once into a
-/// float image and `vips_resize` then works on it WITHOUT un-premultiplying
-/// ("This operation does not premultiply alpha" — `libvips/resample/resize.c`),
-/// so the analysis image keeps transparent areas at colour 0. libviprs'
-/// `attention_crop` calls `resize_with` with the default
-/// `ResizeOptions::premultiplied = false`, so the core's own premultiply
-/// bracket (libviprs/libviprs#458) un-premultiplies the already-premultiplied
-/// analysis image on the way out, and the 407 fully transparent pixels of the
-/// 32x32 working image come back as bright garbage (up to 255) where vips has
-/// 0. Those fake bright regions dominate the edge and skin scoring and move the
-/// argmax. Confirmed by isolation: hand the same premultiplied image to
-/// libviprs with the alpha band dropped and it returns vips' (20, 124)
-/// exactly, and the no-alpha `test_smartcrop_attention` above already matches
-/// vips bit for bit.
-#[ignore = "core parity gap: attention_crop resizes the premultiplied analysis image without ResizeOptions::premultiplied, so its un-premultiply turns transparent pixels bright and moves the argmax; vips (20,124) vs libviprs (124,84)"]
+/// This used to be `#[ignore]`d because libviprs returned (124, 84), a real
+/// core parity gap rather than a stale expectation. `libviprs/libviprs#603`
+/// closed it and the cell is live again.
+///
+/// The mechanism is worth keeping written down, because it is a trap for the
+/// next operation that composes on `resize`. `vips_smartcrop_build`
+/// premultiplies once into a float image and `vips_resize` then works on it
+/// WITHOUT un-premultiplying ("This operation does not premultiply alpha" —
+/// `libvips/resample/resize.c`), so the analysis image keeps transparent areas
+/// at colour 0 all the way to the argmax. libviprs' `resize` premultiplies on
+/// its own (`libviprs/libviprs#458`, a deliberate divergence), so its bracket
+/// was un-premultiplying the already-premultiplied analysis image on the way
+/// out, and the 407 fully transparent pixels of the 32x32 working image came
+/// back as bright garbage (up to 255) where vips has 0. Those fake bright
+/// regions dominated the edge and skin scoring and moved the argmax. The core
+/// now drops the alpha band before the shrink, which is exactly what vips
+/// computes: it discards that band right after the resize anyway
+/// (`extract_band(0, "n", 3)`), and a resample that does not premultiply is
+/// per-band independent.
 fn test_smartcrop_rgba() {
     let im = decode_file(&ref_image("rgba.png")).unwrap();
     let (result, attention_x, attention_y) =
@@ -780,12 +782,12 @@ fn test_smartcrop_rgba() {
 ///
 /// Reference: test_conversion.py::test_smartcrop
 ///
-/// Same core parity gap as [`test_smartcrop_rgba`], and it reproduces
-/// identically here (libviprs returns (124, 84) on this path too): passing
-/// `premultiplied = true` only skips the smartcrop-level premultiply, it does
+/// Same core parity gap as [`test_smartcrop_rgba`], and it used to reproduce
+/// identically here (libviprs returned (124, 84) on this path too): passing
+/// `premultiplied = true` only skips the smartcrop-level premultiply, it did
 /// not stop `attention_crop`'s `resize_with` from bracketing its own
-/// premultiply / un-premultiply pair around the resize.
-#[ignore = "core parity gap: same attention_crop resize bracket as test_smartcrop_rgba; vips (20,124) vs libviprs (124,84)"]
+/// premultiply / un-premultiply pair around the resize. Fixed by
+/// `libviprs/libviprs#603` and live again.
 fn test_smartcrop_rgba_premultiplied() {
     let im = decode_file(&ref_image("rgba.png")).unwrap();
     let im = im.premultiply();


### PR DESCRIPTION
Companion to libviprs#611, which closes libviprs#603 and libviprs#604. Same
branch name, so the core repo's integration job clones the pair together.

`test_smartcrop_rgba` and `test_smartcrop_rgba_premultiplied` were `#[ignore]`d
against a real core parity gap rather than a stale expectation: `vips smartcrop
rgba.png out.png 80 60 --interesting attention` prints 20 then 124, and libviprs
returned (124, 84). libviprs#603 closes that, so the cells come back. Their
literals were already right, so nothing here moves an expectation — the
`#[ignore]` attributes and the "this stays ignored" sentences are all that go.

I kept the mechanism in the doc comments rather than dropping it with the
attribute, because it is a trap for whatever composes on `resize` next.
`vips_smartcrop_build` premultiplies once into float and `vips_resize` then
works on that image WITHOUT un-premultiplying ("This operation does not
premultiply alpha", `libvips/resample/resize.c`), so the analysis image keeps
transparent areas at colour 0 all the way to the argmax. libviprs' `resize`
premultiplies on its own (libviprs#458, a deliberate divergence), so its bracket
was un-premultiplying the already-premultiplied analysis image on the way out
and the 407 fully transparent pixels of the 32x32 working image came back as
bright garbage where vips has 0. The core now drops the alpha band before the
shrink, which is exactly what vips computes: it discards that band right after
the resize anyway (`extract_band(0, "n", 3)`), and a resample that does not
premultiply is per-band independent.

## Against the core branch

```
cargo test --features ported_tests --test ported_conversion
  test result: ok. 44 passed; 0 failed; 0 ignored     (was 42 passed, 2 ignored)

cargo fmt -- --check                                  ok
cargo test                                            748 passed, 0 failed, 11 ignored
cargo test --test resample_premultiplied_alpha_reference
                                                      8 passed, 0 failed
```

That last one is worth calling out rather than burying in the total. It is this
repo's vips-pinned low-alpha resample suite —
`rgba16_low_alpha_reduce_preserves_colour`,
`low_alpha_two_axis_reduce_matches_vips`, `integer_shrink_premultiplies_like_vips`
and the three `downscale_half_alpha_rounds_half_up` cells — so it is the closest
thing here to an independent check that the core's new un-premultiply dead zone
did not move anything that was already matching vips. It did not.

## COUNTERPART_REV is deliberately left alone

It still pins `0eb7a75`, where the core does not have the fix, so the `Ported
Cells (green subset)` job on this branch fails exactly these two cells until
libviprs#611 merges and the pin is bumped. Confirmed on this branch's run rather
than predicted:

```
test test_smartcrop_rgba ... FAILED
test test_smartcrop_rgba_premultiplied ... FAILED
  left: 124
 right: 20
test result: FAILED. 42 passed; 2 failed; 0 ignored
```

Nothing else in that job moved, and every other job on this branch is green.
That is the honest state of the pair; pinning the core PR's branch head instead
would go green now and leave a dangling SHA behind after the squash-merge.

## Unrelated, and worth an issue of its own

`./tools/run_ported_cells.sh` against the core branch is also red on
`ported_foreign::test_gifsave`, and that has nothing to do with this change:

```
thread 'test_gifsave' panicked at tests/ported_foreign.rs:2337:60:
called `Result::unwrap_err()` on an `Ok` value: [71, 73, 70, 56, 57, 97, ...]
```

The cell asserts the deferred-stub `Err`, and core `261b51d` (libviprs#596,
issues #570 and #571) landed a real still-image GIF encoder after this repo's
pin. So the cell fails against core `main` too, not just against this branch,
and it wants a companion from the GIF lane rather than a fix from here. Left
alone. CI confirms the reading: on this branch's `Ported Cells` run, which uses
the pinned `0eb7a75` where the stub is still a stub, `test_gifsave` passes.


