### PR TITLE
tools: let a repo's own local-ci.py drive its pre-commit hook (closes #165)

### DIFF
--- a/tests/install_hooks_localci_selection.rs
+++ b/tests/install_hooks_localci_selection.rs
@@ -1,0 +1,177 @@
+//! Guards that `write_pre_commit` (`tools/install-hooks.sh`) actually picks
+//! between its two pre-commit templates on whether the target repo ships
+//! `tools/local-ci.py`: present, it gets a hook that defers to it; absent, it
+//! gets the hardcoded per-repo cargo list.
+//!
+//! `tests/install_hooks_mirror_ci.rs` exercises the hardcoded list's
+//! *contents* in detail, but its synthetic `Workspace` never lays down a
+//! `tools/local-ci.py` anywhere, so neither the detection logic nor the
+//! LOCALCI branch itself was exercised by anything before this — and
+//! `libviprs` ships `tools/local-ci.py` today, so that branch is live for
+//! every real contributor.
+//!
+//! Both branches are driven by actually running the installed hook, with a
+//! recording stand-in in place of whatever each branch shells out to, rather
+//! than by reading the hook's text (libviprs/libviprs#695).
+
+use std::process::Command;
+
+mod common;
+use common::hooks::{Workspace, make_executable};
+
+/// A stand-in for `tools/local-ci.py` that just proves it ran. Carries a
+/// real shebang so that invoking it directly by path (rather than through
+/// `python3 <path>`) also works, which matters for the two tests here that
+/// are not about the executable-bit fix and would otherwise fail for an
+/// unrelated reason under the pre-fix hook.
+const RECORDING_LOCALCI: &str = r#"#!/usr/bin/env python3
+import os
+with open(os.environ["LOCALCI_RECORD"], "a") as f:
+    f.write("LOCALCI-RAN\n")
+"#;
+
+/// A recording `cargo`, the same stand-in `tests/install_hooks_mirror_ci.rs`
+/// uses to let the hardcoded fallback branch run to completion without a
+/// real cargo project.
+const RECORDING_CARGO: &str = r#"#!/bin/sh
+printf 'cargo %s\n' "$*" >> "$CARGO_RECORD"
+exit 0
+"#;
+
+/// Run `repo`'s installed pre-commit hook with a recording `cargo` in front
+/// of it and a stand-in `tools/run_ported_cells.sh` beside it, and report
+/// what each side of the branch recorded: whatever `cargo` saw, and whatever
+/// `local-ci.py` saw.
+fn run_hook(ws: &Workspace, repo: &str) -> (String, String) {
+    let repo_dir = ws.repo(repo);
+    let hook = repo_dir.join(".git/hooks/pre-commit");
+    assert!(
+        hook.is_file(),
+        "no pre-commit hook was installed into {repo}, so this guard would \
+         pass on two empty recordings"
+    );
+
+    let bin = ws.root.join("cargo-recorder").join(repo);
+    std::fs::create_dir_all(&bin).expect("create the recorder directory");
+    let cargo = bin.join("cargo");
+    std::fs::write(&cargo, RECORDING_CARGO).expect("write the recording cargo");
+    make_executable(&cargo);
+
+    // The fallback hook reaches this one by relative path rather than
+    // through PATH (tests/install_hooks_mirror_ci.rs does the same).
+    let ported = repo_dir.join("tools/run_ported_cells.sh");
+    std::fs::create_dir_all(ported.parent().expect("tools dir")).expect("create tools dir");
+    std::fs::write(&ported, "#!/bin/sh\nexit 0\n").expect("write a stand-in run_ported_cells.sh");
+    make_executable(&ported);
+
+    let cargo_record = ws.root.join(format!("{repo}.cargo.record"));
+    let localci_record = ws.root.join(format!("{repo}.localci.record"));
+    let _ = std::fs::remove_file(&cargo_record);
+    let _ = std::fs::remove_file(&localci_record);
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    let out = Command::new("bash")
+        .arg(&hook)
+        .current_dir(&repo_dir)
+        .env("PATH", path)
+        .env("CARGO_RECORD", &cargo_record)
+        .env("LOCALCI_RECORD", &localci_record)
+        .output()
+        .expect("run the generated pre-commit hook");
+    assert!(
+        out.status.success(),
+        "the pre-commit hook for {repo} failed with every command stubbed to \
+         succeed:\n{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    (
+        std::fs::read_to_string(&cargo_record).unwrap_or_default(),
+        std::fs::read_to_string(&localci_record).unwrap_or_default(),
+    )
+}
+
+/// A repo with no `tools/local-ci.py` gets the hardcoded per-repo cargo list,
+/// and nothing else.
+#[test]
+fn a_repo_without_local_ci_py_gets_the_hardcoded_fallback() {
+    let ws = Workspace::new();
+
+    let (cargo_ran, localci_ran) = run_hook(&ws, "libviprs-tests");
+
+    assert!(
+        !cargo_ran.is_empty(),
+        "libviprs-tests has no tools/local-ci.py, so its pre-commit hook must \
+         run the hardcoded cargo step list; nothing was recorded"
+    );
+    assert!(
+        localci_ran.is_empty(),
+        "libviprs-tests has no tools/local-ci.py, so its pre-commit hook must \
+         not have run one:\n{localci_ran}"
+    );
+}
+
+/// A repo that ships `tools/local-ci.py` gets a hook that defers to it
+/// instead of the hardcoded list.
+#[test]
+fn a_repo_with_local_ci_py_defers_to_it_instead() {
+    let ws = Workspace::new();
+
+    let local_ci = ws.repo("libviprs").join("tools/local-ci.py");
+    ws.commit(
+        "libviprs",
+        "add a recording stand-in for local-ci.py",
+        &[("tools/local-ci.py", RECORDING_LOCALCI)],
+    );
+    make_executable(&local_ci);
+    ws.install_hooks();
+
+    let (cargo_ran, localci_ran) = run_hook(&ws, "libviprs");
+
+    assert!(
+        !localci_ran.is_empty(),
+        "libviprs now ships tools/local-ci.py, so its pre-commit hook must \
+         defer to it; it never ran"
+    );
+    assert!(
+        cargo_ran.is_empty(),
+        "libviprs ships tools/local-ci.py, so its pre-commit hook must not \
+         also run the hardcoded cargo list:\n{cargo_ran}"
+    );
+}
+
+/// Low-severity fix, same review round: the hook used to invoke
+/// `local-ci.py` directly by path, relying on its shebang and the executable
+/// bit. A present-but-not-executable script failed with a confusing
+/// "Permission denied" while the hook's own error text claimed "CI will fail
+/// the same way," which was false for what was actually a local permissions
+/// problem. Invoking it through `python3` instead means the executable bit
+/// no longer matters at all — assert that directly with a stand-in that is
+/// deliberately left non-executable.
+#[test]
+fn the_localci_hook_runs_it_even_when_it_is_not_executable() {
+    let ws = Workspace::new();
+
+    ws.commit(
+        "libviprs",
+        "add a non-executable recording stand-in for local-ci.py",
+        &[("tools/local-ci.py", RECORDING_LOCALCI)],
+    );
+    // Deliberately not made executable: the fix invokes it via `python3
+    // "$REPO_DIR/tools/local-ci.py"`, so this must still run.
+    ws.install_hooks();
+
+    let (_, localci_ran) = run_hook(&ws, "libviprs");
+
+    assert!(
+        !localci_ran.is_empty(),
+        "a non-executable tools/local-ci.py did not run. The hook must \
+         invoke it in a way that does not depend on the executable bit or \
+         its shebang line (e.g. `python3 \"$REPO_DIR/tools/local-ci.py\"`)."
+    );
+}

