### PR TITLE
fix(hooks): gate on the tree being pushed, not on the main checkout

### DIFF
--- a/Dockerfile.dockerignore
+++ b/Dockerfile.dockerignore
@@ -1,17 +1,20 @@
 # BuildKit .dockerignore for the run-tests.sh Docker mirror.
 #
-# The mirror builds with the WORKSPACE ROOT (the parent of libviprs/ and
-# libviprs-tests/) as the build context and `-f libviprs-tests/Dockerfile`
-# (see tools/run-tests.sh). Docker therefore reads its ignore rules from the
-# context root's `.dockerignore`, NOT from `libviprs-tests/.dockerignore`.
-# BuildKit checks for a `<dockerfile>.dockerignore` next to the `-f` Dockerfile
-# first and prefers it, so this file (living in the libviprs-tests repo, in
-# scope) is the authoritative ignore set for the mirror build. It fully
-# replaces the context-root file, so it must carry every exclusion, not just
-# the native-library additions.
+# The mirror stages the two trees under test into a scratch context and builds
+# with that as the build context and `-f <tests tree>/Dockerfile` (see
+# tools/run-tests.sh, "Build context"). The `-f` Dockerfile therefore sits
+# outside the context it is building. BuildKit looks for a
+# `<dockerfile>.dockerignore` next to the `-f` Dockerfile first and prefers it
+# over a `.dockerignore` at the context root, and it does that whether or not
+# the two live in the same directory, so this file (living in the
+# libviprs-tests repo, beside the Dockerfile it belongs to) is the
+# authoritative ignore set for the mirror build. It fully replaces any
+# context-root file, so it must carry every exclusion, not just the
+# native-library additions.
 #
-# Patterns are relative to the build context (the workspace root); `**/` makes
-# them match under both libviprs/ and libviprs-tests/.
+# Patterns are relative to the build context, which holds exactly two entries,
+# `libviprs/` and `libviprs-tests/`, staged there by run-tests.sh. `**/` makes
+# them match under both.
 **/target/
 **/.git/
 **/.DS_Store

