### PR TITLE
test(ported): stop pinning deferrals FITS and OpenEXR no longer have (closes #167)

### DIFF
--- a/tests/ported_foreign.rs
+++ b/tests/ported_foreign.rs
@@ -3032,11 +3032,15 @@ fn test_svgload() {
 ///
 /// Reference: test_foreign.py::test_fits
 fn test_fitsload() {
-    // Deferred: the FITS decoder is not wired, so decode_file returns a
-    // typed error rather than a raster. Pin that deferred contract.
+    // FITS is wired now (libviprs#625, issue #505), so this asserts what the
+    // doc above always described instead of pinning the deferral it replaced.
+    let raster = decode_file(&ref_image("WFPC2u5780205r_c0fx.fits"))
+        .expect("the reference WFPC2 FITS image decodes");
     assert!(
-        decode_file(&ref_image("WFPC2u5780205r_c0fx.fits")).is_err(),
-        "deferred FITS decode must return a typed error"
+        raster.width() > 0 && raster.height() > 0,
+        "FITS decode returned a {}x{} raster",
+        raster.width(),
+        raster.height()
     );
 }
 
@@ -3056,11 +3060,19 @@ fn test_fitsload() {
 ///
 /// Reference: test_foreign.py
 fn test_openexrload() {
-    // Deferred: the OpenEXR decoder is not wired, so decode_file returns a
-    // typed error rather than a raster. Pin that deferred contract.
+    // OpenEXR is wired now (libviprs#626, issue #504), so this stops
+    // asserting the deferral. It still errors, and the reason is the point:
+    // this reference fixture uses CHANNEL SUBSAMPLING, which the port refuses
+    // deliberately rather than guessing at a resample. The old assertion
+    // passed for the wrong reason, holding while the decoder did not exist
+    // and continuing to hold once it did, so it could never have told us
+    // whether EXR worked. Pin the specific refusal instead of "is_err".
+    let err = decode_file(&ref_image("sample.exr"))
+        .expect_err("sample.exr subsamples channels, which the port refuses");
+    let msg = err.to_string();
     assert!(
-        decode_file(&ref_image("sample.exr")).is_err(),
-        "deferred OpenEXR decode must return a typed error"
+        msg.contains("subsampling"),
+        "expected the channel-subsampling refusal, got: {msg}"
     );
 }
 


### PR DESCRIPTION
`main` is red. `test_fitsload` fails with "deferred FITS decode must return a typed error", because FITS is no longer deferred: libviprs#625 landed it and the decode now succeeds.

The cell was a placeholder pinning the deferral, and its own doc comment says what it was always supposed to do:

> 1. Load the WFPC2 FITS image from the reference suite.
> 2. Verify dimensions are positive.

So it now does that.

## The EXR cell is the more interesting half

`test_openexrload` pins the same deferral for OpenEXR, which libviprs#626 also landed. It did **not** go red, and the reason is worth writing down.

`sample.exr` uses **channel subsampling**, which the port refuses deliberately rather than guessing at a resample. So `decode_file` still returns an error, and `is_err()` still holds.

That assertion therefore passed while the decoder did not exist, and kept passing once it did. It could never have told anyone whether OpenEXR worked. It is the same shape this epic keeps finding: a check whose name promises one thing and whose assertion cannot fail for the reason it claims to test.

It now pins the specific refusal, asserting the channel-subsampling message rather than "some error happened", so it fails if the reason ever changes.

## Not touched

`test_jp2kload` still pins its deferral and that is still correct. Only the JPEG 2000 **oracle capture** landed (#637 / libviprs#647); the decoder is not wired.

## Verified

`./tools/run_ported_cells.sh --require-fixtures`: **390 passed, 0 failed, 20 ignored**.

This also unblocks #166, whose CI failure is this same red main rather than anything in that change.

Closes #167