--- a/tests/install_hooks_localci_worktree.rs
+++ b/tests/install_hooks_localci_worktree.rs
@@ -1,0 +1,184 @@
+//! Guards that the LOCALCI pre-commit hook (`write_pre_commit` in
+//! `tools/install-hooks.sh`) resolves `REPO_DIR` against the tree actually
+//! being committed in, not against the shared `.git/hooks` directory a
+//! repo's main checkout and every one of its linked worktrees have in
+//! common (libviprs/libviprs#684).
+//!
+//! This is the same bug `install_pre_push` already dodges for the pre-push
+//! hook, via `git rev-parse --show-toplevel`. The LOCALCI branch shipped
+//! with `REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"` instead, which
+//! resolves from the hook's own path rather than from the tree it is
+//! running in, so it always pointed at the main checkout: a commit made
+//! inside a linked worktree silently ran `local-ci.py` against the wrong
+//! tree, with no error.
+//!
+//! Mirrors `tests/prepush_gate_tests_the_pushed_tree.rs`: install the hooks
+//! with the real installer, put a recording stand-in in place of
+//! `tools/local-ci.py` so nothing here asserts on the hook's text
+//! (libviprs/libviprs#695), create a linked worktree with
+//! `Workspace::worktree`, and run the installed hook the way git does — the
+//! hook file always lives under the main checkout's shared `.git/hooks`,
+//! while the process's working directory is whichever tree is actually
+//! being committed in.
+
+use std::path::Path;
+use std::process::Command;
+
+mod common;
+use common::hooks::{Workspace, make_executable};
+
+/// A stand-in for `tools/local-ci.py` that records its own resolved path
+/// (`sys.argv[0]`, made absolute) and its arguments, so a push can be judged
+/// by what the hook actually invoked rather than by reading the hook's text.
+/// Carries a real shebang so it also runs correctly when invoked directly by
+/// path under the pre-fix hook, isolating these tests to the REPO_DIR bug
+/// rather than entangling them with the separate executable-bit fix.
+const RECORDING_LOCALCI: &str = r#"#!/usr/bin/env python3
+import os
+import sys
+
+with open(os.environ["LOCALCI_RECORD"], "a") as f:
+    f.write("ARGV0=" + os.path.abspath(sys.argv[0]) + "\n")
+    f.write("ARGS=" + " ".join(sys.argv[1:]) + "\n")
+"#;
+
+/// Run the pre-commit hook installed into `repo`'s main checkout, with the
+/// process's working directory set to `cwd`. This is exactly the shape git
+/// itself uses: the hook file always lives in the main checkout's shared
+/// `.git/hooks`, and the working directory is whichever tree is actually
+/// being committed in — the main checkout itself, or one of its linked
+/// worktrees.
+fn run_pre_commit(ws: &Workspace, repo: &str, cwd: &Path, record: &Path) -> String {
+    let hook = ws.repo(repo).join(".git/hooks/pre-commit");
+    let _ = std::fs::remove_file(record);
+
+    let out = Command::new("bash")
+        .arg(&hook)
+        .current_dir(cwd)
+        .env("LOCALCI_RECORD", record)
+        .output()
+        .expect("run the installed pre-commit hook");
+    assert!(
+        out.status.success(),
+        "the pre-commit hook failed running from {}:\n{}{}",
+        cwd.display(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    std::fs::read_to_string(record).unwrap_or_default()
+}
+
+/// The `ARGV0=` line out of what a hook run recorded, or a panic naming what
+/// was printed instead — the hook running at all but `local-ci.py` never
+/// executing is itself a finding worth seeing.
+fn recorded_argv0(out: &str) -> String {
+    out.lines()
+        .find_map(|l| l.strip_prefix("ARGV0="))
+        .unwrap_or_else(|| {
+            panic!("local-ci.py never ran, so REPO_DIR resolved to nothing useful:\n{out}")
+        })
+        .to_string()
+}
+
+/// #684, for the pre-commit hook this time rather than the pre-push one:
+/// `REPO_DIR` has to name the tree actually being committed in, whether
+/// that is the main checkout or one of its linked worktrees.
+#[test]
+fn the_localci_hook_runs_local_ci_py_from_the_tree_being_committed_in() {
+    let ws = Workspace::new();
+
+    // Give "libviprs" a tools/local-ci.py so write_pre_commit takes the
+    // LOCALCI branch instead of the hardcoded cargo list, then re-run the
+    // installer so the new hook lands. Executable, so this is a pure test of
+    // REPO_DIR resolution and not entangled with the executable-bit fix
+    // covered separately in tests/install_hooks_localci_selection.rs.
+    let local_ci = ws.repo("libviprs").join("tools/local-ci.py");
+    ws.commit(
+        "libviprs",
+        "add a recording stand-in for local-ci.py",
+        &[("tools/local-ci.py", RECORDING_LOCALCI)],
+    );
+    make_executable(&local_ci);
+    ws.install_hooks();
+
+    let hook_text = std::fs::read_to_string(ws.repo("libviprs").join(".git/hooks/pre-commit"))
+        .expect("read the installed pre-commit hook");
+    assert!(
+        hook_text.contains("local-ci.py"),
+        "libviprs now ships tools/local-ci.py, so its pre-commit hook must \
+         defer to it instead of the hardcoded cargo list. Installed hook:\n{hook_text}"
+    );
+
+    let lane = ws.worktree("libviprs", "lane");
+    let main = ws.repo("libviprs");
+
+    let cases: &[(&Path, &str)] = &[
+        (
+            &main,
+            "a commit in the main checkout must run local-ci.py from the main checkout",
+        ),
+        (
+            &lane,
+            "a commit in a linked worktree must run local-ci.py from that \
+             worktree, not from the main checkout whose .git/hooks directory \
+             the hook file actually lives in and is shared by every worktree \
+             (libviprs/libviprs#684)",
+        ),
+    ];
+
+    for (i, (cwd, why)) in cases.iter().enumerate() {
+        let record = ws.root.join(format!("localci-{i}.record"));
+        let out = run_pre_commit(&ws, "libviprs", cwd, &record);
+        let argv0 = recorded_argv0(&out);
+
+        let expected = cwd.join("tools/local-ci.py");
+        assert_eq!(
+            argv0,
+            expected.display().to_string(),
+            "the pre-commit hook ran local-ci.py from {argv0}, not from {}, \
+             because {why}. Fix: derive REPO_DIR from \
+             `git rev-parse --show-toplevel`, the way install_pre_push \
+             already does for the pre-push hook, rather than from \
+             `$(dirname \"$0\")/../..`, which always resolves to wherever the \
+             hook file itself sits. The hook said:\n{out}",
+            expected.display()
+        );
+    }
+}
+
+/// The same hook, run against a repo with more than one linked worktree, has
+/// to tell them apart from each other too — not just from the main checkout.
+/// A fix that special-cased "not the main checkout" without actually asking
+/// git which tree is live would still be wrong here.
+#[test]
+fn the_localci_hook_tells_two_worktrees_of_the_same_repo_apart() {
+    let ws = Workspace::new();
+
+    let local_ci = ws.repo("libviprs").join("tools/local-ci.py");
+    ws.commit(
+        "libviprs",
+        "add a recording stand-in for local-ci.py",
+        &[("tools/local-ci.py", RECORDING_LOCALCI)],
+    );
+    make_executable(&local_ci);
+    ws.install_hooks();
+
+    let lane_a = ws.worktree("libviprs", "lane-a");
+    let lane_b = ws.worktree("libviprs", "lane-b");
+
+    for (i, lane) in [&lane_a, &lane_b].into_iter().enumerate() {
+        let record = ws.root.join(format!("localci-lane-{i}.record"));
+        let out = run_pre_commit(&ws, "libviprs", lane, &record);
+        let argv0 = recorded_argv0(&out);
+
+        let expected = lane.join("tools/local-ci.py");
+        assert_eq!(
+            argv0,
+            expected.display().to_string(),
+            "a commit in {} ran local-ci.py from {argv0} instead of from that \
+             same worktree. The hook said:\n{out}",
+            lane.display()
+        );
+    }
+}

--- a/tools/install-hooks.sh
+++ b/tools/install-hooks.sh
@@ -179,9 +179,14 @@ set -euo pipefail
 # Installed by libviprs-tests/tools/install-hooks.sh.
 # To skip (emergency only): git commit --no-verify
 
-REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
-echo "Running the CI job list locally (Check & Lint, MSRV, Docs)..."
-if ! "$REPO_DIR/tools/local-ci.py" --fast; then
+# A repo's main checkout and all of its linked worktrees share one hooks
+# directory, and git invokes the hook with $0 inside that shared directory
+# regardless of which worktree is actually being committed in, so deriving
+# REPO_DIR from $0 always resolves to the main checkout (libviprs/libviprs#684,
+# the same bug install_pre_push below already dodges). Ask git instead.
+REPO_DIR="$(git rev-parse --show-toplevel)"
+echo "Running the fast CI jobs locally (tools/local-ci.py --fast)..."
+if ! python3 "$REPO_DIR/tools/local-ci.py" --fast; then
     echo ""
     echo "Failed. These are the real CI commands, so CI will fail the same way."
     echo "Run everything including tests: tools/local-ci.py"

--- a/tools/install-hooks.sh
+++ b/tools/install-hooks.sh
@@ -160,14 +160,48 @@ drop_generated_pre_push() {
 write_pre_commit() {
     local hooks_dir="$1"
     local repo_name="$2"
+    local repo_dir="${3:-}"
     local pre_commit="$hooks_dir/pre-commit"
+
+    # A repo that ships tools/local-ci.py gets a hook that runs THAT. It reads
+    # .github/workflows/ci.yml at run time and executes whatever is in there,
+    # inside a container carrying the toolchains the workflow asks for, so it
+    # cannot drift from CI. The hardcoded per-repo lists further up are the
+    # fallback for repos without one, and they are only ever a subset.
+    if [ -n "$repo_dir" ] && [ -f "$repo_dir/tools/local-ci.py" ]; then
+        cat > "$pre_commit" << 'LOCALCI'
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pre-commit hook: runs the fast half of this repo's real CI job list, in
+# Docker, via tools/local-ci.py. That script derives its commands from
+# .github/workflows/ci.yml, so this hook and CI cannot disagree.
+# Installed by libviprs-tests/tools/install-hooks.sh.
+# To skip (emergency only): git commit --no-verify
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+echo "Running the CI job list locally (Check & Lint, MSRV, Docs)..."
+if ! "$REPO_DIR/tools/local-ci.py" --fast; then
+    echo ""
+    echo "Failed. These are the real CI commands, so CI will fail the same way."
+    echo "Run everything including tests: tools/local-ci.py"
+    echo "Skip this hook once:            git commit --no-verify"
+    exit 1
+fi
+echo "Passed. Tests and the integration job run on push,"
+echo "or now with: tools/local-ci.py"
+LOCALCI
+        chmod +x "$pre_commit"
+        return
+    fi
 
     {
         cat << 'HEAD'
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Pre-commit hook: mirrors this repo's CI Check & Lint job exactly.
+# Pre-commit hook: a SUBSET of this repo's CI Check & Lint job, not all of
+# it. A repo with tools/local-ci.py gets the real thing instead.
 # Installed by libviprs-tests/tools/install-hooks.sh — to update, edit
 # the script and re-run it. To skip (emergency only):
 #   git commit --no-verify
@@ -425,8 +459,9 @@ for REPO_DIR in "${REPOS[@]}"; do
         *)
             # The pre-commit hook goes everywhere: it runs the repo's own
             # `cargo fmt` and `cargo clippy` in the repo it is installed in, so
-            # for the cli it gates the cli.
-            write_pre_commit "$HOOKS_DIR" "$REPO_NAME"
+            # for the cli it gates the cli. $REPO_DIR lets it detect a
+            # tools/local-ci.py in the target repo and defer to that instead.
+            write_pre_commit "$HOOKS_DIR" "$REPO_NAME" "$REPO_DIR"
             if has_suite_slot "$REPO_NAME"; then
                 install_pre_push "$HOOKS_DIR"
                 echo "  done: $REPO_NAME (pre-commit + pre-push)"


### PR DESCRIPTION
`tools/install-hooks.sh` generates the pre-commit hooks for four repos from a hardcoded per-repo list of cargo commands:

```bash
LIBVIPRS_CARGO_STEPS=(
    "cargo clippy --all-targets -- -D warnings -W clippy::incompatible_msrv -W deprecated"
    "cargo clippy --all-targets --features pdfium -- -D warnings -W clippy::incompatible_msrv -W deprecated"
)
```

and the hook it writes announces itself as mirroring "this repo's CI Check & Lint job exactly".

For libviprs that is two of that job's seven steps, and nothing from the other four jobs: three of CI's twenty. Two places describe the same thing, nothing compares them, and `ci.yml` grew while the list did not. Tracked on the core side as libviprs/libviprs#657.

## What changes

libviprs/libviprs#658 adds `tools/local-ci.py` there, which reads `.github/workflows/ci.yml` at run time and runs what is actually in it, in a container carrying the toolchains the workflow asks for. It cannot drift, because it holds no copy of the commands.

So this generator should stop writing a list of its own for any repo that has one. The change is:

- If a repo ships `tools/local-ci.py`, write a hook that calls it (`--fast` for pre-commit, which is Check & Lint, MSRV and Docs; the slow Test and Integration jobs stay on push). The repo directory is now passed through so the generator can detect it.
- Otherwise keep the existing behaviour, because `libviprs-cli` and `pdfium-render` have no such script.
- Stop the fallback hook claiming it mirrors CI exactly. It says it is a subset now, and points at `local-ci.py` as the real thing, because a hook that overstates its coverage is worse than one that admits it.

Verified by running it: libviprs gets the `local-ci.py` hook, `libviprs-cli` gets the honest fallback, all four repos install without error.

Closes #165
