### PR TITLE
test: tighten the colour tolerances and un-ignore the smartcrop cell (closes #163)

### DIFF
--- a/tests/cli_colour_diff.rs
+++ b/tests/cli_colour_diff.rs
@@ -24,8 +24,8 @@
 //! | `colourspace … xyz`   | `.v` float | 1e-4 | 1.5e-5 |
 //! | `colourspace … scrgb` | `.v` float | 1e-4 | 1.0e-6 |
 //! | `colourspace … lab` → PNG (#36) | PNG uchar | 1 (≤1 LSB) | 0 |
-//! | `colourspace icc_pcs_lab.v … srgb` → PNG (#36 non-round-trip) | PNG uchar | 1 (≤1 LSB) | 1 |
-//! | `colourspace --source-space lab` → PNG | PNG uchar | 1 (≤1 LSB) | 1 |
+//! | `colourspace icc_pcs_lab.v … srgb` → PNG (#36 non-round-trip) | PNG uchar | 0 (EXACT) | 0 |
+//! | `colourspace --source-space lab` → PNG | PNG uchar | 0 (EXACT) | 0 |
 //! | `dE76` | `.v` float | 1e-4 | 6.5e-5 |
 //! | `dE00` | `.v` float | 1e-4 | 6.5e-5 |
 //! | `dECMC` (GOLDEN-ONLY) | `.v` float | 1e-3 | 0 (viprs self-pin) |
@@ -60,9 +60,30 @@ use tempfile::TempDir;
 /// so the two agree to well under 1e-4 (measured ≤6.5e-5).
 const FLOAT_TOL: f64 = 1e-4;
 
-/// BOUNDED-TOL ≤1 LSB for the interpretation-aware PNG saves (`colourspace … lab`
-/// written to an integer sink runs the vips-style LAB→sRGB conversion, #36; and
-/// the `--source-space` override): uchar, measured 0 / 1.
+/// EXACT: bit-exact decode comparison (`CLI_CONTRACT.md` §5). The two
+/// non-round-trip `colourspace … → PNG` cells below used to sit at ≤1 LSB
+/// and now measure 0, because libviprs core #581 ported the interpolated
+/// `Y2v` lookup vips actually uses for the linear → sRGB store
+/// (`colour/LabQ2sRGB.c:126-146`, `:282-353`) instead of evaluating the
+/// transfer function analytically. That was the whole of the deviation:
+/// on the neutral LabS L sweep it moved 16295 of 98304 sRGB codes by one
+/// count, and the two cells here were seeing the tail of it.
+const EXACT: f64 = 0.0;
+
+/// BOUNDED-TOL ≤1 LSB for the ROUND-TRIP interpretation-aware PNG save
+/// (`colourspace … lab` written to an integer sink runs the vips-style
+/// LAB→sRGB conversion, #36): uchar, measured 0.
+///
+/// This is the only ≤1-LSB cell left in the file, and it is deliberate
+/// rather than left over. It measures 0 and always has: the
+/// round trip indexes the `Y2v` table with an exact integer and never
+/// interpolates, so it was never exposed to the #581 mechanism at all.
+/// The band it keeps is the cross-arch one — the table is built with
+/// `powf` in `f32`, and a libm that lands an ULP away on some other host
+/// would shift a table entry and therefore a code. Do NOT fold the two
+/// EXACT cells back into this constant: they are exact for a reason and
+/// sharing a number is how the last conflation happened (see the
+/// `sharpen` note in `cli_convolution_diff.rs`).
 const UCHAR_1LSB: f64 = 1.0;
 
 /// BOUNDED-TOL ≤2 LSB for the device-space ICC round trips (`icc_export`,
@@ -203,8 +224,9 @@ fn colourspace_lab_to_png_runs_interpretation_aware_save() {
 // rgb.png), so an identity/no-op colourspace would still pass it; here the
 // reference DIFFERS from the input, so a raw-cast / no-op colourspace would
 // garble the output. This makes the PNG path discriminate the colourspace
-// transform itself, not just the interpretation-aware save. uchar ≤1 LSB
-// (measured 1).
+// transform itself, not just the interpretation-aware save. EXACT (tol 0)
+// since libviprs core #581; it used to be ≤1 LSB at measured 1, and the 1
+// was the interpolated-LUT deviation in the linear → sRGB store.
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -222,7 +244,7 @@ fn colourspace_lab_input_to_png_discriminates_the_transform() {
     decode_compare(
         &out,
         &cli_fixture("colour/colourspace_lab_input_png_expected.png"),
-        UCHAR_1LSB,
+        EXACT,
     );
 }
 
@@ -230,7 +252,7 @@ fn colourspace_lab_input_to_png_discriminates_the_transform() {
 // colourspace --source-space — force the sRGB-tagged input to be read as LAB,
 // then convert to sRGB. Genuinely discriminating: if --source-space were ignored
 // the op would collapse to the srgb->srgb identity (255 apart from this result).
-// uchar ≤1 LSB (measured 1).
+// EXACT (tol 0) since libviprs core #581, same mechanism as the cell above.
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -250,7 +272,7 @@ fn colourspace_source_space_override_matches_vips() {
     decode_compare(
         &out,
         &cli_fixture("colour/colourspace_srcspace_expected.png"),
-        UCHAR_1LSB,
+        EXACT,
     );
 }
 

--- a/tests/cli_convolution_diff.rs
+++ b/tests/cli_convolution_diff.rs
@@ -56,14 +56,18 @@
 //!   nothing about per-pixel error `sum((w_hat - w) * p)`.
 //!   `conv_hostile_mask_matches_vips_exact` uses a mask that gate **accepts**
 //!   and on which the two paths differ by **57**.
-//! * **BOUNDED-TOL ≤1 LSB (tol 1) — `sharpen` ONLY.** This is a separate
-//!   tolerance with a separate cause and it must not be folded back into the
-//!   one above. `sharpen` convolves the L of LabS, which is 16-bit, and the
-//!   vector path is gated on `BandFmt == VIPS_FORMAT_UCHAR` (`convi.c:1151`),
-//!   so `sharpen` takes the portable C path on **both** libvips builds
-//!   (`VIPS_INFO=1` reports "convi: using C path"). #558 cannot be its
-//!   mechanism. The remaining deviation is a real libviprs bug, issue #581,
-//!   which the shared constant was concealing.
+//! * **`sharpen` is EXACT (tol 0) as of libviprs core #581.** It used to
+//!   carry its own ≤1-LSB band. #558 split that off from the integer-`conv`
+//!   constant and showed the vector path could not explain it — the vector
+//!   path is gated on `BandFmt == VIPS_FORMAT_UCHAR` (`convi.c:1151`) and
+//!   `sharpen` convolves the L of LabS, which is 16-bit, so both libvips
+//!   builds take the portable C path (`VIPS_INFO=1` reports "convi: using C
+//!   path"). #581 then found the deviation was never in the convolution at
+//!   all: it was in the `scRGB -> sRGB` store the sharpened LabS comes back
+//!   through, where libviprs evaluated the transfer function analytically
+//!   and vips reads an interpolated integer LUT
+//!   (`colour/LabQ2sRGB.c:126-146`, `:282-353`). With the LUT ported,
+//!   `sharpen` matches vips byte for byte.
 //! * **BOUNDED-TOL float (small eps)** — the large-magnitude float image
 //!   surfaces (`conv`/`compass`/`gaussblur` float, `convsep`, measured ≤1.5e-5
 //!   on the author Mac — the core's two-pass accumulation order differs from
@@ -113,22 +117,6 @@ use tempfile::TempDir;
 /// EXACT: bit-exact decode comparison (CLI_CONTRACT.md §5). Used for the
 /// scale-1 compass, fastcor, and the integer-valued gaussmat/logmat matrices.
 const EXACT: f64 = 0.0;
-
-/// BOUNDED-TOL ≤1 LSB for **`sharpen` and nothing else** (issue #581).
-///
-/// This used to be shared with integer `conv`/`gaussblur`, and sharing it was
-/// hiding two unrelated causes under one number. Integer convolution on uchar
-/// is now EXACT against a `VIPS_NOVECTOR=1` reference (#558); what is left
-/// here is `sharpen`'s own deviation, which #558 demonstrably cannot explain:
-/// `sharpen` runs its unsharp mask on the L of LabS, which is 16-bit, and
-/// `vips_convi`'s vector path is gated on `BandFmt == VIPS_FORMAT_UCHAR`
-/// (`convi.c:1151`), so both libvips builds take the portable C path here —
-/// `VIPS_INFO=1` says "convi: using C path" on the plain binary.
-///
-/// Measured max-abs-diff 1 on this fixture and 44 of 256 samples deviating.
-/// Do NOT reuse this constant for another op: give the next deviation its own
-/// name and its own explanation, or the same conflation happens again.
-const SHARPEN_LSB: f64 = 1.0;
 
 /// BOUNDED-TOL for the large-magnitude float image surfaces
 /// (`conv`/`compass`/`gaussblur` float, `convsep`). Measured ≤1.5e-5 on the
@@ -742,17 +730,17 @@ fn gaussblur_float_matches_vips_bounded_tol() {
 // ---------------------------------------------------------------------------
 // sharpen — S1, LabS unsharp mask. m1/m2 nonzero so it truly sharpens.
 //
-// This is the ONLY remaining tolerance in the cell, it has its own constant,
-// and it is NOT issue #558. sharpen convolves the L of LabS, which is 16-bit,
-// and `vips_convi`'s vector path is gated on `BandFmt == VIPS_FORMAT_UCHAR`
-// (convi.c:1151), so both libvips builds take the portable C path here —
-// confirmed with VIPS_INFO=1. 44 of 256 samples deviate; that is a real
-// libviprs bug, tracked as issue #581, and until #558 it was hiding under a
-// constant shared with integer conv.
+// EXACT (tol 0) as of libviprs core #581. This cell carried the last tolerance
+// in the file, at 44 of 256 samples deviating by 1, and it was never the
+// convolution: #558 ruled the vector path out (16-bit LabS takes the portable
+// C path on both builds, convi.c:1151, confirmed with VIPS_INFO=1), and #581
+// tracked it to the scRGB -> sRGB store on the way back out of LabS, where
+// vips reads an interpolated integer LUT and libviprs was evaluating the
+// curve. Do not re-add a band here without a mechanism to name.
 // ---------------------------------------------------------------------------
 
 #[test]
-fn sharpen_matches_vips_bounded_tol() {
+fn sharpen_matches_vips_exact() {
     if skip_if_no_cli("sharpen") {
         return;
     }
@@ -771,7 +759,7 @@ fn sharpen_matches_vips_bounded_tol() {
     decode_compare(
         &out,
         &cli_fixture("convolution/sharpen_expected.png"),
-        SHARPEN_LSB,
+        EXACT,
     );
 }
 

--- a/tests/ported_conversion.rs
+++ b/tests/ported_conversion.rs
@@ -735,23 +735,25 @@ fn test_smartcrop_attention() {
 ///
 /// The literals are right: `vips smartcrop rgba.png out.png 80 60 --interesting
 /// attention --attention-x --attention-y` on vips 8.18.4 prints 20 then 124.
-/// libviprs returns (124, 84), and that is a core parity gap, not a stale
-/// expectation, so this stays `#[ignore]` rather than being re-pinned to the
-/// wrong answer. Mechanism: `vips_smartcrop_build` premultiplies once into a
-/// float image and `vips_resize` then works on it WITHOUT un-premultiplying
-/// ("This operation does not premultiply alpha" — `libvips/resample/resize.c`),
-/// so the analysis image keeps transparent areas at colour 0. libviprs'
-/// `attention_crop` calls `resize_with` with the default
-/// `ResizeOptions::premultiplied = false`, so the core's own premultiply
-/// bracket (libviprs/libviprs#458) un-premultiplies the already-premultiplied
-/// analysis image on the way out, and the 407 fully transparent pixels of the
-/// 32x32 working image come back as bright garbage (up to 255) where vips has
-/// 0. Those fake bright regions dominate the edge and skin scoring and move the
-/// argmax. Confirmed by isolation: hand the same premultiplied image to
-/// libviprs with the alpha band dropped and it returns vips' (20, 124)
-/// exactly, and the no-alpha `test_smartcrop_attention` above already matches
-/// vips bit for bit.
-#[ignore = "core parity gap: attention_crop resizes the premultiplied analysis image without ResizeOptions::premultiplied, so its un-premultiply turns transparent pixels bright and moves the argmax; vips (20,124) vs libviprs (124,84)"]
+/// This used to be `#[ignore]`d because libviprs returned (124, 84), a real
+/// core parity gap rather than a stale expectation. `libviprs/libviprs#603`
+/// closed it and the cell is live again.
+///
+/// The mechanism is worth keeping written down, because it is a trap for the
+/// next operation that composes on `resize`. `vips_smartcrop_build`
+/// premultiplies once into a float image and `vips_resize` then works on it
+/// WITHOUT un-premultiplying ("This operation does not premultiply alpha" —
+/// `libvips/resample/resize.c`), so the analysis image keeps transparent areas
+/// at colour 0 all the way to the argmax. libviprs' `resize` premultiplies on
+/// its own (`libviprs/libviprs#458`, a deliberate divergence), so its bracket
+/// was un-premultiplying the already-premultiplied analysis image on the way
+/// out, and the 407 fully transparent pixels of the 32x32 working image came
+/// back as bright garbage (up to 255) where vips has 0. Those fake bright
+/// regions dominated the edge and skin scoring and moved the argmax. The core
+/// now drops the alpha band before the shrink, which is exactly what vips
+/// computes: it discards that band right after the resize anyway
+/// (`extract_band(0, "n", 3)`), and a resample that does not premultiply is
+/// per-band independent.
 fn test_smartcrop_rgba() {
     let im = decode_file(&ref_image("rgba.png")).unwrap();
     let (result, attention_x, attention_y) =
@@ -780,12 +782,12 @@ fn test_smartcrop_rgba() {
 ///
 /// Reference: test_conversion.py::test_smartcrop
 ///
-/// Same core parity gap as [`test_smartcrop_rgba`], and it reproduces
-/// identically here (libviprs returns (124, 84) on this path too): passing
-/// `premultiplied = true` only skips the smartcrop-level premultiply, it does
+/// Same core parity gap as [`test_smartcrop_rgba`], and it used to reproduce
+/// identically here (libviprs returned (124, 84) on this path too): passing
+/// `premultiplied = true` only skips the smartcrop-level premultiply, it did
 /// not stop `attention_crop`'s `resize_with` from bracketing its own
-/// premultiply / un-premultiply pair around the resize.
-#[ignore = "core parity gap: same attention_crop resize bracket as test_smartcrop_rgba; vips (20,124) vs libviprs (124,84)"]
+/// premultiply / un-premultiply pair around the resize. Fixed by
+/// `libviprs/libviprs#603` and live again.
 fn test_smartcrop_rgba_premultiplied() {
     let im = decode_file(&ref_image("rgba.png")).unwrap();
     let im = im.premultiply();


### PR DESCRIPTION
Two sets of expectations in this suite were deliberately weakened around core gaps that the epic #520 batch has now closed. With the counterpart pinned at `f62a56a` (#162), they can be tightened back.

**Two colour cells were pinned at ≤1 LSB instead of exact.** `colourspace icc_pcs_lab.v … srgb` and `colourspace --source-space lab`, both to PNG, sat at a tolerance of 1 because libviprs evaluated the sRGB transfer function analytically where vips interpolates a rounded `Y2v` lookup. libviprs#610 ports that lookup, so both go to EXACT (tolerance 0).

**A smartcrop RGBA cell was `#[ignore]`d for a real parity gap.** `attention_crop` resized the premultiplied analysis image without `ResizeOptions::premultiplied`, so the core's own premultiply bracket un-premultiplied an already-premultiplied image, 407 fully transparent pixels came back as bright garbage, and that moved the argmax: vips (20, 124) against libviprs (124, 84). libviprs#611 fixes it, so the cell can assert the real answer instead of carrying a paragraph explaining why it cannot.

The convolution differential cells move with the first group, since the same LUT change touches `sharpen`.

Work already done on branches that predate the batch: #155 and #156 each carry one half. Both are stuck at a single commit because the repository's `basic` ruleset applies to `~ALL` branches with a `pull_request` rule and no bypass actors, so a branch here can be created but never pushed to again. Rather than leave two stale branches, the changes are being carried onto one fresh branch together and #155 / #156 closed as superseded.

Verified with the two checkouts laid out as siblings, the way the integration job lays them out: **748 passed, 0 failed, 11 ignored**.

Closes #163