--- a/tests/common/hooks.rs
+++ b/tests/common/hooks.rs
@@ -1,0 +1,49 @@
+//! Reads the git hooks `tools/install-hooks.sh` writes, so the guards on them
+//! can assert against the text that actually lands in `.git/hooks/`.
+//!
+//! Two suites need this (`prepush_gate_tests_the_pushed_tree` for #684 and
+//! `prepush_gate_cost_controls` for #683) and both used to carry their own
+//! copy, including the heredoc marker string byte for byte. That marker is the
+//! fragile part: change the quoting in `install-hooks.sh` and every copy has to
+//! follow, and the one that does not follow fails with "no longer writes the
+//! pre-push hook from a heredoc" rather than with anything about the change
+//! that broke it. One copy, here.
+
+use std::path::{Path, PathBuf};
+
+/// This crate's root, which is also the repo root for the harness checkout.
+pub fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
+}
+
+/// Read a repo-relative file, naming the path if it is not there.
+pub fn read(rel: &str) -> String {
+    let path = repo_root().join(rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+/// The marker `install-hooks.sh` opens the pre-push heredoc with. Kept as one
+/// constant so the two guards cannot drift apart on it.
+const PRE_PUSH_HEREDOC: &str = "cat > \"$pre_push\" << 'HOOK'\n";
+
+/// The pre-push hook body exactly as `install-hooks.sh` writes it: the heredoc
+/// between `<< 'HOOK'` and the closing `HOOK`. Reading the generated text
+/// rather than the generator keeps the assertions pointed at what actually
+/// lands in `.git/hooks/pre-push`.
+pub fn generated_pre_push() -> String {
+    let script = read("tools/install-hooks.sh");
+    let start = script
+        .find(PRE_PUSH_HEREDOC)
+        .map(|i| i + PRE_PUSH_HEREDOC.len())
+        .expect(
+            "tools/install-hooks.sh no longer writes the pre-push hook from a \
+             `cat > \"$pre_push\" << 'HOOK'` heredoc; update PRE_PUSH_HEREDOC in \
+             tests/common/hooks.rs to follow it rather than deleting the guards \
+             that read it",
+        );
+    let rest = &script[start..];
+    let end = rest
+        .find("\nHOOK\n")
+        .expect("unterminated pre-push heredoc in tools/install-hooks.sh");
+    rest[..end].to_string()
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,8 +6,9 @@
 //! Cargo treats `tests/common/mod.rs` (directory module) specially — it
 //! isn't compiled as its own integration target.
 //!
-//! The canonical-fixture loader sits in [`fixtures`], and [`workflows`]
-//! resolves the CI workflow files the pinning guards read. Below them: PDF /
+//! The canonical-fixture loader sits in [`fixtures`], [`workflows`]
+//! resolves the CI workflow files the pinning guards read, and [`hooks`]
+//! reads the hook text `tools/install-hooks.sh` generates. Below them: PDF /
 //! pdfium-specific shared helpers for the streaming-mode integration
 //! tests. The pdfium helpers are gated behind the `pdfium` feature so
 //! the module compiles cleanly with the default feature set.
@@ -21,6 +22,7 @@
 pub mod cli;
 pub mod dzsave_expected;
 pub mod fixtures;
+pub mod hooks;
 pub mod workflows;
 
 #[cfg(feature = "pdfium")]

--- a/tests/prepush_gate_tests_the_pushed_tree.rs
+++ b/tests/prepush_gate_tests_the_pushed_tree.rs
@@ -1,0 +1,202 @@
+//! Guards that the local pre-push gate tests the tree being pushed
+//! (libviprs/libviprs#684).
+//!
+//! `tools/run-tests.sh` used to derive the trees under test from its own
+//! location, so `$WORKSPACE_ROOT/libviprs` was the answer no matter which
+//! working tree the push came from. Epic #520 runs every lane in a git
+//! worktree, and a repo shares one hooks directory between its main checkout
+//! and all of its linked worktrees, so the gate compiled `main` on every lane
+//! push and could not fail on the author's own changes. A green pre-push read
+//! as "my branch passes" and meant nothing of the kind.
+//!
+//! Two properties have to hold together, and neither is visible from the
+//! other side, which is why both are pinned here:
+//!
+//!   * the hook has to *find* the pushed tree, and it cannot do that from
+//!     `$0` (shared hooks directory) or by walking up from `.git` (in a
+//!     worktree that is a file holding a `gitdir:` pointer, not a directory).
+//!     Only `git rev-parse` knows.
+//!   * `run-tests.sh` has to *accept* it. It did not have a parameter for it
+//!     at all, so passing one from the hook was not enough on its own.
+//!
+//! These are text and behaviour guards on the harness rather than on library
+//! output, in the same shape as `counterpart_pinning` and
+//! `feature_rename_docs_present`: there is no libvips analogue for "the local
+//! gate is honest", and the failure mode is silent by construction.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn read(rel: &str) -> String {
+    let path = repo_root().join(rel);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+/// The pre-push hook body exactly as `install-hooks.sh` writes it: the
+/// heredoc between `<< 'HOOK'` and the closing `HOOK`. Reading the generated
+/// text rather than the generator keeps the assertions below pointed at what
+/// actually lands in `.git/hooks/pre-push`.
+fn generated_pre_push() -> String {
+    let script = read("tools/install-hooks.sh");
+    let start = script
+        .find("cat > \"$pre_push\" << 'HOOK'\n")
+        .map(|i| i + "cat > \"$pre_push\" << 'HOOK'\n".len())
+        .expect(
+            "tools/install-hooks.sh no longer writes the pre-push hook from a \
+             `cat > \"$pre_push\" << 'HOOK'` heredoc; update this guard to \
+             follow it rather than deleting it",
+        );
+    let rest = &script[start..];
+    let end = rest
+        .find("\nHOOK\n")
+        .expect("unterminated pre-push heredoc in tools/install-hooks.sh");
+    rest[..end].to_string()
+}
+
+/// #684: the hook must ask git which tree is being pushed. `$0` points into
+/// the hooks directory, which a main checkout shares with every worktree
+/// hanging off it, so anything resolved from it names the main checkout.
+#[test]
+fn pre_push_hook_resolves_the_pushed_tree_from_git() {
+    let hook = generated_pre_push();
+
+    assert!(
+        hook.contains("git rev-parse --show-toplevel"),
+        "the pre-push hook must take the tree under test from \
+         `git rev-parse --show-toplevel`, which is the working tree whose \
+         commits are going out (#684)"
+    );
+    assert!(
+        hook.contains("git rev-parse --git-common-dir"),
+        "the pre-push hook must find the repo's main checkout through \
+         `git rev-parse --git-common-dir`; a linked worktree's `.git` is a \
+         file holding a `gitdir:` pointer, so walking up from it does not \
+         give a repository root (#684)"
+    );
+    assert!(
+        !hook.contains(r#"$(dirname "$0")/../.."#),
+        "the pre-push hook still derives a repository from its own path. \
+         Every worktree of a repo runs the same hook file out of the main \
+         checkout's hooks directory, so that always names the main checkout \
+         and never the branch being pushed (#684)"
+    );
+}
+
+/// #684: finding the tree is only half of it. The hook has to hand it over,
+/// and `run-tests.sh` has to have somewhere to put it.
+#[test]
+fn pre_push_hook_hands_the_tree_to_run_tests() {
+    let hook = generated_pre_push();
+
+    for slot in ["LIBVIPRS_DIR", "LIBVIPRS_TESTS_DIR"] {
+        assert!(
+            hook.contains(&format!("export {slot}=")),
+            "the pre-push hook must export {slot} so run-tests.sh builds the \
+             pushed tree; without it the script falls back to the sibling \
+             checkout, which is the whole of #684"
+        );
+    }
+
+    let script = read("tools/run-tests.sh");
+    for slot in ["LIBVIPRS_DIR", "LIBVIPRS_TESTS_DIR"] {
+        assert!(
+            script.contains(slot),
+            "tools/run-tests.sh must read {slot}, or the hook exporting it \
+             has no effect (#684)"
+        );
+    }
+}
+
+/// The behavioural half: hand `run-tests.sh` a tree and it must say, before
+/// it builds anything, that it is going to build that tree. `--plan` exists
+/// so this is answerable without Docker, and so a human can ask the same
+/// question from a worktree in under a second.
+#[test]
+fn run_tests_plan_reports_the_tree_it_was_handed() {
+    let core = tempfile::tempdir().expect("temp dir for a stand-in core crate");
+    let core_path = core.path().canonicalize().expect("canonical temp path");
+    std::fs::write(
+        core_path.join("Cargo.toml"),
+        "[package]\nname = \"libviprs\"\nversion = \"0.0.0\"\n",
+    )
+    .expect("write stand-in Cargo.toml");
+
+    let script = repo_root().join("tools/run-tests.sh");
+    let root = repo_root();
+
+    let by_flag = Command::new("bash")
+        .arg(&script)
+        .arg("--plan")
+        .arg("--libviprs")
+        .arg(&core_path)
+        .arg("--libviprs-tests")
+        .arg(&root)
+        .output()
+        .expect("run tools/run-tests.sh --plan");
+    assert!(
+        by_flag.status.success(),
+        "`run-tests.sh --plan` failed: {}",
+        String::from_utf8_lossy(&by_flag.stderr)
+    );
+    let by_flag = String::from_utf8_lossy(&by_flag.stdout).to_string();
+
+    let by_env = Command::new("bash")
+        .arg(&script)
+        .arg("--plan")
+        .env("LIBVIPRS_DIR", &core_path)
+        .env("LIBVIPRS_TESTS_DIR", &root)
+        .output()
+        .expect("run tools/run-tests.sh --plan with the env form");
+    assert!(
+        by_env.status.success(),
+        "`run-tests.sh --plan` with LIBVIPRS_DIR set failed: {}",
+        String::from_utf8_lossy(&by_env.stderr)
+    );
+    let by_env = String::from_utf8_lossy(&by_env.stdout).to_string();
+
+    let wanted = core_path.display().to_string();
+    for (form, plan) in [("--libviprs", &by_flag), ("LIBVIPRS_DIR", &by_env)] {
+        assert!(
+            plan.contains(&wanted),
+            "run-tests.sh ignored the core tree passed by {form}. It planned:\n{plan}"
+        );
+    }
+}
+
+/// The default has to keep working, because the sibling layout is what CI,
+/// the README and every by-hand invocation use. #684 is about the default
+/// being the *only* answer, not about the default being wrong.
+#[test]
+fn run_tests_still_defaults_to_the_sibling_layout() {
+    let script = repo_root().join("tools/run-tests.sh");
+    let out = Command::new("bash")
+        .arg(&script)
+        .arg("--plan")
+        .env_remove("LIBVIPRS_DIR")
+        .env_remove("LIBVIPRS_TESTS_DIR")
+        .output()
+        .expect("run tools/run-tests.sh --plan with no overrides");
+    assert!(
+        out.status.success(),
+        "`run-tests.sh --plan` failed with no overrides: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let plan = String::from_utf8_lossy(&out.stdout);
+
+    // `libviprs = { path = "../libviprs" }` in this crate's manifest means the
+    // sibling is present whenever this test can run at all.
+    let sibling = repo_root()
+        .join("../libviprs")
+        .canonicalize()
+        .expect("the core crate sits at ../libviprs; this suite could not have compiled otherwise");
+    assert!(
+        plan.contains(&sibling.display().to_string()),
+        "with nothing passed, run-tests.sh must still plan the sibling core \
+         checkout at {}. It planned:\n{plan}",
+        sibling.display()
+    );
+}

--- a/tests/prepush_gate_tests_the_pushed_tree.rs
+++ b/tests/prepush_gate_tests_the_pushed_tree.rs
@@ -24,38 +24,10 @@
 //! `feature_rename_docs_present`: there is no libvips analogue for "the local
 //! gate is honest", and the failure mode is silent by construction.
 
-use std::path::PathBuf;
 use std::process::Command;
 
-fn repo_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-}
-
-fn read(rel: &str) -> String {
-    let path = repo_root().join(rel);
-    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
-}
-
-/// The pre-push hook body exactly as `install-hooks.sh` writes it: the
-/// heredoc between `<< 'HOOK'` and the closing `HOOK`. Reading the generated
-/// text rather than the generator keeps the assertions below pointed at what
-/// actually lands in `.git/hooks/pre-push`.
-fn generated_pre_push() -> String {
-    let script = read("tools/install-hooks.sh");
-    let start = script
-        .find("cat > \"$pre_push\" << 'HOOK'\n")
-        .map(|i| i + "cat > \"$pre_push\" << 'HOOK'\n".len())
-        .expect(
-            "tools/install-hooks.sh no longer writes the pre-push hook from a \
-             `cat > \"$pre_push\" << 'HOOK'` heredoc; update this guard to \
-             follow it rather than deleting it",
-        );
-    let rest = &script[start..];
-    let end = rest
-        .find("\nHOOK\n")
-        .expect("unterminated pre-push heredoc in tools/install-hooks.sh");
-    rest[..end].to_string()
-}
+mod common;
+use common::hooks::{generated_pre_push, read, repo_root};
 
 /// #684: the hook must ask git which tree is being pushed. `$0` points into
 /// the hooks directory, which a main checkout shares with every worktree
@@ -188,7 +160,10 @@ fn run_tests_still_defaults_to_the_sibling_layout() {
     let plan = String::from_utf8_lossy(&out.stdout);
 
     // `libviprs = { path = "../libviprs" }` in this crate's manifest means the
-    // sibling is present whenever this test can run at all.
+    // sibling is present whenever this test can run at all. Both sides are
+    // physical paths: `canonicalize` here, `pwd -P` in the script. A logical
+    // `pwd` over there would print the symlink a workspace was reached through
+    // and this would go red on a layout that works perfectly well.
     let sibling = repo_root()
         .join("../libviprs")
         .canonicalize()

--- a/tests/prepush_gate_tests_the_pushed_tree.rs
+++ b/tests/prepush_gate_tests_the_pushed_tree.rs
@@ -200,3 +200,100 @@ fn run_tests_still_defaults_to_the_sibling_layout() {
         sibling.display()
     );
 }
+
+/// git hands every hook a `GIT_DIR`, and in a worktree it points at that
+/// worktree's admin directory. It beats both `git -C` and the working
+/// directory, so a `git` call made from inside the gate answers for the
+/// repository doing the pushing whatever directory it was aimed at. The first
+/// run of the fixed hook reported the pushing branch's HEAD as the revision of
+/// an unrelated tree, which is #684 wearing a different hat: a banner that
+/// names the wrong commit is no better than a gate that builds the wrong one.
+#[test]
+fn run_tests_does_not_report_the_pushing_repo_as_another_tree() {
+    let core = tempfile::tempdir().expect("temp dir for a stand-in core crate");
+    let core_path = core.path().canonicalize().expect("canonical temp path");
+    std::fs::write(
+        core_path.join("Cargo.toml"),
+        "[package]\nname = \"libviprs\"\nversion = \"0.0.0\"\n",
+    )
+    .expect("write stand-in Cargo.toml");
+
+    let mut cmd = Command::new("bash");
+    cmd.arg(repo_root().join("tools/run-tests.sh"))
+        .arg("--plan")
+        .arg("--libviprs")
+        .arg(&core_path)
+        .arg("--libviprs-tests")
+        .arg(repo_root());
+
+    // Reproduce the hook's environment where there is one to reproduce. Inside
+    // the container the build context carries no `.git`, so there is no git
+    // dir to inherit and the assertion below simply holds for the plainer
+    // reason; on a developer checkout it is the real thing.
+    if let Ok(out) = Command::new("git")
+        .arg("-C")
+        .arg(repo_root())
+        .args(["rev-parse", "--absolute-git-dir"])
+        .output()
+    {
+        if out.status.success() {
+            let dir = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if !dir.is_empty() {
+                cmd.env("GIT_DIR", dir);
+            }
+        }
+    }
+
+    let out = cmd.output().expect("run tools/run-tests.sh --plan");
+    assert!(
+        out.status.success(),
+        "`run-tests.sh --plan` failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let plan = String::from_utf8_lossy(&out.stdout);
+    let line = plan
+        .lines()
+        .find(|l| l.contains(&core_path.display().to_string()))
+        .unwrap_or_else(|| panic!("no plan line names the stand-in core tree:\n{plan}"));
+    assert!(
+        line.contains("not a git checkout"),
+        "run-tests.sh described a directory that is not a git checkout as though \
+         it were one, which means it answered from the inherited GIT_DIR rather \
+         than from the tree it was handed. Line was: {line}"
+    );
+}
+
+/// The same leak, from the hook's side: it has to drop the git environment
+/// before handing over, or every `git` call the suite makes inherits it.
+#[test]
+fn pre_push_hook_clears_the_inherited_git_environment() {
+    let hook = generated_pre_push();
+    assert!(
+        hook.contains("unset GIT_DIR"),
+        "the pre-push hook must unset GIT_DIR before running the suite; git \
+         exports it into hooks and it wins over `git -C`, so anything the \
+         suite asks git answers for the pushing repository (#684)"
+    );
+}
+
+/// Both slots get named, not just the one being pushed. run-tests.sh falls
+/// back to the siblings of wherever the script sits, and for a libviprs-tests
+/// push that script is inside the worktree, whose neighbours are other lanes.
+#[test]
+fn pre_push_hook_pins_both_trees_not_just_the_pushed_one() {
+    let hook = generated_pre_push();
+    let libviprs_arm = hook
+        .split("libviprs-tests)")
+        .next()
+        .expect("the case statement has a libviprs arm");
+    assert!(
+        libviprs_arm.contains("LIBVIPRS_TESTS_DIR=\"$WORKSPACE_ROOT/libviprs-tests\""),
+        "a libviprs push must also pin the test tree to the workspace sibling, \
+         rather than leaving run-tests.sh to infer it (#684)"
+    );
+    assert!(
+        hook.contains("LIBVIPRS_DIR=\"$WORKSPACE_ROOT/libviprs\""),
+        "a libviprs-tests push must also pin the core tree to the workspace \
+         sibling, rather than leaving run-tests.sh to infer it (#684)"
+    );
+}

--- a/tools/install-hooks.sh
+++ b/tools/install-hooks.sh
@@ -159,12 +159,18 @@ RUN_TESTS="$WORKSPACE_ROOT/libviprs-tests/tools/run-tests.sh"
 # Hand the pushed tree to the suite in whichever slot it belongs. Without
 # this run-tests.sh falls back to the sibling checkouts, which is the whole
 # defect. libviprs-cli has no slot in this suite and keeps the old behaviour.
+# Both slots get pinned, not just the one being pushed. run-tests.sh falls
+# back to the siblings of wherever the script itself sits, and the script the
+# line below may pick sits inside the worktree, whose neighbours are other
+# lanes rather than the workspace. Naming both leaves nothing to infer.
 case "$REPO_NAME" in
     libviprs)
         export LIBVIPRS_DIR="$TREE"
+        export LIBVIPRS_TESTS_DIR="$WORKSPACE_ROOT/libviprs-tests"
         ;;
     libviprs-tests)
         export LIBVIPRS_TESTS_DIR="$TREE"
+        export LIBVIPRS_DIR="$WORKSPACE_ROOT/libviprs"
         # A push that changes the harness gates on the harness it changes,
         # not on the copy sitting in the main checkout.
         if [ -x "$TREE/tools/run-tests.sh" ]; then
@@ -178,6 +184,13 @@ if [ ! -f "$RUN_TESTS" ]; then
     echo "Skipping pre-push tests. Install libviprs-tests as a sibling directory."
     exit 0
 fi
+
+# git hands every hook a GIT_DIR (and, in a worktree, one pointing at the
+# per-worktree admin directory), and it wins over -C and over the working
+# directory for every git command anything below runs. Leaving it set made the
+# suite report this push's HEAD as the revision of trees it had never looked
+# at. The paths above are already resolved, so drop it here.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_QUARANTINE_PATH
 
 echo "Running pre-push test suite on $TREE..."
 if ! "$RUN_TESTS"; then

--- a/tools/install-hooks.sh
+++ b/tools/install-hooks.sh
@@ -11,6 +11,9 @@ set -euo pipefail
 #                 Check & Lint. Update the per-repo cargo command lists below
 #                 when a repo's CI matrix changes, and re-run this script.
 #   pre-push    — Docker test suite via run-tests.sh (slow, on every push)
+#                 Runs against the working tree being pushed, which for a
+#                 linked worktree is not the main checkout the hooks
+#                 directory lives in (libviprs/libviprs#684).
 #
 # Usage:  ./tools/install-hooks.sh          # from libviprs-tests/
 #         ./libviprs-tests/tools/install-hooks.sh  # from workspace root
@@ -134,9 +137,41 @@ set -euo pipefail
 # Installed by libviprs-tests/tools/install-hooks.sh
 # To skip (emergency only): git push --no-verify
 
-REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
-WORKSPACE_ROOT="$(cd "$REPO_DIR/.." && pwd)"
+# A repo's main checkout and all of its linked worktrees share one hooks
+# directory, and git invokes the hook with $0 inside that shared directory.
+# Anything resolved from $0 is therefore the main checkout, whichever tree is
+# actually being pushed, which is how every lane worktree on epic #520 gated
+# against `main` instead of against its own branch (libviprs/libviprs#684).
+# A worktree's .git is a file holding a gitdir: pointer rather than a
+# directory, so walking up from it does not work either. Ask git, which runs
+# hooks from the top of the working tree whose commits are going out.
+TREE="$(git rev-parse --show-toplevel)"
+
+# --git-common-dir is the *main* checkout's .git for a linked worktree, and a
+# path relative to here for the main checkout itself, so resolve it from the
+# tree rather than assuming it is absolute. Its parent tells us which repo
+# this is, and where the sibling libviprs-tests checkout lives.
+MAIN_CHECKOUT="$(cd "$TREE" && cd "$(dirname "$(git rev-parse --git-common-dir)")" && pwd)"
+REPO_NAME="$(basename "$MAIN_CHECKOUT")"
+WORKSPACE_ROOT="$(cd "$MAIN_CHECKOUT/.." && pwd)"
 RUN_TESTS="$WORKSPACE_ROOT/libviprs-tests/tools/run-tests.sh"
+
+# Hand the pushed tree to the suite in whichever slot it belongs. Without
+# this run-tests.sh falls back to the sibling checkouts, which is the whole
+# defect. libviprs-cli has no slot in this suite and keeps the old behaviour.
+case "$REPO_NAME" in
+    libviprs)
+        export LIBVIPRS_DIR="$TREE"
+        ;;
+    libviprs-tests)
+        export LIBVIPRS_TESTS_DIR="$TREE"
+        # A push that changes the harness gates on the harness it changes,
+        # not on the copy sitting in the main checkout.
+        if [ -x "$TREE/tools/run-tests.sh" ]; then
+            RUN_TESTS="$TREE/tools/run-tests.sh"
+        fi
+        ;;
+esac
 
 if [ ! -f "$RUN_TESTS" ]; then
     echo "Warning: run-tests.sh not found at $RUN_TESTS"
@@ -144,11 +179,8 @@ if [ ! -f "$RUN_TESTS" ]; then
     exit 0
 fi
 
-echo "Running pre-push test suite..."
-"$RUN_TESTS"
-
-EXIT_CODE=$?
-if [ $EXIT_CODE -ne 0 ]; then
+echo "Running pre-push test suite on $TREE..."
+if ! "$RUN_TESTS"; then
     echo ""
     echo "Pre-push tests failed. Push aborted."
     echo "Fix the failures or use: git push --no-verify"

--- a/tools/run-tests.sh
+++ b/tools/run-tests.sh
@@ -118,10 +118,15 @@ CONTAINER_NAME="libviprs-tests-run"
 #   workspace/
 #     libviprs/          (core library)
 #     libviprs-tests/    (integration tests + Dockerfile)
+#
+# Every path here is resolved with `pwd -P`, so the banner, the staged build
+# context and anything comparing against them all name the same directory even
+# when the workspace is reached through a symlink. A logical `pwd` would print
+# the link and the physical path would be what actually got staged.
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-SELF_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+SELF_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd -P)"
 
 LIBVIPRS_DIR="${LIBVIPRS_ARG:-${LIBVIPRS_DIR:-$WORKSPACE_ROOT/libviprs}}"
 # The test tree defaults to the checkout this script is part of, not to the
