### PR TITLE
test(ported): assert the JPEG XL cell on both sides of the jxl feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         # feature-gated module can no longer ship green just because the default
         # harness never compiled that code. `-Dwarnings` means every gated test
         # target is fully type-checked and linted here.
-        feature: [object-store-sink, packfile, tracing]
+        feature: [object-store-sink, packfile, tracing, jxl]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/clone-counterpart

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,13 @@ packfile = ["libviprs/packfile"]
 # does not support `optional = true` on dev-deps), but they are only
 # *linked* from code guarded by `#[cfg(feature = "tracing")]`.
 tracing = ["libviprs/tracing"]
+# Activates the core crate's non-default `jxl` feature so `test_jxlsave` in
+# `tests/ported_foreign.rs` exercises the real JPEG XL round trip rather than
+# the typed refusal the default build reports (libviprs#500). The cell asserts
+# under both, so the feature is what decides which contract is pinned, not
+# whether anything is pinned at all. `tools/run_ported_cells.sh` runs it both
+# ways, the same shape `test_dz_zip` uses for `packfile`.
+jxl = ["libviprs/jxl"]
 
 [dependencies]
 libviprs = { path = "../libviprs" }
@@ -52,7 +59,9 @@ pdfium-render = { version = "0.9", optional = true }
 # here also reach the core `libviprs` crate's `image` dependency, so the ported
 # foreign cell's `decode_file`/`decode_bytes` calls gain the pure-Rust decoders
 # for these formats (bmp/gif/pnm/tga/ico/webp/hdr). See tools/run_ported_cells.sh
-# and issue #77. Encode-only external formats (heif/avif/jp2k/jxl) stay deferred.
+# and issue #77. Encode-only external formats (heif/avif/jp2k) stay deferred;
+# JPEG XL has a real decoder and a real lossless encoder as of libviprs#500,
+# behind the `jxl` feature above.
 image = { version = "0.25", default-features = false, features = [
     "jpeg", "png", "tiff", "bmp", "gif", "pnm", "tga", "ico", "webp", "hdr",
 ] }

--- a/tests/ported_foreign.rs
+++ b/tests/ported_foreign.rs
@@ -9,6 +9,7 @@
 //! Manual (#[ignore]) stubs document what remains to be implemented.
 
 use std::io::Cursor;
+use std::num::NonZeroU16;
 use std::path::Path;
 
 use image::ImageEncoder;
@@ -19,8 +20,9 @@ use libviprs::{
     TiffCompression, TileFormat, decode_bytes_fail_on, decode_file, decode_file_fail_on,
     decode_file_sequential, decode_file_with_shrink, decode_svg, decode_tiff_page,
     extract_page_image, extract_page_image_dpi, extract_page_image_with_background,
-    extract_page_image_with_password, generate_pyramid_region, gif, magickload, magickload_with,
-    pdf_info, pdf_info_with_password, thumbnail, thumbnail_crop, tiff_page_count, webp,
+    extract_page_image_with_password, generate_pyramid_region, gif, jxl, magickload,
+    magickload_with, pdf_info, pdf_info_with_password, thumbnail, thumbnail_crop, tiff_page_count,
+    webp,
 };
 
 mod common;
