### PR TITLE
test(ported): follow the three GIF cells to the shipped encoder (closes #153)

### DIFF
--- a/COUNTERPART_REV
+++ b/COUNTERPART_REV
@@ -118,4 +118,27 @@
 # cannot compile against the old pin. Also carries #598, which fused the
 # convolution inner loop, and #561 and #556, which deliberately moved output bytes
 # for cast and the Lab to LabS store.
-0eb7a753e019b5adce27ba0ab063f4b952c67966
+#
+# Bumped to 261b51d, which is libviprs #596 (issues #570 and #571): still-image
+# GIF load and save. This is the minimal commit that carries the encoder, and it
+# is deliberately not the current core main. Three ported GIF cells cannot be
+# verified against a pin that predates it: `test_gifsave` asserted the deferred
+# `EncodeError::Unsupported` stub and now gets real GIF89a bytes back, so
+# `unwrap_err()` panics on an `Ok`, and `test_gifload` and
+# `test_gifload_truncated` were `#[ignore]`d against a missing encoder and a
+# decode path that rejected a broken tail. All three follow the shipped
+# behaviour in this commit.
+#
+# I stopped here rather than at core main so this bump carries one behaviour
+# change and nothing else. The four commits above 261b51d on core main (#601
+# zero-based decode_tiff_page, #602 the direct Lch/Cmc to LabS edges, #599
+# canny, #600 the .v trailer) each have or want a companion of their own, and
+# folding them in would put four unrelated changes under this lane's
+# verification.
+#
+# Anything downstream of #596 in this repo is load and save structure, not
+# bytes: the quantiser is median cut against vips's libimagequant, so the cells
+# pin palette size, the reserved transparent index, the interlace flag and
+# round-trip fidelity rather than byte-identical output. The measured facts are
+# `oracle-captures/foreign-gif/oracle.json` in the core repo.
+261b51d4aeada416102d20eba807815f5f77c310

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,6 +890,7 @@ dependencies = [
  "ab_glyph",
  "blake3",
  "flate2",
+ "gif",
  "image",
  "image-webp",
  "lopdf",

--- a/tests/ported_foreign.rs
+++ b/tests/ported_foreign.rs
@@ -2152,7 +2152,6 @@ fn test_webp() {
 }
 
 #[test]
-#[ignore = "GIF decodes but does not match the libvips reference PNG pixel-for-pixel; animated-GIF frame compositing parity is deferred"]
 /// GIF load/save.
 ///
 /// ## Required API
@@ -2168,11 +2167,19 @@ fn test_webp() {
 /// 2. Verify dimensions and band count.
 /// 3. Encode to GIF buffer, verify round-trip dimensions.
 ///
+/// libviprs#596 (issues #570 and #571) landed both halves, so this runs.
+/// The literals are the vips 8.18.4 capture in
+/// `oracle-captures/foreign-gif/oracle.json`: `loads["trans-x.gif"]` is
+/// 100x100 with FOUR bands and one page, because a frame declares a
+/// transparent index and `nsgifload.c:271` sizes the image
+/// `has_transparency ? 4 : 3`.
+///
 /// Reference: test_foreign.py::test_gif
 fn test_gifload() {
     let im = decode_file(&ref_image("trans-x.gif")).unwrap();
-    assert!(im.width() > 0);
-    assert!(im.height() > 0);
+    assert_eq!((im.width(), im.height()), (100, 100));
+    assert_eq!(im.format(), PixelFormat::Rgba8);
+    assert_eq!(im.get_int("n-pages"), Some(1));
 
     let buf = im.encode_gif(gif::SaveOptions::default()).unwrap();
     let im2 = decode_bytes(&buf).unwrap();
@@ -2241,7 +2248,6 @@ fn test_gifload_animation_dispose_previous() {
 }
 
 #[test]
-#[ignore = "needs the deferred fail_on strictness knob; decode_file_fail_on always errors, so the is_ok assertion cannot hold"]
 /// Truncated GIF loads normally but fails with fail_on="warning"/"truncated".
 ///
 /// ## Required API
@@ -2253,14 +2259,31 @@ fn test_gifload_animation_dispose_previous() {
 ///
 /// ## Test logic (from libvips test_foreign.py::test_gifload_truncated)
 ///
-/// 1. Load truncated.gif normally — should succeed.
-/// 2. Load with fail_on="warning" — should fail.
-/// 3. Load with fail_on="truncated" — should fail.
+/// 1. Load truncated.gif normally, which should succeed.
+/// 2. Load with fail_on="warning", which should fail.
+/// 3. Load with fail_on="truncated", which should fail.
+///
+/// Step 1 is what libviprs#596 moved: the previous decode path rejected the
+/// broken tail outright, and the codec now keeps the rows that did arrive.
+/// The geometry is the vips 8.18.4 capture in
+/// `oracle-captures/foreign-gif/oracle.json`: `loads["truncated.gif"]` is
+/// 575x800 with FOUR bands, because a frame that runs out of data leaves
+/// the rest of the canvas uncomposited and therefore transparent, and that
+/// is what sets `has_transparency` even though the graphic control
+/// extension clears the transparency flag.
+///
+/// Steps 2 and 3 hold for a weaker reason than they look: `fail_on` is
+/// still the blanket `foreign_stubs` stub that errors for every level and
+/// every format, so they do not yet prove the truncation was noticed. They
+/// only become real when the strictness knob lands.
 ///
 /// Reference: test_foreign.py::test_gifload_truncated
 fn test_gifload_truncated() {
     let im = decode_file(&ref_image("truncated.gif"));
     assert!(im.is_ok(), "Truncated GIF should load normally");
+    let im = im.unwrap();
+    assert_eq!((im.width(), im.height()), (575, 800));
+    assert_eq!(im.format(), PixelFormat::Rgba8);
 
     let fail_warn = decode_file_fail_on(&ref_image("truncated.gif"), "warning");
     assert!(
@@ -2310,34 +2333,158 @@ fn test_gifload_frame_error() {
 }
 
 #[test]
-/// Animated GIF save roundtrip preserving metadata; interlace and dither effects.
+/// GIF save roundtrip preserving metadata; interlace and dither effects.
 ///
 /// ## Required API
 ///
 /// ```rust,ignore
-/// /// Encode raster as GIF bytes. Interlacing and the dither level (0.0 - 1.0)
-/// /// are fields on the options struct rather than separate methods.
+/// /// Encode raster as GIF bytes. Interlacing, the dither level (0.0 - 1.0)
+/// /// and the palette bitdepth are fields on the options struct rather than
+/// /// separate methods.
 /// fn Raster::encode_gif(&self, options: gif::SaveOptions) -> Result<Vec<u8>, EncodeError>;
 ///
-/// /// Get the number of pages (frames) in a multi-page image.
-/// fn Raster::get_n_pages(&self) -> u32;
+/// /// Read back a metadata integer, which is where the page count lives.
+/// fn Raster::get_int(&self, name: &str) -> Option<i64>;
 /// ```
 ///
 /// ## Test logic (from libvips test_foreign.py::test_gifsave)
 ///
-/// 1. Load an animated GIF, save to buffer, reload, verify page count matches.
-/// 2. Save interlaced GIF — size >= non-interlaced.
-/// 3. Save with higher dither — larger file.
+/// 1. Save to a buffer, reload, verify page count matches.
+/// 2. Save interlaced GIF, size >= non-interlaced, same pixels.
+/// 3. Save with a higher dither, the palette mapping moves.
+///
+/// libviprs#596 (issues #570 and #571) retired the deferred stub this cell
+/// used to pin, so it asserts the encoder rather than its absence. Every
+/// literal comes from the vips 8.18.4 capture in
+/// `oracle-captures/foreign-gif/oracle.json`:
+///
+/// * `saves.transparent_index_reservation`: vips reserves palette index 0
+///   for transparency whenever the palette does not saturate
+///   `min(255, 1 << bitdepth)` (`cgifsave.c:795-796`), so an ordinary
+///   OPAQUE image saved by `vips gifsave` reloads with FOUR bands.
+///   cramps.gif is exactly that case. It loads three-band, and at the
+///   default bitdepth 8 its sixteen colours leave the index free, so it
+///   comes back four-band. At bitdepth 2 the four entries saturate and it
+///   comes back three-band.
+/// * `saves.interlace`: `interlaced_flag` true, `progressive_flag` false,
+///   `reload_identical` true.
+/// * `saves.dither`: the level is not monotone in pixels changed for vips,
+///   and not monotone in bytes for libviprs either, measured on cramps.gif
+///   at bitdepth 2 as 5821, 5792, 5810, 5855 then 5747 bytes for dither
+///   0, 0.25, 0.5, 0.75 and 1.0. So upstream's "higher dither, larger file"
+///   is not a property either encoder has, and only the `dither == 0`
+///   identity is pinned as an equality. The rest is pinned as "the mapping
+///   moved".
+///
+/// Deferred: upstream reloads an ANIMATED GIF and matches the page count.
+/// #596 is still-image only and its loader takes frame 0, the way `vips
+/// gifload` defaults to `page = 0, n = 1`, so cogs.gif loads `n-pages 5`
+/// and re-saves to `n-pages 1`. The round trip is pinned on a one-frame
+/// source until the animation lane lands.
 ///
 /// Reference: test_foreign.py::test_gifsave
 fn test_gifsave() {
+    // 1. Round trip. trans-x.gif is one frame, and GIF's LZW is exactly
+    // lossless once the palette fits, so this is an identity.
     let im = decode_file(&ref_image("trans-x.gif")).unwrap();
-    // Deferred external codec: the encoder returns a typed
-    // EncodeError::Unsupported rather than bytes. Pin that contract.
-    let __err = im.encode_gif(gif::SaveOptions::default()).unwrap_err();
+    assert_eq!(im.get_int("n-pages"), Some(1));
+    let plain = im.encode_gif(gif::SaveOptions::default()).unwrap();
+    let back = decode_bytes(&plain).unwrap();
+    assert_eq!((back.width(), back.height()), (im.width(), im.height()));
+    assert_eq!(
+        back.get_int("n-pages"),
+        im.get_int("n-pages"),
+        "a one-frame source must reload with the same page count"
+    );
+    assert_eq!(
+        back.data(),
+        im.data(),
+        "the source palette fits, so the round trip is exact"
+    );
+
+    // The reserved transparent index, which is why an opaque source comes
+    // back carrying a band it did not have.
+    let opaque = decode_file(&ref_image("cramps.gif")).unwrap();
+    assert_eq!(opaque.format(), PixelFormat::Rgb8);
+    let spare = decode_bytes(&opaque.encode_gif(gif::SaveOptions::default()).unwrap()).unwrap();
+    assert_eq!(
+        spare.format(),
+        PixelFormat::Rgba8,
+        "bitdepth 8 leaves index 0 free, so the reload gains an alpha band"
+    );
+    let rgb: Vec<u8> = spare
+        .data()
+        .chunks_exact(4)
+        .flat_map(|p| &p[..3])
+        .copied()
+        .collect();
+    assert_eq!(rgb, opaque.data(), "the spare index must not move a colour");
+    let saturated = opaque
+        .encode_gif(gif::SaveOptions {
+            bitdepth: 2,
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(
+        decode_bytes(&saturated).unwrap().format(),
+        PixelFormat::Rgb8,
+        "four entries for four colours leaves no index free, so no alpha band"
+    );
+
+    // 2. Interlace.
+    let woven = im
+        .encode_gif(gif::SaveOptions {
+            interlaced: true,
+            ..Default::default()
+        })
+        .unwrap();
+    let woven_back = decode_bytes(&woven).unwrap();
+    assert_eq!(
+        back.get_int("interlaced"),
+        None,
+        "the default save is progressive"
+    );
+    assert_eq!(
+        woven_back.get_int("interlaced"),
+        Some(1),
+        "the interlace flag must reach the wire"
+    );
     assert!(
-        matches!(__err, EncodeError::Unsupported { .. }),
-        "deferred encoder must return typed Unsupported, got {__err:?}"
+        woven.len() >= plain.len(),
+        "interlacing reorders rows, so LZW cannot do better: {} < {}",
+        woven.len(),
+        plain.len()
+    );
+    assert_eq!(
+        woven_back.data(),
+        back.data(),
+        "interlacing changes storage, not pixels"
+    );
+
+    // 3. Dither, on a source that overflows the palette so there is a
+    // quantisation error to diffuse in the first place. cramps.gif at its
+    // own bitdepth 4 is exact and dither cannot move anything.
+    let nearest = gif::SaveOptions {
+        dither: 0.0,
+        bitdepth: 2,
+        ..Default::default()
+    };
+    let once = opaque.encode_gif(nearest).unwrap();
+    assert_eq!(
+        once,
+        opaque.encode_gif(nearest).unwrap(),
+        "the undithered path must be deterministic"
+    );
+    let diffused = opaque
+        .encode_gif(gif::SaveOptions {
+            dither: 1.0,
+            ..nearest
+        })
+        .unwrap();
+    assert_ne!(
+        decode_bytes(&diffused).unwrap().data(),
+        decode_bytes(&once).unwrap().data(),
+        "dithering must change which palette entry a pixel takes"
     );
 }
 


### PR DESCRIPTION
libviprs #596 (`261b51d`, closing libviprs#570 and libviprs#571) landed still-image GIF
load and save, and three ported cells stopped describing the code. Nothing in CI could
see it: the integration job compiles the ported cells (libviprs#595) but does not run
them, because they need libvips reference fixtures the runner does not have. A signature
break fails; a behavioural flip like this one walks straight through. That is the
intended trade rather than a defect, and it is why this one had to be found by hand.

It surfaces on any PR that bumps `COUNTERPART_REV` past `261b51d`, which is why #155 and
#156 both hit it at the same time and neither could fix it from where they sat.

## The evidence

Against core `261b51d`, before this change, running the six GIF cells with
`--include-ignored` so the deferred ones report too:

```
running 6 tests
test test_gifsave ... FAILED
test test_gifload_animation_dispose_previous ... FAILED
test test_gifload ... ok
test test_gifload_animation_dispose_background ... FAILED
test test_gifload_truncated ... ok
test test_gifload_frame_error ... FAILED

---- test_gifsave stdout ----
thread 'test_gifsave' panicked at tests/ported_foreign.rs:2337:60:
called `Result::unwrap_err()` on an `Ok` value: [71, 73, 70, 56, 57, 97, 100, 0, 100, 0, ...]

test result: FAILED. 2 passed; 4 failed; 0 ignored
```

`test_gifload` and `test_gifload_truncated` are the two that read `ok` there: they were
`#[ignore]`d and now pass, so the attribute is all that was standing between them and
green.

## What the three moved cells assert now

`test_gifsave` follows its own docstring, which always described the real test. I did not
derive a single expectation: the GIF lane's oracle work is committed at
`oracle-captures/foreign-gif/` in the core repo, and every literal traces to a key in its
`oracle.json`.

| what | where it comes from |
|---|---|
| the round trip is pixel-exact | GIF's LZW is lossless once the palette fits, `notes[0]` |
| an OPAQUE source reloads with FOUR bands | `saves.transparent_index_reservation`, vips keeps index 0 free whenever the palette does not saturate `min(255, 1 << bitdepth)` (`cgifsave.c:795-796`) |
| at bitdepth 2 the same source reloads with THREE | same block, `bitdepth2_unique8` |
| the interlace flag reaches the wire and moves no pixel | `saves.interlace`: `interlaced_flag` true, `progressive_flag` false, `reload_identical` true |
| `dither: 0.0` is a deterministic nearest-colour mapping | `saves.dither` |

cramps.gif is the opaque case, and it is worth spelling out because it is the trap: it
loads three-band, and at the default bitdepth 8 its sixteen colours leave index 0 free,
so it comes back four-band with the RGB untouched. That band count reaches operations
downstream, so it is a real pin rather than a curiosity.

What the docstring asked for and I deliberately did NOT assert is step 3's "higher
dither, larger file". It is false. On cramps.gif at bitdepth 2 the sizes run 5821, 5792,
5810, 5855 then 5747 bytes for dither 0, 0.25, 0.5, 0.75 and 1.0, so the largest file is
in the middle and the smallest is at full dither. vips is not monotone either
(`saves.dither` measures 0, 70, 95, 88, 90 pixels changed for the same levels), which is
why the capture pins only the `dither == 0` identity as an equality. I pinned that
identity and "a higher level moves the mapping", and said why in the doc comment so the
next person does not put the size assertion back.

Step 1's "animated GIF" is deferred rather than asserted, for the same honesty reason.
#596 is still-image only and its loader takes frame 0, the way `vips gifload` defaults to
`page = 0, n = 1`. Measured: cogs.gif loads `n-pages 5` and re-saves to `n-pages 1`,
garden.gif 35 to 1. So the page-count round trip is pinned on a one-frame source, with a
note saying what it is waiting for.

`test_gifload` and `test_gifload_truncated` lose their `#[ignore]` and gain the geometry
the capture records, because `width() > 0` is not much of a pin. trans-x.gif is 100x100
with four bands and one page; truncated.gif is 575x800 with four bands, four because a
frame that runs out of data leaves the rest of the canvas uncomposited and therefore
transparent, even though its graphic control extension clears the transparency flag.

One thing I want on the record rather than buried: `test_gifload_truncated`'s steps 2 and
3 pass for a weaker reason than they look. `decode_file_fail_on` is still the blanket
`foreign_stubs` stub that errors for every level and every format, so those two legs do
not yet prove the truncation was noticed. Only step 1 moved. I said so in the cell's doc
comment instead of letting it read as a strictness test it is not.

## Not changed

`test_gifload_frame_error` and the two `dispose-*` cells are untouched and stay
`#[ignore]`d. I checked that rather than assuming it, by running them against both pins:

```
                            core 0eb7a75 (old pin)     core 261b51d (new pin)
test_gifload_frame_error    "should succeed with       "should succeed with
                             fail_on=truncated"         fail_on=truncated"
dispose-background          left: 168  right: 504      left: 168  right: 504
dispose-previous            left: 100  right: 300      left: 100  right: 300
```

Byte-identical failures on both. `frame_error` wants the `fail_on` strictness knob, which
#596 did not touch. The two `dispose-*` cells compare against a reference PNG that stacks
every frame (504 = 3 x 168, 300 = 3 x 100), so they want animated-GIF frame compositing,
which is the animation lane rather than this one.

## The pin, and a suggestion for the other two

`COUNTERPART_REV` moves from `0eb7a75` to **`261b51d4aeada416102d20eba807815f5f77c310`**.
It has to move in this commit, because the cells cannot be verified against a revision
that predates the encoder they now describe.

I stopped at `261b51d` rather than at core `main`, which is four commits further on. That
is the minimal commit carrying #596, so this bump moves exactly one behaviour and nothing
else. The four above it (libviprs#601 zero-based `decode_tiff_page`, libviprs#602 the
direct Lch/Cmc to LabS edges, libviprs#599 canny, libviprs#600 the `.v` trailer) each have
or want a companion of their own, and folding them in would put four unrelated changes
under this lane's verification for no gain to the three cells at hand.

The `Cargo.lock` line is the pin's doing, not mine: core takes `gif` as a direct
dependency at `261b51d`, and `gif` was already a lock node because `image`'s `gif` feature
pulls it, so it is one new edge and zero new packages. Same shape as the lock line in
#151.

**On #155 and #156.** I think they should follow this pin rather than each bumping
separately, and here is the reasoning. Neither can go fully green at any commit that
exists on core `main` today, because #155 needs core#610 and #156 needs core#611 and
neither has merged. So their pins have to move again afterwards whatever they do now.
What this PR gives them in the meantime is that `test_gifsave` is no longer a red check
they cannot act on: with these cells merged, a pin anywhere at or past `261b51d` keeps it
green. My suggestion is that this PR carries the pin for the batch, #155 and #156 leave
`COUNTERPART_REV` alone, and one final bump to a core `main` commit containing #610 and
#611 lands after those merge. Three lanes each bumping to a different SHA, one of them a
branch head that goes dangling after a squash-merge, is the version I would avoid.

## Local gate

Every job the CI workflow runs, run in the worktree against core `261b51d`:

```
cargo fmt -- --check                                              ok
cargo clippy --all-targets -- -D warnings                         0 errors
cargo clippy --all-targets --features object-store-sink           0 errors
cargo clippy --all-targets --features packfile                    0 errors
cargo clippy --all-targets --features tracing                     0 errors
cargo test                                     748 passed, 0 failed, 11 ignored
cargo test --features "ported_tests tracing" --test phase3_tracing
                                                12 passed, 0 failed
cargo test --features object-store-sink (3 cells)
                                                17 passed, 0 failed, 3 ignored
./tools/run_ported_cells.sh --clippy                              0 errors
./tools/run_ported_cells.sh --require-fixtures    Green ported cells passed
```

`ported_foreign` inside that last run comes to **87 passed, 0 failed, 19 ignored**,
against 84 passed, 1 failed, 21 ignored on `main` at this pin, measured in a clean
detached worktree at `530b4f8` pointed at the same core. The three cells are the
whole delta: two out of `ignored` and into `passed`, and one out of `failed` and into
`passed`.

Baseline on `main` (`530b4f8`, the commit this branched from) against the pin `main`
names, `0eb7a75`: **748 passed, 0 failed, 11 ignored** on `cargo test`, so the default
suite is unchanged at 748/0/11. That is what I expect: nothing here touches a cell
outside `ported_foreign`, and the default `cargo test` does not build the ported cells at
all.

The reference fixtures are the pinned suite at `e01a479`, and `fixture_audit` runs first
in the ported script and passes, so the cells consumed a complete suite at the pinned
revision rather than whatever happened to be on disk.

Closes #153.

## CI on this branch

All eight jobs green on run
[32917556851](https://github.com/libviprs/libviprs-tests/actions/runs/32917556851):

```
Integration Tests                        pass   6m32s
Integration Tests (pdfium)               pass  11m02s
Ported Cells (green subset)              pass   2m08s
CLI Differential (all 17 op families)    pass   1m53s
Feature Cell (object-store-sink)         pass     22s
Feature Cell (packfile)                  pass     45s
Feature Cell (tracing)                   pass     36s
Lint                                     pass     25s
```

`Ported Cells` is the one that could not have been green before this change, and `CLI
Differential` is the one that actually exercises the pin bump, since it is the job that
clones core at `COUNTERPART_REV` and builds `viprs` against it. Both pass, so `261b51d`
moves nothing in the seventeen op families either.