@@ -148,8 +153,8 @@ if [ ! -d "$TESTS_DIR" ]; then
     exit 1
 fi
 
-LIBVIPRS_DIR="$(cd "$LIBVIPRS_DIR" && pwd)"
-TESTS_DIR="$(cd "$TESTS_DIR" && pwd)"
+LIBVIPRS_DIR="$(cd "$LIBVIPRS_DIR" && pwd -P)"
+TESTS_DIR="$(cd "$TESTS_DIR" && pwd -P)"
 
 if [ ! -f "$TESTS_DIR/Dockerfile" ]; then
     echo "Error: Dockerfile not found at $TESTS_DIR/Dockerfile"

--- a/tools/run-tests.sh
+++ b/tools/run-tests.sh
@@ -161,14 +161,24 @@ if [ ! -f "$LIBVIPRS_DIR/Cargo.toml" ]; then
     exit 1
 fi
 
+# git exports GIT_DIR, GIT_WORK_TREE and friends into every hook it runs, and
+# they beat both `-C` and the working directory. Left in place they make `git`
+# answer for the repository that is pushing rather than for the directory it
+# was pointed at, which is the same class of lie as #684 itself: the banner
+# below reported the pushing branch's HEAD as the revision of an unrelated
+# tree. Ask cleanly.
+git_at() {
+    env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_PREFIX git "$@"
+}
+
 # A one-line description of a tree for the banner. The whole of #684 is that
 # "which commit did that just test?" had no answer anywhere in the output, so
 # print one, twice: before the run and again with the verdict.
 tree_desc() {
     local dir="$1"
     local rev
-    if rev="$(git -C "$dir" rev-parse --short HEAD 2>/dev/null)"; then
-        if [ -n "$(git -C "$dir" status --porcelain 2>/dev/null | head -1)" ]; then
+    if rev="$(git_at -C "$dir" rev-parse --short HEAD 2>/dev/null)"; then
+        if [ -n "$(git_at -C "$dir" status --porcelain 2>/dev/null | head -1)" ]; then
             rev="$rev+dirty"
         fi
         printf '%s' "$rev"
@@ -307,14 +317,19 @@ echo ""
 echo "Running tests (${ARCH_LABEL})..."
 echo "================================================================"
 
+# `set -e` used to take the script out at this line on a failing run, so
+# everything below it, the verdict, the trees it was built from, and the
+# container cleanup, never happened. The push aborted on docker's status with
+# no report of what had been tested.
+set +e
 docker run \
     --platform "$PLATFORM" \
     --name "$CONTAINER_NAME" \
     --memory=4g \
     ${DOCKER_RUN_MOUNTS[@]+"${DOCKER_RUN_MOUNTS[@]}"} \
     "$IMAGE_NAME"
-
 EXIT_CODE=$?
+set -e
 
 # ---------------------------------------------------------------------------
 # Cleanup

--- a/tools/run-tests.sh
+++ b/tools/run-tests.sh
@@ -13,6 +13,15 @@ set -euo pipefail
 #         ./run-tests.sh --loom           # also run Loom after Docker tests
 #         ./run-tests.sh --miri --loom    # run both
 #         ./run-tests.sh arm --miri       # combine arch + flags
+#         ./run-tests.sh --plan           # print what would be built, run nothing
+#
+# Which trees get tested:
+#         ./run-tests.sh --libviprs PATH        # core crate to build
+#         ./run-tests.sh --libviprs-tests PATH  # test crate to build
+#   or the LIBVIPRS_DIR / LIBVIPRS_TESTS_DIR environment variables. The core
+#   crate defaults to the sibling of this script's grandparent directory and
+#   the test crate to the checkout this script belongs to, which in the
+#   expected layout are the two directories every existing caller already got.
 #
 # Runs libviprs unit tests and libviprs-tests integration tests, both with
 # the pdfium feature enabled. Exit code reflects test results.
@@ -20,18 +29,51 @@ set -euo pipefail
 # --miri  Run Miri (requires nightly toolchain with miri component) on
 #         libviprs after the Docker tests pass.
 # --loom  Run Loom concurrency tests on libviprs after the Docker tests pass.
+# --plan  Resolve and print the trees and the image, then exit without
+#         touching Docker. The cheap way to check that a pre-push hook is
+#         about to test the tree you think it is.
 # ---------------------------------------------------------------------------
 
 RUN_MIRI=false
 RUN_LOOM=false
+PRINT_PLAN=false
 ARCH=""
+LIBVIPRS_ARG=""
+TESTS_ARG=""
 
-for arg in "$@"; do
-    case "$arg" in
-        --miri) RUN_MIRI=true ;;
-        --loom) RUN_LOOM=true ;;
-        *)      ARCH="$arg" ;;
+usage() {
+    awk '
+        /^# -{20,}/ { fence++; if (fence == 2) exit; next }
+        fence == 1 && /^#/ { line = $0; sub(/^# ?/, "", line); print line }
+    ' "$0"
+}
+
+need_value() {
+    if [ "$2" -lt 2 ]; then
+        echo "Error: $1 needs a path argument."
+        exit 1
+    fi
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --miri)              RUN_MIRI=true ;;
+        --loom)              RUN_LOOM=true ;;
+        --plan|--dry-run)    PRINT_PLAN=true ;;
+        -h|--help)           usage; exit 0 ;;
+        --libviprs)          need_value "$1" "$#"; LIBVIPRS_ARG="$2"; shift ;;
+        --libviprs=*)        LIBVIPRS_ARG="${1#--libviprs=}" ;;
+        --libviprs-tests)    need_value "$1" "$#"; TESTS_ARG="$2"; shift ;;
+        --libviprs-tests=*)  TESTS_ARG="${1#--libviprs-tests=}" ;;
+        -*)
+            echo "Error: unknown option '$1'."
+            echo ""
+            usage
+            exit 1
+            ;;
+        *)                   ARCH="$1" ;;
     esac