@@ -2733,30 +2735,75 @@ fn test_jp2ksave() {
 /// ## Required API
 ///
 /// ```rust,ignore
-/// fn Raster::encode_jxl(&self, lossless: bool) -> Result<Vec<u8>, EncodeError>;
+/// fn Raster::encode_jxl(&self, options: jxl::SaveOptions) -> Result<Vec<u8>, EncodeError>;
 /// fn decode_bytes(data: &[u8]) -> Result<Raster, DecodeError>;
 /// ```
 ///
 /// ## Test logic (from libvips test_foreign.py::test_jxlsave)
 ///
-/// libvips tests JXL entirely via save_load_buffer — no .jxl fixture file.
+/// libvips tests JXL entirely via save_load_buffer, with no .jxl fixture file.
 /// 1. Load sample.jpg as the source colour image.
 /// 2. Encode as JXL (lossy), decode, verify dimensions and avg within threshold.
 /// 3. Encode as JXL (lossless), decode, verify exact round-trip.
 /// 4. Lossy buffer should be much smaller than lossless.
 ///
+/// Steps 2 and 4 have no spelling here and that is the point rather than a
+/// gap. The only JPEG XL encoder reachable in pure Rust is `zune-jpegxl`,
+/// which is lossless modular and has no VarDCT path anywhere in it, so
+/// `jxlsave`'s `distance`, `Q`, `tier` and `effort` have nothing behind
+/// them. libviprs#620 made lossy unrepresentable rather than accepting one
+/// of those arguments and discarding it: `jxl::SaveOptions` carries a
+/// `Compression` whose one variant is `Lossless`, and `Compression` is
+/// `#[non_exhaustive]` so `Lossy { distance }` can join it later without
+/// breaking this cell. With no lossy buffer to produce there is nothing to
+/// compare a size against either.
+///
+/// Step 3 then needs no tolerance at all, because there is no quantisation
+/// anywhere in the pipeline and the round trip is the exact identity. The
+/// cell checks it at both integer carriers, since JPEG XL holds 16-bit
+/// samples natively where WebP does not.
+///
 /// Reference: test_foreign.py::test_jxlsave
 fn test_jxlsave() {
     let im = decode_file(&ref_image("sample.jpg")).unwrap();
 
-    // Lossy round-trip
-    // Deferred external codec: the encoder returns a typed
-    // EncodeError::Unsupported rather than bytes. Pin that contract.
-    let __err = im.encode_jxl(false).unwrap_err();
-    assert!(
-        matches!(__err, EncodeError::Unsupported { .. }),
-        "deferred encoder must return typed Unsupported, got {__err:?}"
+    let bytes = im.encode_jxl(jxl::SaveOptions::default()).unwrap();
+    // A bare codestream, which is also what `vips jxlsave --keep none`
+    // writes: the encoder emits no ISOBMFF box container, so there is
+    // nowhere for an ICC profile, an EXIF block or an XMP packet to go.
+    assert_eq!(&bytes[..2], b"\xff\x0a");
+
+    let back = decode_bytes(&bytes).unwrap();
+    assert_eq!((back.width(), back.height()), (im.width(), im.height()));
+    assert_eq!(back.format(), im.format());
+    assert_eq!(
+        back.data(),
+        im.data(),
+        "lossless JPEG XL is an exact identity"
     );
+
+    // The 16-bit carrier too, which is where JPEG XL and WebP part company:
+    // `encode_webp` refuses a wide raster because the format has no 16-bit
+    // sample, and this encoder does not have to.
+    let wide = im.cast(PixelFormat::Rgb16);
+    let wide_bytes = wide.encode_jxl(jxl::SaveOptions::default()).unwrap();
+    let wide_back = decode_bytes(&wide_bytes).unwrap();
+    assert_eq!(wide_back.format(), PixelFormat::Rgb16);
+    assert_eq!(
+        wide_back.data(),
+        wide.data(),
+        "the 16-bit round trip is exact as well"
+    );
+
+    // Float has no encoder behind it, and the refusal names the remedy
+    // rather than quantising silently. vips writes float samples natively.
+    let float = im.cast(PixelFormat::FloatF32(NonZeroU16::new(3).unwrap()));
+    let err = float
+        .encode_jxl(jxl::SaveOptions::default())
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("float"), "{err}");
+    assert!(err.contains("cast"), "{err}");
 }
 
 #[test]

--- a/tests/ported_foreign.rs
+++ b/tests/ported_foreign.rs
@@ -9,6 +9,8 @@
 //! Manual (#[ignore]) stubs document what remains to be implemented.
 
 use std::io::Cursor;
+// Only the `jxl`-feature-on body of `test_jxlsave` names a float carrier.
+#[cfg(feature = "jxl")]
 use std::num::NonZeroU16;
 use std::path::Path;
 
@@ -2763,10 +2765,23 @@ fn test_jp2ksave() {
 /// cell checks it at both integer carriers, since JPEG XL holds 16-bit
 /// samples natively where WebP does not.
 ///
+/// The codec landed behind libviprs' non-default `jxl` feature, so this cell
+/// has two bodies and asserts under both. `--features jxl` runs the round
+/// trip; the default build pins the typed refusal, the way `test_svgload`
+/// below pins `svg`'s. Two bodies rather than one `#[cfg]` on the whole test
+/// because a cell that silently stops asserting is the failure mode this
+/// suite exists to catch, and `tools/run_ported_cells.sh` runs it both ways
+/// for the same reason it runs `test_dz_zip` under `packfile`.
+///
 /// Reference: test_foreign.py::test_jxlsave
 fn test_jxlsave() {
     let im = decode_file(&ref_image("sample.jpg")).unwrap();
+    jxlsave_body(&im);
+}
 
+/// The `jxl`-feature-on body: the real round trip.
+#[cfg(feature = "jxl")]
+fn jxlsave_body(im: &Raster) {
     let bytes = im.encode_jxl(jxl::SaveOptions::default()).unwrap();
     // A bare codestream, which is also what `vips jxlsave --keep none`
     // writes: the encoder emits no ISOBMFF box container, so there is
@@ -2804,6 +2819,20 @@ fn test_jxlsave() {
         .to_string();
     assert!(err.contains("float"), "{err}");
     assert!(err.contains("cast"), "{err}");
+}
+
+/// The `jxl`-feature-off body: the encoder is compiled out, so it reports the
+/// typed `Unsupported` every format without an encoder in the build reports,
+/// carrying the name the caller asked for. The signature is the same one the
+/// feature-on body calls, which is the half of the contract that matters to a
+/// consumer who does not enable the feature.
+#[cfg(not(feature = "jxl"))]
+fn jxlsave_body(im: &Raster) {
+    let err = im.encode_jxl(jxl::SaveOptions::default()).unwrap_err();
+    assert!(
+        matches!(err, EncodeError::Unsupported { ref format } if format == "jxl"),
+        "without the jxl feature the encoder must refuse by name, got {err:?}"
+    );
 }
 
 #[test]

--- a/tools/run_ported_cells.sh
+++ b/tools/run_ported_cells.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # against the current core. The two codec cells (ported_foreign,
 # ported_connection) landed with the codec surface (core PRs #309-#315,
 # issue #77): the real-impl subset is green, and the genuinely-external codec
-# tests (HEIF/AVIF, JP2K, JPEG-XL, WebP/GIF encode, magick, SVG, UHDR,
+# tests (HEIF/AVIF, JP2K, WebP/GIF encode, magick, SVG, UHDR,
 # FITS/OpenEXR/OpenSlide/MAT/Analyze/NIfTI/Radiance, OJPEG/JPEG-in-TIFF/CCITT/
 # BigTIFF/tiled) either assert the typed Unsupported/decode contract or stay
 # `#[ignore]` with a precise reason. This script is the single source of truth
@@ -161,6 +161,18 @@ echo ""
 echo "Running the ZipSink cell under --features 'ported_tests packfile'..."
 run_leg "test_dz_zip (packfile)" \
     cargo test --features "ported_tests packfile" --no-fail-fast --test ported_foreign -- test_dz_zip
+
+# test_jxlsave has two bodies, for the same reason and in the same shape. The
+# green-cells leg above ran the feature-off one, which pins the typed refusal a
+# default build reports; this leg runs the round trip against the real codec.
+# libviprs put JPEG XL behind a non-default `jxl` feature (libviprs#500)
+# because it costs 21 crates, and without this leg the cell would stay green
+# while having quietly stopped touching the codec at all. It reads sample.jpg
+# from the reference suite fetched above.
+echo ""
+echo "Running the JPEG XL cell under --features 'ported_tests jxl'..."
+run_leg "test_jxlsave (jxl)" \
+    cargo test --features "ported_tests jxl" --no-fail-fast --test ported_foreign -- test_jxlsave
 
 echo ""
 echo "Running phase3_tracing under --features tracing (per-tile span tests)..."


### PR DESCRIPTION
**Supersedes #159**, which carries the first of these two commits and cannot be advanced: this repo's `basic` ruleset targets `~ALL` refs with a `pull_request` rule and no bypass actors, so a branch can be created but never pushed to again. Close #159 in favour of this one, or merge #159 first and this on top; the two commits are ordered so either works.

Companion to libviprs#628 (issues libviprs#500, libviprs#619, libviprs#620, libviprs#622). **Do not merge before the core PR**: `encode_jxl`'s signature moves there and the `jxl` feature does not exist until it lands, so this branch cannot even resolve its manifest against the current `COUNTERPART_REV`.

## What changed since #159

libviprs put JPEG XL behind a **non-default `jxl` feature** after the adversarial panel held libviprs#628 on the dependency graph: unconditional `jxl-oxide` and `zune-jpegxl` add 21 crates to what a consumer compiles, one of them `tracing`, which that crate deliberately keeps opt-in.

That gave `test_jxlsave` two ways to go wrong, and #159 as it stands takes the first:

- assert the round trip, and stop compiling on a default build, or
- assert the refusal, and quietly stop touching the codec at all.

It now does both. The cell keeps one name and one fixture load and hands off to one of two bodies, so the feature decides *which* contract is pinned rather than *whether* anything is pinned. `test_svgload` two cells down is the shape I copied for the refusal half, and it is the shape this suite already uses for a core feature it does not enable.

The round trip is the arm that would otherwise never run anywhere, so `tools/run_ported_cells.sh` runs the cell a second time under `--features "ported_tests jxl"`, right next to the `test_dz_zip` leg that does exactly this for `packfile`. A `jxl` feature forwards to `libviprs/jxl` and joins the feature-cell matrix beside `packfile` and `tracing`, so a lint or build regression under the gated code cannot ship green because the default harness never compiled it.

## Local run

Built and run against the core branch `feat/500-jxl` through a sibling checkout, which is the layout libviprs' own integration job uses:

```
cargo fmt -- --check                                              clean
cargo test --features ported_tests --no-run                       builds
cargo test --features "ported_tests jxl" --no-run                 builds
cargo test --features ported_tests --test ported_foreign -- test_jxlsave
  test test_jxlsave ... ok      (the refusal body)
cargo test --features "ported_tests jxl" --test ported_foreign -- test_jxlsave
  test test_jxlsave ... ok      (the round-trip body)
cargo test --features ported_tests --test ported_foreign -- test_svgload test_webp
  2 passed                      (the shared import block is intact)
```

## Not changed

`COUNTERPART_REV` stays where it is. It gets the core merge SHA once libviprs#628 lands, not before.

**Expect every check on this branch to be red until then, not just the new one.** `jxl = ["libviprs/jxl"]` is a manifest-level statement, so cargo refuses to resolve the workspace at all against a core that has no such feature, and that stops each job before it compiles anything. #159 was red on one job for a narrower version of the same reason. There is no way to declare the feature and keep resolving against the old pin, so this is the ordering rather than a fault in the branch: merge libviprs#628, bump `COUNTERPART_REV`, and the checks have something to say.