+    shift
 done
 
 # Auto-detect architecture if not specified
@@ -62,6 +104,93 @@ IMAGE_NAME="libviprs-tests:local"
 CONTAINER_NAME="libviprs-tests-run"
 
 # ---------------------------------------------------------------------------
+# Resolve the trees under test
+# ---------------------------------------------------------------------------
+# Two different questions used to share one answer here. The script needs to
+# know where it lives, to find its own helpers and its scratch directory. It
+# also needs to know which working trees to test. Deriving the second from the
+# first made the answer "the sibling checkouts", always, so a pre-push hook
+# firing from a git worktree built `main` and never saw a line of the branch
+# being pushed (libviprs/libviprs#684). The caller passes the trees now, and
+# the sibling layout is only the default.
+#
+# Expected default layout:
+#   workspace/
+#     libviprs/          (core library)
+#     libviprs-tests/    (integration tests + Dockerfile)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SELF_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+LIBVIPRS_DIR="${LIBVIPRS_ARG:-${LIBVIPRS_DIR:-$WORKSPACE_ROOT/libviprs}}"
+# The test tree defaults to the checkout this script is part of, not to the
+# sibling named libviprs-tests. In the layout above they are the same
+# directory; run the script out of a worktree and only the first one is right.
+TESTS_DIR="${TESTS_ARG:-${LIBVIPRS_TESTS_DIR:-$SELF_DIR}}"
+
+if [ ! -d "$LIBVIPRS_DIR" ]; then
+    echo "Error: libviprs/ not found at $LIBVIPRS_DIR"
+    echo "Pass --libviprs PATH (or set LIBVIPRS_DIR), or use the sibling layout:"
+    echo "  workspace/"
+    echo "    libviprs/"
+    echo "    libviprs-tests/"
+    exit 1
+fi
+
+if [ ! -d "$TESTS_DIR" ]; then
+    echo "Error: libviprs-tests/ not found at $TESTS_DIR"
+    echo "Pass --libviprs-tests PATH (or set LIBVIPRS_TESTS_DIR), or use the"
+    echo "sibling layout:"
+    echo "  workspace/"
+    echo "    libviprs/"
+    echo "    libviprs-tests/"
+    exit 1
+fi
+
+LIBVIPRS_DIR="$(cd "$LIBVIPRS_DIR" && pwd)"
+TESTS_DIR="$(cd "$TESTS_DIR" && pwd)"
+
+if [ ! -f "$TESTS_DIR/Dockerfile" ]; then
+    echo "Error: Dockerfile not found at $TESTS_DIR/Dockerfile"
+    exit 1
+fi
+
+if [ ! -f "$LIBVIPRS_DIR/Cargo.toml" ]; then
+    echo "Error: no Cargo.toml under $LIBVIPRS_DIR, so it is not a libviprs checkout."
+    exit 1
+fi
+
+# A one-line description of a tree for the banner. The whole of #684 is that
+# "which commit did that just test?" had no answer anywhere in the output, so
+# print one, twice: before the run and again with the verdict.
+tree_desc() {
+    local dir="$1"
+    local rev
+    if rev="$(git -C "$dir" rev-parse --short HEAD 2>/dev/null)"; then
+        if [ -n "$(git -C "$dir" status --porcelain 2>/dev/null | head -1)" ]; then
+            rev="$rev+dirty"
+        fi
+        printf '%s' "$rev"
+    else
+        printf 'not a git checkout'
+    fi
+}
+
+print_trees() {
+    echo "  libviprs:       $LIBVIPRS_DIR ($(tree_desc "$LIBVIPRS_DIR"))"
+    echo "  libviprs-tests: $TESTS_DIR ($(tree_desc "$TESTS_DIR"))"
+}
+
+echo "Test plan (${ARCH_LABEL}):"
+print_trees
+echo "  image:          $IMAGE_NAME"
+
+if [ "$PRINT_PLAN" = true ]; then
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
 # Pre-flight checks
 # ---------------------------------------------------------------------------
 
@@ -73,45 +202,6 @@ if ! docker info >/dev/null 2>&1; then
         sleep 1
     done
     echo "Docker is running."
-fi
-
-# ---------------------------------------------------------------------------
-# Resolve workspace layout
-# ---------------------------------------------------------------------------
-# Supports invocation from either libviprs-tests/ or libviprs/.
-# Expected sibling layout:
-#   workspace/
-#     libviprs/          (core library)
-#     libviprs-tests/    (integration tests + Dockerfile)
-
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-
-# The Dockerfile and .dockerignore live in libviprs-tests/
-TESTS_DIR="$WORKSPACE_ROOT/libviprs-tests"
-LIBVIPRS_DIR="$WORKSPACE_ROOT/libviprs"
-
-if [ ! -d "$LIBVIPRS_DIR" ]; then
-    echo "Error: libviprs/ not found at $LIBVIPRS_DIR"
-    echo "Expected sibling layout:"
-    echo "  workspace/"
-    echo "    libviprs/"
-    echo "    libviprs-tests/"
-    exit 1
-fi
-
-if [ ! -d "$TESTS_DIR" ]; then
-    echo "Error: libviprs-tests/ not found at $TESTS_DIR"
-    echo "Expected sibling layout:"
-    echo "  workspace/"
-    echo "    libviprs/"
-    echo "    libviprs-tests/"
-    exit 1
-fi
-
-if [ ! -f "$TESTS_DIR/Dockerfile" ]; then
-    echo "Error: Dockerfile not found at $TESTS_DIR/Dockerfile"
-    exit 1
 fi
 
 # ---------------------------------------------------------------------------
@@ -128,6 +218,7 @@ fi
 # use only the reference suite plus in-test synthetics.
 
 FIXTURES_DIR="$TESTS_DIR/tmp/libvips-reference-tests"
+echo ""
 echo "Fetching libvips reference suite (pinned, idempotent)..."
 if ! "$TESTS_DIR/tools/fetch_reference_suite.sh"; then
     if [ -d "$FIXTURES_DIR/test-suite/images" ]; then
@@ -144,6 +235,50 @@ if [ -d "$FIXTURES_DIR/test-suite/images" ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Build context
+# ---------------------------------------------------------------------------
+# The Dockerfile copies `libviprs/` and `libviprs-tests/` out of the context
+# root, so pointing LIBVIPRS_DIR at a worktree is not enough on its own: the
+# context has to hold the two trees under those two names. It used to be the
+# workspace root, which only worked because the two names happen to be there,
+# and which also shipped every other sibling in that directory to the daemon
+# on every build — on this epic, ~150 lane worktrees of the same crate.
+#
+# Stage the two trees into a scratch context instead. It sits beside this
+# script rather than beside the tree under test, so runs from different
+# worktrees reuse the same warm copy. The exclusions here are a speed measure
+# only: Dockerfile.dockerignore stays the authoritative ignore set, and Docker
+# reads it from next to the -f Dockerfile, which comes from the tree under
+# test.
+
+CONTEXT_ROOT="${RUN_TESTS_CONTEXT_DIR:-$SELF_DIR/tmp/build-context}"
+
+stage_tree() {
+    local src="$1"
+    local dst="$2"
+    mkdir -p "$dst"
+    if command -v rsync >/dev/null 2>&1; then
+        rsync -a --delete \
+            --exclude '/.git' \
+            --exclude '/target/' \
+            --exclude '/tmp/' \
+            "$src/" "$dst/"
+    else
+        rm -rf "$dst"
+        mkdir -p "$dst"
+        ( cd "$src" && tar -cf - \
+            --exclude ./.git --exclude ./target --exclude ./tmp . ) \
+          | ( cd "$dst" && tar -xf - )
+    fi
+}
+
+echo ""
+echo "Staging build context at $CONTEXT_ROOT..."
+mkdir -p "$CONTEXT_ROOT"
+stage_tree "$LIBVIPRS_DIR" "$CONTEXT_ROOT/libviprs"
+stage_tree "$TESTS_DIR" "$CONTEXT_ROOT/libviprs-tests"
+
+# ---------------------------------------------------------------------------
 # Stop any previous instance
 # ---------------------------------------------------------------------------
 
@@ -155,14 +290,14 @@ fi
 # Build
 # ---------------------------------------------------------------------------
 
+echo ""
 echo "Building test image '${IMAGE_NAME}' (${ARCH_LABEL})..."
-echo "  libviprs:       $LIBVIPRS_DIR"
-echo "  libviprs-tests: $TESTS_DIR"
+print_trees
 DOCKER_BUILDKIT=1 docker build \
     --platform "$PLATFORM" \
     -f "$TESTS_DIR/Dockerfile" \
     -t "$IMAGE_NAME" \
-    "$WORKSPACE_ROOT"
+    "$CONTEXT_ROOT"
 
 # ---------------------------------------------------------------------------
 # Run tests
@@ -191,10 +326,12 @@ if [ $EXIT_CODE -eq 0 ]; then
     echo ""
     echo "================================================================"
     echo "All tests passed (${ARCH_LABEL})."
+    print_trees
 else
     echo ""
     echo "================================================================"
     echo "Tests FAILED (exit code ${EXIT_CODE})."
+    print_trees
     exit $EXIT_CODE
 fi
 


### PR DESCRIPTION
`tools/run-tests.sh` worked out which trees to test from where the script itself
sits, so `$WORKSPACE_ROOT/libviprs` was the answer on every run. Epic
libviprs/libviprs#520 puts each lane in its own git worktree, and a repo shares
one hooks directory between its main checkout and every worktree hanging off it,
so `pre-push` fired from a lane and gated that branch against `main`. The gate
could not fail on the author's own changes, which is worse than having no gate at
all: green read as "my branch passes" and meant nothing of the kind.

**Finding the tree.** The hook cannot get there from `$0`, which points into the
hooks directory every worktree shares, and it cannot walk up from `.git`, which
in a worktree is a file holding a `gitdir:` pointer rather than a directory. It
asks `git rev-parse --show-toplevel`, the tree git runs the hook from, and
`--git-common-dir` for the main checkout beside it, which is what names the repo
and locates the sibling harness.

**Accepting it.** `run-tests.sh` had no parameter for the tree at all, so passing
one from the hook was not enough on its own. `--libviprs` / `--libviprs-tests`,
or `LIBVIPRS_DIR` / `LIBVIPRS_TESTS_DIR`, carry it now, with the old sibling
paths as the defaults so every existing caller gets exactly what it got before.

**Actually building it.** This is the part the issue does not reach, and on its
own it would have left the fix looking right and doing nothing. The Dockerfile
copies `libviprs/` and `libviprs-tests/` out of the context root, so the context
has to hold the two trees under those two names. It was the workspace root, which
only ever worked because those two names happen to sit there. The two trees get
staged into a scratch context instead. That also stops every other sibling in the
workspace going to the daemon on each build, which on this machine is around 150
lane worktrees of the same crate.

**Saying what it did.** A run prints the trees and their revisions before it
builds and again with the verdict, and `--plan` answers the same question in a
second without touching Docker. The second commit closes a leak the first real
push exposed: git exports `GIT_DIR` into every hook, and it beats `git -C`, so
the banner reported the pushing branch's HEAD as the revision of a tree it had
never looked at. That commit also stops `set -e` taking the script out on the
`docker run` line, which is why a SIGKILLed container came back as a bare
"Pre-push tests failed" with no verdict, no trees, and no cleanup.

## Evidence

Pushed this branch from a git worktree with the fixed hook installed, and looked
inside the container the gate built while it was still running:

```
$ docker exec libviprs-tests-run sha256sum /src/libviprs-tests/tools/run-tests.sh
f3bb48d20ead6910...  /src/libviprs-tests/tools/run-tests.sh

worktree  tools/run-tests.sh   f3bb48d20ead6910...   <- what it built
origin/main tools/run-tests.sh 2464ba58d63a2ca6...   <- what it used to build
```

`tests/prepush_gate_tests_the_pushed_tree.rs` exists only on this branch, and the
container has it too. Under the old script neither could have been in there.

The core half of it, pointed at the `#672` lane worktree that found this, and
read out of the running container:

```
$ docker exec libviprs-tests-run sha256sum src/raster.rs src/source.rs src/imageio.rs
b3cb9a03b532a148...  src/raster.rs
5ed58793d252998d...  src/source.rs
0746d0ea134272e2...  src/imageio.rs

                    worktree (b1f4120)   main checkout (8e189be)
src/raster.rs       b3cb9a03b532a148     993f77c95222cfcb
src/source.rs       5ed58793d252998d     3ba2b27d13edb3b0
src/imageio.rs      0746d0ea134272e2     72f3c0744c2389de
```

Three for three on the worktree, none on the main checkout. That is the exact
comparison the issue makes, the other way round.

That run then failed, on `arithmetic_large_input_fallible_alloc` with
`signal: 9, SIGKILL`, which is libviprs/libviprs#683 and the reason this branch
went up with `--no-verify`. Worth saying plainly: that is the first time the gate
has failed on a lane's own tree, because until now it could not.

Seven cells in `tests/prepush_gate_tests_the_pushed_tree.rs` pin both halves, so
a regression here fails out loud instead of going quiet again.

## Deploying it

The generated hook only reaches a repo when `tools/install-hooks.sh` runs there,
and this branch does not run it. Everyone wanting the fix needs one
`./libviprs-tests/tools/install-hooks.sh` from the workspace root after it lands.

libviprs/libviprs#683 is stacked on top of this branch.

Closes libviprs/libviprs#684
