### PR TITLE
fix(hooks): stop the pre-push gate OOMing, and stop it running for nothing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,15 @@ ENV CARGO_PROFILE_DEV_DEBUG=0
 # The wall-clock perf-ratio smoke is `#[ignore]`d here and runs in the nightly
 # workflow, so it never gates this container run.
 #
+# The integration step compiles and runs in two calls with a `sync` between
+# them, rather than in the one `cargo test` that does both. Building ~130 test
+# binaries leaves gigabytes of dirty page cache in the cgroup, and dirty pages
+# cannot be reclaimed until they have been written back, so the first
+# memory-hungry test binary to start could push the group over its ceiling
+# faster than reclaim could answer. The kernel then killed it, and it came back
+# as a SIGKILL against whichever test was running (libviprs/libviprs#683).
+# Flushing first costs a second and makes that cache cheap to give up.
+#
 # The final step runs the green ported_* cells (feature = "ported_tests") via
 # tools/run_ported_cells.sh, the single source of truth for the green-cell
 # list (deferred remainder: issue #77). The cells read the pinned libvips
@@ -82,7 +91,8 @@ CMD sh -c '\
     echo "================================================================" && \
     echo "Running libviprs-tests integration tests (with pdfium)..." && \
     echo "================================================================" && \
-    cd /src/libviprs-tests && cargo test --features pdfium && \
+    cd /src/libviprs-tests && cargo test --features pdfium --no-run && sync && \
+    cargo test --features pdfium && \
     echo "" && \
     echo "================================================================" && \
     echo "Running libviprs-tests green ported cells (ported_tests)..." && \

--- a/README.md
+++ b/README.md
@@ -152,10 +152,38 @@ repos (libviprs, libviprs-cli, libviprs-tests):
 - `cargo fmt -- --check` — rejects unformatted code
 - `cargo clippy --all-targets -- -D warnings` — rejects lint warnings
 
-**Pre-push** (runs on every `git push`):
-- Runs the full Docker test suite via `run-tests.sh`
+**Pre-push** (runs on `git push`, when the push can reach the suite):
+- Runs the Docker test suite via `run-tests.sh`, against the working tree being
+  pushed. A linked worktree gates on its own branch, not on the main checkout
+  (libviprs/libviprs#684).
+- Skips the run when nothing in the push can reach a test. The list of paths
+  that count as inert is deliberately short and partly per-repo: `.github/` and
+  `.gitignore` are inert for a libviprs push and *not* for a libviprs-tests
+  one, whose guards read both. `README.md` and `CHANGELOG.md` are on neither
+  list, because the documentation guards read them out of both checkouts. The
+  hook names the path that made it run, or the paths that let it skip.
+- `LIBVIPRS_PREPUSH_ALL=1 git push` runs the suite whatever the paths say. Use
+  this rather than `--no-verify` when you do not trust a skip decision: it is
+  the difference between overriding the filter and turning the gate off.
+
+Before pushing, `./tools/run-tests.sh --plan` answers "which trees, which
+revisions, what budget" in a second without touching Docker.
+
+The container budget is three environment variables, all read by
+`run-tests.sh` (see its `--help`):
+
+| Variable | What it does |
+|---|---|
+| `RUN_TESTS_MEMORY` | Hard memory ceiling, default `4g`, clamped to what the Docker VM actually has. A ceiling above the VM total never binds, and the kill then lands outside the container where the daemon does not record it. |
+| `RUN_TESTS_BUILD_JOBS` | Concurrent `rustc` processes, default derived from the ceiling at ~1.5 GiB each. This is the first lever on an out-of-memory kill. |
+| `RUN_TESTS_TEST_THREADS` | `cargo test` thread pool, default cargo's own. The Dockerfile explains why the pdfium suites want the full pool. |
+
+A container killed for memory says so in those words and prints the budget it
+used; it is not a test failure, whatever test name printed last.
 
 To bypass in emergencies: `git commit --no-verify` or `git push --no-verify`.
+For a pre-push you think is skipping wrongly, reach for `LIBVIPRS_PREPUSH_ALL=1`
+first, because `--no-verify` is how the gate stopped protecting anything.
 
 ## Test Suites
 

--- a/tests/arithmetic_large_input_fallible_alloc.rs
+++ b/tests/arithmetic_large_input_fallible_alloc.rs
@@ -34,19 +34,217 @@
 //! (vips-8.18.4) and committed under
 //! `tests/fixtures/arithmetic_large_input_fallible_alloc_expected/`.
 
-use libviprs::{PixelFormat, Raster};
+use libviprs::{ArithmeticError, PixelFormat, Raster, RasterError};
 
-/// A raster whose `hough_circle` vote accumulator is far larger than any host
-/// can address. A 24000×24000 Gray8 raster (~576 MB, well within the 8 GiB
-/// construction budget) with a full `1..=65535` radius range makes
-/// `acc = 24000 * 24000 * 65535 * 4 bytes ≈ 137 TiB`, above the ~64 TiB point
-/// at which the allocator refuses the reservation outright (rather than
-/// lazily over-committing it), so the failure is fast and deterministic: the
-/// pristine infallible `vec![0u32; …]` aborts, the fallible scratch returns
-/// `Err`.
+/// A raster whose `hough_circle` vote accumulator is far larger than this
+/// process is allowed to have. A 24000×24000 Gray8 raster (~576 MB, well
+/// within the 8 GiB construction budget) with a full `1..=65535` radius range
+/// makes `acc = 24000 * 24000 * 65535 * 4 bytes ≈ 137 TiB`.
+///
+/// "Larger than the process is allowed to have" is deliberately not the same
+/// claim as "larger than the allocator will hand out". 137 TiB is refused
+/// outright on macOS and on x86-64 Linux, and it is *not* refused on aarch64
+/// Linux, where the reservation fits in the 48-bit address space and the
+/// kernel kills the process partway through zeroing it. That difference is
+/// libviprs/libviprs#683 and it is why [`bounded_child`] exists: the cells run
+/// under an `RLIMIT_AS` of their own, so the refusal is a property of the test
+/// rather than a guess about the host. See its doc for the whole of it.
 const OVERSIZE_DIM: u32 = 24_000;
 const RADIUS_MIN: u32 = 1;
 const RADIUS_MAX: u32 = 65_535;
+
+/// A slot the two oversize cells take in turn.
+///
+/// Both build the same 24000x24000 Gray8 raster, ~576 MB apiece, and cargo
+/// runs the cells of one binary on a thread pool, so the binary's resident
+/// peak was twice what either cell needs. The slot is taken in the parent, so
+/// it also serialises the bounded children below.
+fn oversize_slot() -> std::sync::MutexGuard<'static, ()> {
+    static SLOT: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // A poisoned slot still serialises. The second cell panics on purpose, so
+    // refusing to hand the slot out after it would be the wrong answer.
+    SLOT.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Set in the child so it runs the cell body instead of spawning again.
+const BOUNDED_CHILD: &str = "LIBVIPRS_TESTS_BOUNDED_ADDRESS_SPACE";
+
+/// The child prints this before it execs the test binary, carrying whatever
+/// `ulimit -v` reports *after* the attempt to set it. The parent quotes it in
+/// every message, because "the child ran under a 2 GiB cap" and "the child ran
+/// uncapped and the allocator refused instead" are two different results and
+/// the run has to say which one it got. macOS returns `unlimited` here: its
+/// `ulimit -v` fails with `Invalid argument` and the cell falls back on the
+/// allocator refusal, which is exactly where it already was.
+const LIMIT_MARKER: &str = "address-space-kib:";
+
+/// The name of the enclosing `#[test] fn`, derived rather than typed.
+///
+/// The child is a re-exec of this binary with `--exact <name>`, and libtest
+/// exits 0 when a filter matches nothing (`running 0 tests` / `test result:
+/// ok. 0 passed`). A hand-typed literal that drifts from the function name
+/// therefore leaves both cells permanently green having executed nothing,
+/// which a reviewer demonstrated by changing one character. Nothing in the
+/// toolchain ties a string literal to a function name, so take the name from
+/// the function: `type_name` of a fn item declared inside it is
+/// `<krate>::<test fn>::probe`. [`bounded_child`] also insists on seeing
+/// `1 passed` come back, so if this ever resolves to something else the cell
+/// goes red rather than quiet.
+macro_rules! this_test_name {
+    () => {{
+        fn probe() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            std::any::type_name::<T>()
+        }
+        let path = type_name_of(probe);
+        let path = path.strip_suffix("::probe").unwrap_or(path);
+        path.rsplit("::").next().unwrap_or(path)
+    }};
+}
+
+/// 2 GiB, in KiB, which is what `ulimit -v` wants. Room for the 576 MB raster
+/// and the harness several times over, and nowhere near the ~137 TiB the vote
+/// accumulator asks for.
+const ADDRESS_SPACE_KIB: &str = "2097152";
+
+/// Re-run one oversize cell in a child process whose address space is capped,
+/// and return `false` in the parent once the child has been checked.
+///
+/// Both cells assert that an over-capacity scratch allocation is *refused*,
+/// and they get there by asking `try_hough_circle` for a vote accumulator of
+/// roughly 137 TiB. The premise underneath is that the allocator refuses a
+/// reservation that large outright. That holds on macOS, which does not
+/// over-commit, and on x86-64 Linux, whose 47-bit user address space (128
+/// TiB) has nowhere to put the mapping. It does not hold on aarch64 Linux:
+/// the 48-bit space (256 TiB) has room, `Vec::try_reserve_exact` succeeds,
+/// `Vec::resize` starts writing zeros into it, and the kernel kills the
+/// process somewhere past three gigabytes.
+///
+/// That is the `signal: 9, SIGKILL` in libviprs/libviprs#683, and it is not a
+/// bug in libviprs. The size these cells pick simply is not over-capacity on
+/// that host, so the fallible path they mean to exercise is never reached. It
+/// went unnoticed because the same cells pass on the x86-64 GitHub runners
+/// and on a macOS host, and the local Docker mirror is the one place that
+/// runs them on aarch64 Linux.
+///
+/// So the cells stop asking the host what it will refuse and bring their own
+/// ceiling. Each re-runs itself in a child with `RLIMIT_AS` set far below the
+/// request, where the reservation is refused everywhere, immediately, with no
+/// page ever touched. The contract under test is unchanged and the sizes stay
+/// where they are: the accumulator is still caller-scaled and still far past
+/// anything the process can have. What changes is that "past anything this
+/// process can have" is now a property of the test rather than a guess about
+/// the machine.
+///
+/// A host that ignores `ulimit -v` (Darwin does) lands back on the allocator,
+/// which is where these cells already were and where they already pass. If it
+/// ignores the limit *and* over-commits, the child dies rather than the whole
+/// test binary, and the parent says which cell and why instead of leaving a
+/// bare SIGKILL against a test name.
+fn bounded_child(test_name: &str) -> bool {
+    if std::env::var_os(BOUNDED_CHILD).is_some() {
+        return true;
+    }
+
+    let exe = std::env::current_exe().expect("path of the running test binary");
+    // `ulimit -v` is a no-op on Darwin and fails there with `Invalid argument`.
+    // Swallowing that and carrying on is right, the allocator refusal still
+    // holds, but the run has to say so, so read the limit back and print it
+    // before the exec. Output is captured rather than streamed, so the parent
+    // can both quote it and check that a test actually ran.
+    let out = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            "ulimit -v {ADDRESS_SPACE_KIB} 2>/dev/null || :; \
+             echo \"{LIMIT_MARKER} $(ulimit -v)\"; \
+             exec \"$0\" \"$1\" --exact --test-threads=1"
+        ))
+        .arg(&exe)
+        .arg(test_name)
+        .env(BOUNDED_CHILD, "1")
+        .output()
+        .unwrap_or_else(|e| panic!("re-run {test_name} under a bounded address space: {e}"));
+
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    let regime = address_space_regime(&stdout);
+    let transcript = format!("--- child stdout ---\n{stdout}\n--- child stderr ---\n{stderr}\n---");
+
+    assert!(
+        stdout.contains(LIMIT_MARKER),
+        "the child never reached the exec: it printed no `{LIMIT_MARKER}` line, so \
+         nothing below can be said about {test_name}.\n{transcript}"
+    );
+
+    if !out.status.success() {
+        panic!(
+            "{test_name} did not pass in a child process ({}).\n{}\n{}",
+            out.status,
+            diagnose(&out.status, regime),
+            transcript
+        );
+    }
+
+    // libtest exits 0 when the filter matches nothing, so a successful status
+    // on its own proves only that the binary ran. Insist on a test having
+    // passed inside it.
+    assert!(
+        stdout.contains("1 passed"),
+        "the child exited 0 but no test ran: `--exact {test_name}` matched \
+         nothing, so this cell proved nothing. The name is derived from the \
+         function by this_test_name!(), so if it no longer matches, libtest's \
+         naming has moved.\n{transcript}"
+    );
+    false
+}
+
+/// What `ulimit -v` reported in the child, as a sentence for the messages.
+fn address_space_regime(child_stdout: &str) -> &'static str {
+    let reported = child_stdout
+        .lines()
+        .find_map(|l| l.trim().strip_prefix(LIMIT_MARKER))
+        .map(str::trim)
+        .unwrap_or("");
+    if reported == ADDRESS_SPACE_KIB {
+        "the child ran under the RLIMIT_AS cap"
+    } else if reported.is_empty() {
+        "the child never reported its address-space limit"
+    } else {
+        "the cap did not apply (this host refused `ulimit -v`), so the child \
+         ran uncapped and the assertion rests on the allocator refusing"
+    }
+}
+
+/// A kill is not one thing. Signal 6 and signal 9 mean opposite things here and
+/// the message used to name only one of them, the wrong one: reverting
+/// `try_hough_circle`'s accumulator to an infallible `vec![0u32; acc_len]`,
+/// which is the regression these cells exist to catch, kills the child with
+/// SIGABRT rather than SIGKILL.
+#[cfg(unix)]
+fn diagnose(status: &std::process::ExitStatus, regime: &str) -> String {
+    use std::os::unix::process::ExitStatusExt;
+    match status.signal() {
+        Some(6) => format!(
+            "SIGABRT: the process aborted rather than returning. That is \
+             `handle_alloc_error` firing on an infallible allocation, which is \
+             the regression these cells exist to catch: the vote accumulator is \
+             not going through the fallible path. ({regime}.)"
+        ),
+        Some(9) => format!(
+            "SIGKILL: the process was killed rather than refused. Nothing \
+             declined the {ADDRESS_SPACE_KIB} KiB request, so it was served \
+             lazily and then written into until the kernel picked the process \
+             off. ({regime}.)"
+        ),
+        Some(sig) => format!("killed by signal {sig}. ({regime}.)"),
+        None => format!("the cell failed on its own assertions. ({regime}.)"),
+    }
+}
+
+#[cfg(not(unix))]
+fn diagnose(_status: &std::process::ExitStatus, regime: &str) -> String {
+    format!("({regime}.)")
+}
 
 /// Directory holding the committed input fixtures and the offline libvips
 /// reference output for the differential `mul` check.
@@ -79,16 +277,41 @@ fn samples_u16(data: &[u8]) -> Vec<u16> {
 /// abort through `handle_alloc_error`.
 #[test]
 fn hough_circle_oversize_scratch_returns_typed_error_not_abort() {
+    let _slot = oversize_slot();
+    if !bounded_child(this_test_name!()) {
+        return;
+    }
     let raster = Raster::zeroed(OVERSIZE_DIM, OVERSIZE_DIM, PixelFormat::Gray8)
         .expect("oversize Gray8 raster is within the construction budget");
     // radii = 65535 is exactly the u16::MAX band ceiling, so `format_for`
     // succeeds and execution reaches the accumulator allocation — the buffer
     // this test is about — rather than short-circuiting on TooManyBands.
     let result = raster.try_hough_circle(RADIUS_MIN, RADIUS_MAX);
+    // Naming the variant, not just `is_err()`. Under RLIMIT_AS the set of
+    // things that can return `Err` here is much wider than it was, and an
+    // early `if radii > K { return Err(..) }` added upstream would keep a bare
+    // `is_err()` green while it stopped the accumulator being allocated at all.
     assert!(
-        result.is_err(),
-        "oversized hough_circle scratch must return Err, not a raster"
+        matches!(
+            result,
+            Err(ArithmeticError::Raster(
+                RasterError::AllocationFailed { .. }
+            ))
+        ),
+        "oversized hough_circle scratch must fail as \
+         ArithmeticError::Raster(RasterError::AllocationFailed), which is the \
+         fallible accumulator path. Got: {}",
+        describe(&result)
     );
+}
+
+/// A one-line description of a `try_hough_circle` result for the message
+/// above. `Raster` is large and its `Debug` prints the pixel buffer.
+fn describe(result: &Result<Raster, ArithmeticError>) -> String {
+    match result {
+        Ok(r) => format!("Ok(a {}x{} {:?} raster)", r.width(), r.height(), r.format()),
+        Err(e) => format!("Err({e:?})"),
+    }
 }
 
 /// The same fallible-scratch guarantee, driven through the panicking wrapper:
@@ -97,13 +320,21 @@ fn hough_circle_oversize_scratch_returns_typed_error_not_abort() {
 /// catchable; an abort is not.
 #[test]
 fn hough_circle_oversize_scratch_panics_not_aborts() {
+    let _slot = oversize_slot();
+    if !bounded_child(this_test_name!()) {
+        return;
+    }
+    // The raster is built *outside* catch_unwind on purpose. Under the 2 GiB
+    // cap a 576 MB construction is comfortable but no longer unfailable, and
+    // inside the closure a panicking `.expect(..)` would satisfy
+    // `caught.is_err()` without `hough_circle` ever being called, so the cell
+    // would pass having tested the constructor. Before this branch there was
+    // no cap and that could not happen.
+    let raster = Raster::zeroed(OVERSIZE_DIM, OVERSIZE_DIM, PixelFormat::Gray8)
+        .expect("oversize Gray8 raster is within the construction budget");
     let prev = std::panic::take_hook();
     std::panic::set_hook(Box::new(|_| {}));
-    let caught = std::panic::catch_unwind(|| {
-        let raster = Raster::zeroed(OVERSIZE_DIM, OVERSIZE_DIM, PixelFormat::Gray8)
-            .expect("oversize Gray8 raster is within the construction budget");
-        raster.hough_circle(RADIUS_MIN, RADIUS_MAX)
-    });
+    let caught = std::panic::catch_unwind(|| raster.hough_circle(RADIUS_MIN, RADIUS_MAX));
     std::panic::set_hook(prev);
     assert!(
         caught.is_err(),

--- a/tests/prepush_gate_cost_controls.rs
+++ b/tests/prepush_gate_cost_controls.rs
@@ -1,0 +1,685 @@
+//! Guards on what the local pre-push gate costs, and on what it is allowed to
+//! skip to save that cost (libviprs/libviprs#683).
+//!
+//! The gate ran the whole Docker suite on every push, including pushes that
+//! touched no Rust at all, and it fell over under its own memory ceiling in a
+//! way that read as a test failure. Between the two, `--no-verify` became the
+//! normal way to push, and a hook nobody runs protects nothing. Both halves
+//! are cheap to get wrong again in the direction that hurts: a skip list that
+//! grows past what is provably inert, and a budget that goes back to being a
+//! number nobody checked against the machine.
+//!
+//! The failure mode of the whole change is the gate quietly ceasing to run, so
+//! these guards are built to fail when that happens rather than to describe it.
+//! Two of them lift `inert_path()` out of the generated hook and *execute* it:
+//! one runs every tracked path in both repos through it and pins the set that
+//! comes back inert, the other installs the whole hook in a throwaway workspace
+//! and drives real pushes past it. An earlier pair of text guards here could
+//! not fail for the reason they claimed: a reviewer flipped `inert_path`'s
+//! fallthrough to `true`, disabling the gate for every push in every repo, and
+//! both stayed green.
+
+use std::collections::BTreeSet;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+mod common;
+use common::hooks::{generated_pre_push, read, repo_root};
+
+// ---------------------------------------------------------------------------
+// Running the hook's own `inert_path()`
+// ---------------------------------------------------------------------------
+
+/// The `inert_path()` shell function, lifted verbatim out of the generated
+/// hook and wrapped in a driver that prints the inert ones from a list of
+/// paths on stdin.
+///
+/// Lifting the real text is the point. A guard that re-implements the case
+/// statement in Rust tests the re-implementation, and a guard that greps the
+/// text tests the grep; both were tried here and both waved through six
+/// poisoned entries and a flipped fallthrough.
+fn inert_path_driver() -> String {
+    let hook = generated_pre_push();
+    let start = hook.find("inert_path() {").expect(
+        "the pre-push hook must decide what it may skip in one place, a shell \
+         function called inert_path()",
+    );
+    let end = hook[start..]
+        .find("\n}\n")
+        .map(|i| start + i + 2)
+        .expect("unterminated inert_path()");
+    let body = &hook[start..end];
+    format!(
+        "REPO_NAME=\"$1\"\n\
+         {body}\n\
+         while IFS= read -r candidate; do\n\
+         \x20   [ -z \"$candidate\" ] && continue\n\
+         \x20   if inert_path \"$candidate\"; then printf '%s\\n' \"$candidate\"; fi\n\
+         done\n"
+    )
+}
+
+/// Which of `paths` the hook would treat as inert for a push to `repo_name`.
+fn inert_paths(repo_name: &str, paths: &[String]) -> BTreeSet<String> {
+    let dir = tempfile::tempdir().expect("temp dir for the inert_path driver");
+    let script = dir.path().join("inert_path.sh");
+    std::fs::write(&script, inert_path_driver()).expect("write the inert_path driver");
+
+    let mut child = Command::new("sh")
+        .arg(&script)
+        .arg(repo_name)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("run the inert_path driver");
+    {
+        let stdin = child.stdin.as_mut().expect("driver stdin");
+        for p in paths {
+            writeln!(stdin, "{p}").expect("feed a path to the driver");
+        }
+    }
+    let out = child
+        .wait_with_output()
+        .expect("collect the driver's answer");
+    assert!(
+        out.status.success(),
+        "the inert_path driver failed ({}): {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+/// Every path a repo tracks, or, where there is no repository to ask (the
+/// Docker build context copies both trees without their `.git`), every file in
+/// the tree. Same shape as the working-tree fallback in `pdfium_provenance`.
+fn candidate_paths(root: &Path) -> Vec<String> {
+    if let Ok(out) = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["ls-files", "-z"])
+        .output()
+    {
+        if out.status.success() {
+            return String::from_utf8_lossy(&out.stdout)
+                .split('\0')
+                .filter(|p| !p.is_empty())
+                .map(str::to_string)
+                .collect();
+        }
+    }
+    let mut found = Vec::new();
+    walk(root, root, &mut found);
+    found
+}
+
+fn walk(root: &Path, dir: &Path, found: &mut Vec<String>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        // The same three the build context drops, so the two ways of listing
+        // a tree agree on what is in it.
+        if matches!(name.as_str(), ".git" | "target" | "tmp") {
+            continue;
+        }
+        let path = entry.path();
+        if path.is_dir() {
+            walk(root, &path, found);
+        } else if let Ok(rel) = path.strip_prefix(root) {
+            found.push(rel.to_string_lossy().replace('\\', "/"));
+        }
+    }
+}
+
+/// The sibling core checkout. `libviprs = { path = "../libviprs" }` in this
+/// crate's manifest means it is present whenever this suite can run at all.
+fn core_root() -> PathBuf {
+    repo_root().join("../libviprs")
+}
+
+/// Every path this repo tracks that the pre-push gate is allowed to skip.
+///
+/// `.gitignore` is deliberately absent: `tests/pdfium_provenance.rs` reads it
+/// for the `*.dylib` / `*.so` / `*.dll` patterns that keep a provenance-less
+/// PDFium binary out of the repo (issue #56), so a `.gitignore`-only push is
+/// the one push that must not skip the guard on it.
+const INERT_IN_LIBVIPRS_TESTS: &[&str] = &["LICENSE"];
+
+/// The same for the core checkout, where `.github/` and `.gitignore` are inert
+/// because nothing in either repo reads the core's copies of them.
+const INERT_IN_LIBVIPRS: &[&str] = &[
+    ".github/workflows/ci.yml",
+    ".github/workflows/merge-gate.yml",
+    ".github/workflows/publish.yml",
+    ".gitignore",
+    "LICENSE",
+    "docs/streaming-pdf-rotation.md",
+];
+
+/// The skip list may only hold paths nothing reads, and the only way to know
+/// that is to run every path there is through it.
+///
+/// Set equality rather than a spot check, so widening the list takes two
+/// deliberate edits instead of one. Add `tools/*` and this fails naming
+/// `tools/run-tests.sh`, which *is* the suite; add `src/*` and it fails naming
+/// the core library's source; flip the fallthrough to `true` and it fails
+/// naming everything.
+#[test]
+fn the_skip_list_exempts_exactly_the_pinned_paths() {
+    for (repo_name, root, pinned) in [
+        ("libviprs-tests", repo_root(), INERT_IN_LIBVIPRS_TESTS),
+        ("libviprs", core_root(), INERT_IN_LIBVIPRS),
+    ] {
+        let paths = candidate_paths(&root);
+        assert!(
+            paths.len() > 50,
+            "only {} paths found under {}, so this guard would pass on an empty \
+             tree rather than on a correct skip list",
+            paths.len(),
+            root.display()
+        );
+
+        let got = inert_paths(repo_name, &paths);
+        let want: BTreeSet<String> = pinned.iter().map(|s| s.to_string()).collect();
+
+        let newly_exempt: Vec<&String> = got.difference(&want).collect();
+        let no_longer_there: Vec<&String> = want.difference(&got).collect();
+
+        assert!(
+            newly_exempt.is_empty(),
+            "the pre-push gate would now skip a push that changes only these \
+             {} path(s) in {repo_name}, and they are not on the pinned list:\n  \
+             {}\nEvery one of them is a push that no longer runs a test. If \
+             that is genuinely what you want, add them to the pinned list in \
+             tests/prepush_gate_cost_controls.rs and say in the commit why \
+             nothing reads them (#683).",
+            newly_exempt.len(),
+            newly_exempt
+                .iter()
+                .map(|p| p.as_str())
+                .collect::<Vec<_>>()
+                .join("\n  ")
+        );
+        assert!(
+            no_longer_there.is_empty(),
+            "these paths are pinned as inert for {repo_name} but the tree no \
+             longer has them, or inert_path() no longer says so:\n  {}\nDrop \
+             them from the pinned list in tests/prepush_gate_cost_controls.rs.",
+            no_longer_there
+                .iter()
+                .map(|p| p.as_str())
+                .collect::<Vec<_>>()
+                .join("\n  ")
+        );
+    }
+}
+
+/// The same function, asked directly about the paths whose exemption would
+/// hurt most. Cheap, independent of what either tree happens to contain, and
+/// it names the consequence rather than the pattern.
+#[test]
+fn the_skip_list_never_exempts_what_the_suite_reads() {
+    let load_bearing: &[(&str, &str, &str)] = &[
+        (
+            "libviprs-tests",
+            ".gitignore",
+            "tests/pdfium_provenance.rs reads it for the native-binary patterns \
+             that keep a provenance-less PDFium out of the repo (issue #56)",
+        ),
+        (
+            "libviprs-tests",
+            ".github/workflows/ci.yml",
+            "the pinning guards read this repo's workflows directly \
+             (tests/common/workflows.rs)",
+        ),
+        ("libviprs-tests", "tools/run-tests.sh", "it is the suite"),
+        (
+            "libviprs-tests",
+            "tools/install-hooks.sh",
+            "it generates the hook these guards read",
+        ),
+        (
+            "libviprs-tests",
+            "tests/pdfium_provenance.rs",
+            "it is a test",
+        ),
+        ("libviprs-tests", "Cargo.lock", "it decides what gets built"),
+        (
+            "libviprs-tests",
+            "Dockerfile",
+            "it decides how it gets built",
+        ),
+        (
+            "libviprs-tests",
+            "README.md",
+            "tests/feature_rename_docs_present.rs reads it",
+        ),
+        ("libviprs", "src/lib.rs", "it is the library under test"),
+        (
+            "libviprs",
+            "README.md",
+            "the documentation guards read the core checkout's copy too",
+        ),
+        ("libviprs", "CHANGELOG.md", "same"),
+        ("libviprs", "Cargo.toml", "it decides what gets built"),
+    ];
+
+    for (repo_name, path, why) in load_bearing {
+        let inert = inert_paths(repo_name, &[(*path).to_string()]);
+        assert!(
+            inert.is_empty(),
+            "the pre-push gate would skip a {repo_name} push that changes only \
+             {path}, but {why}. A skip there lets a real failure through as a \
+             saved five minutes (#683)."
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Driving the whole hook
+// ---------------------------------------------------------------------------
+
+/// What the stub `run-tests.sh` prints when the hook decides to run the suite.
+const RAN_MARKER: &str = "STUB-RAN-THE-SUITE";
+
+/// A throwaway workspace holding the two repos the hook expects as siblings,
+/// with the generated pre-push hook installed in both and a stub in place of
+/// `run-tests.sh`, so a decision can be observed without Docker.
+///
+/// The evidence that this change works was six rows of skip/run decisions
+/// produced by hand. For a change whose failure mode is the gate silently
+/// ceasing to run, by hand and uncommitted is the wrong place for it.
+struct Workspace {
+    _dir: tempfile::TempDir,
+    root: PathBuf,
+}
+
+impl Workspace {
+    fn new() -> Workspace {
+        let dir = tempfile::tempdir().expect("temp dir for a stand-in workspace");
+        let root = dir.path().canonicalize().expect("canonical temp path");
+        let hook_body = generated_pre_push();
+
+        for repo in ["libviprs", "libviprs-tests"] {
+            let repo_root = root.join(repo);
+            std::fs::create_dir_all(repo_root.join("tools")).expect("create the stand-in repo");
+            git(&repo_root, &["init", "-q"]);
+
+            let hook = repo_root.join(".git/hooks/pre-push");
+            std::fs::create_dir_all(hook.parent().expect("hooks dir")).expect("create hooks dir");
+            std::fs::write(&hook, &hook_body).expect("install the generated pre-push hook");
+            make_executable(&hook);
+        }
+
+        // The hook points a libviprs push at the sibling harness's script and a
+        // libviprs-tests push at the pushed tree's own copy; in this workspace
+        // those are the same file, and it must exist or the hook bails out
+        // before it ever reaches the skip decision.
+        let stub = root.join("libviprs-tests/tools/run-tests.sh");
+        std::fs::write(&stub, format!("#!/bin/sh\necho \"{RAN_MARKER}\"\n"))
+            .expect("write the stub run-tests.sh");
+        make_executable(&stub);
+
+        Workspace { _dir: dir, root }
+    }
+
+    fn repo(&self, name: &str) -> PathBuf {
+        self.root.join(name)
+    }
+
+    /// Commit `files` in `repo` and return the commit's oid.
+    fn commit(&self, repo: &str, message: &str, files: &[(&str, &str)]) -> String {
+        let root = self.repo(repo);
+        for (rel, contents) in files {
+            let path = root.join(rel);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("create a directory for a stand-in file");
+            }
+            std::fs::write(&path, contents).expect("write a stand-in file");
+        }
+        git(&root, &["add", "-A"]);
+        git(
+            &root,
+            &[
+                "-c",
+                "user.name=prepush guard",
+                "-c",
+                "user.email=guard@example.invalid",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-q",
+                "--allow-empty",
+                "-m",
+                message,
+            ],
+        );
+        git(&root, &["rev-parse", "HEAD"]).trim().to_string()
+    }
+
+    /// Run the installed hook the way git does: from the top of the working
+    /// tree, with the ref updates on stdin.
+    fn push(&self, repo: &str, before: &str, after: &str, force_all: bool) -> String {
+        let root = self.repo(repo);
+        let mut cmd = Command::new("bash");
+        cmd.arg(root.join(".git/hooks/pre-push"))
+            .arg("origin")
+            .arg("git@example.invalid:libviprs/x.git")
+            .current_dir(&root)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        for leaked in [
+            "GIT_DIR",
+            "GIT_WORK_TREE",
+            "GIT_INDEX_FILE",
+            "GIT_PREFIX",
+            "LIBVIPRS_PREPUSH_ALL",
+        ] {
+            cmd.env_remove(leaked);
+        }
+        if force_all {
+            cmd.env("LIBVIPRS_PREPUSH_ALL", "1");
+        }
+
+        let mut child = cmd.spawn().expect("run the generated pre-push hook");
+        {
+            let stdin = child.stdin.as_mut().expect("hook stdin");
+            writeln!(stdin, "refs/heads/main {after} refs/heads/main {before}")
+                .expect("feed the ref update to the hook");
+        }
+        let out = child
+            .wait_with_output()
+            .expect("collect the hook's decision");
+        let text = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            out.status.success(),
+            "the pre-push hook exited {} on a {repo} push:\n{text}",
+            out.status
+        );
+        text
+    }
+}
+
+fn git(dir: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .output()
+        .unwrap_or_else(|e| {
+            panic!(
+                "these guards drive the real hook, which needs git on PATH: \
+                 `git {}` in {}: {e}",
+                args.join(" "),
+                dir.display()
+            )
+        });
+    assert!(
+        out.status.success(),
+        "git {} failed in {}: {}",
+        args.join(" "),
+        dir.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+fn make_executable(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+            .expect("make the stand-in script executable");
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+}
+
+/// The skip list decides nothing on its own; the hook does. So install the
+/// hook, push at it, and read the answer off the run.
+///
+/// These are the six rows the PR body reported by hand, in the tree, where a
+/// change to `inert_path` has to face them.
+#[test]
+fn the_hook_skips_and_runs_the_way_the_list_says() {
+    let ws = Workspace::new();
+
+    let base = [
+        ("README.md", "# stand-in\n"),
+        (".gitignore", "target/\n*.dylib\n"),
+        (".github/workflows/ci.yml", "name: ci\n"),
+        ("LICENSE", "stand-in licence\n"),
+        ("docs/note.md", "stand-in note\n"),
+        ("src/lib.rs", "// stand-in\n"),
+        (
+            "tools/run-tests.sh",
+            "#!/bin/sh\necho \"STUB-RAN-THE-SUITE\"\n",
+        ),
+    ];
+
+    let cases: &[(&str, &str, &str, bool, &str)] = &[
+        (
+            "libviprs-tests",
+            ".gitignore",
+            "target/\n",
+            true,
+            "tests/pdfium_provenance.rs reads this repo's .gitignore for the \
+             native-binary patterns (issue #56), and a push that drops them is \
+             exactly the push that must not skip",
+        ),
+        (
+            "libviprs-tests",
+            ".github/workflows/ci.yml",
+            "name: ci\njobs: {}\n",
+            true,
+            "the pinning guards read this repo's workflows",
+        ),
+        (
+            "libviprs-tests",
+            "LICENSE",
+            "stand-in licence, revised\n",
+            false,
+            "nothing reads it",
+        ),
+        (
+            "libviprs-tests",
+            "tools/run-tests.sh",
+            "#!/bin/sh\necho \"STUB-RAN-THE-SUITE\"\n# changed\n",
+            true,
+            "it is the suite",
+        ),
+        (
+            "libviprs",
+            ".github/workflows/ci.yml",
+            "name: ci\njobs: {}\n",
+            false,
+            "no test reads the core checkout's workflows",
+        ),
+        (
+            "libviprs",
+            "src/lib.rs",
+            "// stand-in, changed\n",
+            true,
+            "it is the library under test",
+        ),
+        (
+            "libviprs",
+            "README.md",
+            "# stand-in, revised\n",
+            true,
+            "the documentation guards read the core checkout's README",
+        ),
+    ];
+
+    for (repo, path, contents, should_run, why) in cases {
+        let before = ws.commit(repo, "base", &base);
+        let after = ws.commit(repo, "change", &[(path, contents)]);
+        let out = ws.push(repo, &before, &after, false);
+
+        let ran = out.contains(RAN_MARKER);
+        let skipped = out.contains("skipping it");
+        assert!(
+            ran != skipped,
+            "the hook neither clearly ran nor clearly skipped a {repo} push \
+             touching {path}:\n{out}"
+        );
+        assert_eq!(
+            ran,
+            *should_run,
+            "a {repo} push touching only {path} must {} the suite, because {why}. \
+             The hook said:\n{out}",
+            if *should_run { "run" } else { "skip" }
+        );
+    }
+}
+
+/// Whatever the list says, there has to be a way to say "run it anyway", or
+/// the next person who does not trust the filter goes back to `--no-verify`
+/// and takes the whole gate with them.
+///
+/// Asserted twice over, because the bare name `LIBVIPRS_PREPUSH_ALL` appears
+/// three times in the hook and is expanded once: delete the one line that
+/// reads it, keep the comment, and a `contains("LIBVIPRS_PREPUSH_ALL")` guard
+/// stays green with the escape hatch gone.
+#[test]
+fn the_skip_can_be_overridden() {
+    let hook = generated_pre_push();
+    assert!(
+        hook.contains("${LIBVIPRS_PREPUSH_ALL"),
+        "the pre-push hook mentions LIBVIPRS_PREPUSH_ALL but never expands it, \
+         so the escape hatch is documentation only. Without a real one the only \
+         way past a wrong skip decision is --no-verify, which is what #683 is \
+         about"
+    );
+
+    // And the same thing again through the hook itself, on a push it would
+    // otherwise skip.
+    let ws = Workspace::new();
+    let before = ws.commit(
+        "libviprs-tests",
+        "base",
+        &[
+            ("LICENSE", "stand-in licence\n"),
+            (
+                "tools/run-tests.sh",
+                "#!/bin/sh\necho \"STUB-RAN-THE-SUITE\"\n",
+            ),
+        ],
+    );
+    let after = ws.commit(
+        "libviprs-tests",
+        "licence tweak",
+        &[("LICENSE", "stand-in licence, revised\n")],
+    );
+
+    let skipped = ws.push("libviprs-tests", &before, &after, false);
+    assert!(
+        !skipped.contains(RAN_MARKER),
+        "a LICENSE-only push should have been skipped, so the override below \
+         proves nothing. The hook said:\n{skipped}"
+    );
+
+    let forced = ws.push("libviprs-tests", &before, &after, true);
+    assert!(
+        forced.contains(RAN_MARKER),
+        "LIBVIPRS_PREPUSH_ALL=1 must run the suite on a push the list would \
+         have skipped. The hook said:\n{forced}"
+    );
+}
+
+/// An out-of-memory kill is not a test failure and must never be reported as
+/// one. Three lanes read a SIGKILL as a broken test because nothing said
+/// otherwise.
+#[test]
+fn run_tests_names_an_out_of_memory_kill() {
+    let script = read("tools/run-tests.sh");
+    assert!(
+        script.contains("OOMKilled"),
+        "tools/run-tests.sh must ask the daemon whether the container was \
+         killed for memory before it reports a failure, or a cgroup kill \
+         arrives looking like whichever test was running at the time (#683)"
+    );
+    assert!(
+        script.contains("MemTotal"),
+        "tools/run-tests.sh must compare its memory ceiling against what the \
+         Docker VM actually has. A ceiling above the VM total never binds, so \
+         the kill lands outside the container and comes back unexplained (#683)"
+    );
+}
+
+/// The budget is reported before anything is built, and it is a real number
+/// that responds to the knobs. `--plan` makes that answerable without Docker.
+#[test]
+fn run_tests_reports_the_budget_it_will_use() {
+    let out = Command::new("bash")
+        .arg(repo_root().join("tools/run-tests.sh"))
+        .arg("--plan")
+        .env("RUN_TESTS_BUILD_JOBS", "1")
+        .output()
+        .expect("run tools/run-tests.sh --plan");
+    assert!(
+        out.status.success(),
+        "`run-tests.sh --plan` failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let plan = String::from_utf8_lossy(&out.stdout);
+    let budget = plan
+        .lines()
+        .find(|l| l.trim_start().starts_with("budget:"))
+        .unwrap_or_else(|| panic!("the plan does not report a budget:\n{plan}"));
+    assert!(
+        budget.contains("--memory=") && budget.contains("1 cargo build job"),
+        "the plan must name the memory ceiling and honour RUN_TESTS_BUILD_JOBS. \
+         It said: {budget}"
+    );
+}
+
+/// A fractional ceiling used to be an arithmetic syntax error, and under
+/// `set -e` that took the whole run out rather than rejecting the value.
+#[test]
+fn run_tests_accepts_a_fractional_memory_ceiling() {
+    let out = Command::new("bash")
+        .arg(repo_root().join("tools/run-tests.sh"))
+        .arg("--plan")
+        .env("RUN_TESTS_MEMORY", "1.5g")
+        .output()
+        .expect("run tools/run-tests.sh --plan");
+    assert!(
+        out.status.success(),
+        "`RUN_TESTS_MEMORY=1.5g run-tests.sh --plan` failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let plan = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        plan.contains("--memory=1536m"),
+        "RUN_TESTS_MEMORY=1.5g must resolve to 1536m. The plan said:\n{plan}"
+    );
+
+    let junk = Command::new("bash")
+        .arg(repo_root().join("tools/run-tests.sh"))
+        .arg("--plan")
+        .env("RUN_TESTS_MEMORY", "lots")
+        .output()
+        .expect("run tools/run-tests.sh --plan");
+    assert!(
+        !junk.status.success(),
+        "RUN_TESTS_MEMORY=lots must be rejected by name, not carried into a \
+         --memory flag. It said:\n{}",
+        String::from_utf8_lossy(&junk.stdout)
+    );
+}

--- a/tools/install-hooks.sh
+++ b/tools/install-hooks.sh
@@ -185,6 +185,121 @@ if [ ! -f "$RUN_TESTS" ]; then
     exit 0
 fi
 
+# ---------------------------------------------------------------------------
+# Is there anything in this push the suite could see?
+# ---------------------------------------------------------------------------
+# A full image build and suite run for a two-file workflow edit is what taught
+# everyone to reach for --no-verify, and a hook nobody runs protects nothing
+# (libviprs/libviprs#683). So skip, but only where the answer is knowable:
+# paths that no test in either repo reads. That list is deliberately short.
+#
+# README.md and CHANGELOG.md are NOT on it. This suite's documentation guards
+# read both, and they read them out of the *core* checkout as well as its own
+# (tests/feature_rename_docs_present.rs), so a docs-only push to either repo
+# can genuinely fail. Two entries are per-repo for the same reason: .github/
+# and .gitignore are inert for a libviprs push and read by a libviprs-tests
+# one, whose pinning guards read .github/workflows/*.yml (tests/common/
+# workflows.rs, tests/counterpart_pinning.rs) and whose provenance guard reads
+# .gitignore for the native-binary patterns (tests/pdfium_provenance.rs, issue
+# #56). A .gitignore-only push is exactly the push that can drop those
+# patterns, so it is the last one that should skip the guard on them.
+#
+# tests/prepush_gate_cost_controls.rs runs every tracked path in both repos
+# through this function for real and pins the set that comes back inert, so
+# adding an entry here fails there with the files it would newly exempt.
+#
+# Set LIBVIPRS_PREPUSH_ALL=1 to run the suite whatever the paths say.
+
+inert_path() {
+    case "$1" in
+        .github/*|.gitignore)
+            [ "$REPO_NAME" != "libviprs-tests" ]
+            ;;
+        docs/*|.gitattributes|.editorconfig|LICENSE|LICENSE-*)
+            true
+            ;;
+        *)
+            false
+            ;;
+    esac
+}
+
+REF_UPDATES="$(cat)"
+CHANGED=""
+SKIP_SUITE=false
+
+if [ "${LIBVIPRS_PREPUSH_ALL:-0}" != "1" ] && [ -n "$REF_UPDATES" ]; then
+    UNKNOWN=false
+    while read -r _local_ref local_oid _remote_ref remote_oid; do
+        if [ -z "${local_oid:-}" ]; then
+            continue
+        fi
+        # An all-zero local oid is a ref deletion: no content goes out.
+        case "$local_oid" in
+            *[!0]*) : ;;
+            *)      continue ;;
+        esac
+
+        BASE=""
+        case "${remote_oid:-}" in
+            *[!0]*)
+                if git cat-file -e "${remote_oid}^{commit}" 2>/dev/null; then
+                    BASE="$remote_oid"
+                fi
+                ;;
+        esac
+        if [ -z "$BASE" ]; then
+            # New branch. Compare against whatever the remote's default branch
+            # already has, and give up rather than guess if that is not here.
+            UPSTREAM="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+            if [ -z "$UPSTREAM" ]; then
+                UPSTREAM="origin/main"
+            fi
+            BASE="$(git merge-base "$local_oid" "$UPSTREAM" 2>/dev/null || true)"
+        fi
+        if [ -z "$BASE" ]; then
+            UNKNOWN=true
+            break
+        fi
+
+        # Unguarded this is a `set -e` exit: a git failure here would abort
+        # the push with nothing printed. A range we cannot diff is a range we
+        # cannot judge, which is the same answer as a base we could not find.
+        if ! REF_PATHS="$(git diff --name-only "$BASE" "$local_oid" --)"; then
+            UNKNOWN=true
+            break
+        fi
+        CHANGED="$CHANGED
+$REF_PATHS"
+    done <<REFS
+$REF_UPDATES
+REFS
+
+    if [ "$UNKNOWN" = false ]; then
+        SKIP_SUITE=true
+        while IFS= read -r changed_path; do
+            if [ -z "$changed_path" ]; then
+                continue
+            fi
+            if inert_path "$changed_path"; then
+                continue
+            fi
+            SKIP_SUITE=false
+            echo "Pre-push: $changed_path can reach the suite, running it."
+            break
+        done <<PATHS
+$CHANGED
+PATHS
+    fi
+fi
+
+if [ "$SKIP_SUITE" = true ]; then
+    echo "Pre-push: nothing in this push reaches the test suite, skipping it."
+    printf '%s\n' "$CHANGED" | sed '/^$/d; s/^/  /'
+    echo "  (LIBVIPRS_PREPUSH_ALL=1 runs it anyway)"
+    exit 0
+fi
+
 # git hands every hook a GIT_DIR (and, in a worktree, one pointing at the
 # per-worktree admin directory), and it wins over -C and over the working
 # directory for every git command anything below runs. Leaving it set made the

--- a/tools/run-tests.sh
+++ b/tools/run-tests.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 #         ./run-tests.sh --miri --loom    # run both
 #         ./run-tests.sh arm --miri       # combine arch + flags
 #         ./run-tests.sh --plan           # print what would be built, run nothing
+#         ./run-tests.sh --dry-run        # alias for --plan
 #
 # Which trees get tested:
 #         ./run-tests.sh --libviprs PATH        # core crate to build
@@ -31,7 +32,23 @@ set -euo pipefail
 # --loom  Run Loom concurrency tests on libviprs after the Docker tests pass.
 # --plan  Resolve and print the trees and the image, then exit without
 #         touching Docker. The cheap way to check that a pre-push hook is
-#         about to test the tree you think it is.
+#         about to test the tree you think it is. --dry-run is the same flag.
+#
+# Container budget:
+#   RUN_TESTS_MEMORY=8g          hard memory ceiling (default 4g, clamped to
+#                                what the Docker VM actually has). Accepts
+#                                g / m / k suffixes or a plain byte count,
+#                                fractions included (1.5g).
+#   RUN_TESTS_BUILD_JOBS=1       concurrent rustc processes (default: derived
+#                                from the memory ceiling). Lower this first on
+#                                an OOM; if one rustc is the peak on its own,
+#                                CARGO_PROFILE_DEV_CODEGEN_UNITS=1 is the next
+#                                lever, not a further job cut.
+#   RUN_TESTS_TEST_THREADS=2     cargo test thread pool (default: cargo's own)
+#   RUN_TESTS_CONTEXT_DIR=PATH   where to stage the Docker build context
+#                                (default: tmp/build-context beside this
+#                                script, so runs from different worktrees
+#                                reuse one warm copy)
 # ---------------------------------------------------------------------------
 
 RUN_MIRI=false
@@ -197,19 +214,11 @@ print_trees() {
     echo "  libviprs-tests: $TESTS_DIR ($(tree_desc "$TESTS_DIR"))"
 }
 
-echo "Test plan (${ARCH_LABEL}):"
-print_trees
-echo "  image:          $IMAGE_NAME"
-
-if [ "$PRINT_PLAN" = true ]; then
-    exit 0
-fi
-
 # ---------------------------------------------------------------------------
 # Pre-flight checks
 # ---------------------------------------------------------------------------
 
-if ! docker info >/dev/null 2>&1; then
+if [ "$PRINT_PLAN" != true ] && ! docker info >/dev/null 2>&1; then
     echo "Warning: Docker is not running, attempting to start it..."
     open -a Docker 2>/dev/null || systemctl start docker.service 2>/dev/null || dockerd &>/dev/null &
     echo "Waiting for Docker to be ready..."
@@ -217,6 +226,98 @@ if ! docker info >/dev/null 2>&1; then
         sleep 1
     done
     echo "Docker is running."
+fi
+
+# ---------------------------------------------------------------------------
+# Container budget
+# ---------------------------------------------------------------------------
+# What holds the memory in here is rustc, not the tests: the suite compiles
+# ~130 integration test binaries, one rustc per container CPU. Against a hard
+# ceiling the kernel kills whichever process is largest when it runs out, and
+# that comes back as `signal: 9, SIGKILL` under whatever test name happened to
+# be running, or as a compile that stops with no message at all. Neither reads
+# as "out of memory", which is what sent three lanes hunting a test bug that
+# was not there (libviprs/libviprs#683).
+#
+# RUN_TESTS_MEMORY, RUN_TESTS_BUILD_JOBS and RUN_TESTS_TEST_THREADS override
+# any of it.
+
+# Shell arithmetic cannot multiply 1.5, and under `set -e` it does not decline
+# politely: `$(( 1.5 * 1024 ))` is a syntax error and takes the script with it,
+# so RUN_TESTS_MEMORY=1.5g used to kill the run rather than set a ceiling. awk
+# handles the fraction and, more to the point, tells us when the value is not a
+# size at all so the caller gets a sentence instead of an arithmetic error.
+to_bytes() {
+    printf '%s' "$1" | awk '
+        {
+            v = tolower($0)
+            if (v !~ /^[0-9]+(\.[0-9]+)?[gmk]?$/) { exit 0 }
+            unit = substr(v, length(v), 1)
+            n = v + 0
+            if      (unit == "g") n *= 1024 * 1024 * 1024
+            else if (unit == "m") n *= 1024 * 1024
+            else if (unit == "k") n *= 1024
+            printf "%.0f\n", n
+        }
+    '
+}
+
+DAEMON_MEM="$(docker info --format '{{.MemTotal}}' 2>/dev/null || echo 0)"
+DAEMON_CPUS="$(docker info --format '{{.NCPU}}' 2>/dev/null || echo 0)"
+case "$DAEMON_MEM"  in ''|*[!0-9]*) DAEMON_MEM=0 ;;  esac
+case "$DAEMON_CPUS" in ''|*[!0-9]*) DAEMON_CPUS=0 ;; esac
+
+MEMORY_BYTES="$(to_bytes "${RUN_TESTS_MEMORY:-4g}")"
+case "$MEMORY_BYTES" in
+    ''|*[!0-9]*|0)
+        echo "Error: RUN_TESTS_MEMORY='${RUN_TESTS_MEMORY:-4g}' is not a memory size."
+        echo "Use a byte count or a g/m/k suffix, e.g. 3g, 1.5g, 3500m, 3500000k."
+        exit 1
+        ;;
+esac
+MEMORY_NOTE=""
+
+# A ceiling above the whole VM is not a ceiling. The cgroup never binds, the
+# VM runs out first, the kernel picks a victim inside the container, and
+# `docker inspect` reports OOMKilled=false because as far as the daemon is
+# concerned nothing hit its limit. That is exactly the shape of the reports on
+# this hook: a SIGKILL with no explanation attached. Clamping under the VM
+# total puts the kill back inside the container where it is recorded, so the
+# message at the bottom can be honest about what happened. On this host the
+# default 4g was already above the VM's 3.8 GiB.
+if [ "$DAEMON_MEM" -gt 0 ] && [ "$MEMORY_BYTES" -ge "$DAEMON_MEM" ]; then
+    MEMORY_BYTES=$(( DAEMON_MEM * 9 / 10 ))
+    MEMORY_NOTE=" (clamped: the Docker VM holds $(( DAEMON_MEM / 1024 / 1024 ))m in total)"
+fi
+
+DOCKER_MEMORY="$(( MEMORY_BYTES / 1024 / 1024 ))m"
+MEMORY_GIB=$(( MEMORY_BYTES / 1024 / 1024 / 1024 ))
+if [ "$MEMORY_GIB" -lt 1 ]; then
+    MEMORY_GIB=1
+fi
+
+# Around 1.5 GiB of headroom per concurrent rustc. Deliberately not applied to
+# the test threads: the Dockerfile says why the pdfium suites run on the
+# default pool, and cutting that would stop exercising the cross-test FPDF
+# concurrency it is there to exercise.
+BUILD_JOBS="${RUN_TESTS_BUILD_JOBS:-}"
+if [ -z "$BUILD_JOBS" ]; then
+    BUILD_JOBS=$(( MEMORY_GIB * 2 / 3 ))
+    if [ "$BUILD_JOBS" -lt 1 ]; then
+        BUILD_JOBS=1
+    fi
+    if [ "$DAEMON_CPUS" -gt 0 ] && [ "$BUILD_JOBS" -gt "$DAEMON_CPUS" ]; then
+        BUILD_JOBS="$DAEMON_CPUS"
+    fi
+fi
+
+echo "Test plan (${ARCH_LABEL}):"
+print_trees
+echo "  image:          $IMAGE_NAME"
+echo "  budget:         --memory=$DOCKER_MEMORY, $BUILD_JOBS cargo build job(s)$MEMORY_NOTE"
+
+if [ "$PRINT_PLAN" = true ]; then
+    exit 0
 fi
 
 # ---------------------------------------------------------------------------
@@ -330,11 +431,17 @@ set +e
 docker run \
     --platform "$PLATFORM" \
     --name "$CONTAINER_NAME" \
-    --memory=4g \
+    --memory="$DOCKER_MEMORY" \
+    -e CARGO_BUILD_JOBS="$BUILD_JOBS" \
+    ${RUN_TESTS_TEST_THREADS:+-e RUST_TEST_THREADS="$RUN_TESTS_TEST_THREADS"} \
     ${DOCKER_RUN_MOUNTS[@]+"${DOCKER_RUN_MOUNTS[@]}"} \
     "$IMAGE_NAME"
 EXIT_CODE=$?
 set -e
+
+# Ask the daemon before the container is gone. A cgroup kill is not a test
+# failure and must not be allowed to read as one.
+OOM_KILLED="$(docker inspect --format '{{.State.OOMKilled}}' "$CONTAINER_NAME" 2>/dev/null || echo false)"
 
 # ---------------------------------------------------------------------------
 # Cleanup
@@ -347,6 +454,41 @@ if [ $EXIT_CODE -eq 0 ]; then
     echo "================================================================"
     echo "All tests passed (${ARCH_LABEL})."
     print_trees
+elif [ "$OOM_KILLED" = "true" ]; then
+    echo ""
+    echo "================================================================"
+    echo "The container ran out of memory and the kernel killed it."
+    echo ""
+    echo "This is not a test failure, whatever test name printed last above."
+    echo "The run had --memory=$DOCKER_MEMORY and $BUILD_JOBS cargo build job(s)."
+    echo "Cheapest first:"
+    echo "  RUN_TESTS_BUILD_JOBS=1 $0"
+    echo "  CARGO_PROFILE_DEV_CODEGEN_UNITS=1 in the Dockerfile, if one rustc is"
+    echo "    the peak on its own and cutting jobs further has stopped helping"
+    echo "  RUN_TESTS_MEMORY=8g $0     (only helps with a Docker VM that big)"
+    echo "  raise the VM's memory under Docker Desktop > Settings > Resources"
+    print_trees
+    exit $EXIT_CODE
+elif [ "$EXIT_CODE" -eq 137 ]; then
+    # 137 is 128+9: the container took a SIGKILL. That is *usually* memory, but
+    # the daemon says it was not an in-cgroup OOM, and `docker stop`, a Ctrl-C
+    # and a daemon restart all land here too. Say both, rather than reporting
+    # every SIGKILL as an OOM the way this arm used to.
+    echo ""
+    echo "================================================================"
+    echo "The container was killed (SIGKILL), and the daemon does not record it"
+    echo "as an out-of-memory kill: docker inspect says OOMKilled=$OOM_KILLED."
+    echo ""
+    echo "Either way this is not a test failure, whatever test name printed"
+    echo "last above. The two things it usually is:"
+    echo "  * memory, killed outside the container's own accounting: the"
+    echo "    Docker VM ran out before the cgroup ceiling bound. The run had"
+    echo "    --memory=$DOCKER_MEMORY and $BUILD_JOBS cargo build job(s); try"
+    echo "    RUN_TESTS_BUILD_JOBS=1 $0"
+    echo "  * something stopped it: docker stop, Ctrl-C, or the daemon"
+    echo "    restarting under it. Nothing to fix; run it again."
+    print_trees
+    exit $EXIT_CODE
 else
     echo ""
     echo "================================================================"


### PR DESCRIPTION
Two separate reasons the gate cost more than it was worth. Between them, `git
push --no-verify` became the normal way to push, which leaves the hook
protecting nothing while still costing everyone several minutes.

## The OOM is a cell whose premise does not hold here

Not memory pressure, in the end. Both oversize-scratch cells assert that an
over-capacity scratch allocation is *refused*, and they get there by asking
`try_hough_circle` for a vote accumulator of roughly 137 TiB. That is refused
on macOS, which does not over-commit, and on the x86-64 runners, whose 47-bit
user address space (128 TiB) has nowhere to put the mapping, which is exactly
why the same cells are green on GitHub. On aarch64 Linux the 48-bit space
(256 TiB) has room: `try_reserve_exact` succeeds, `Vec::resize` starts writing
zeros into it, and the kernel kills the process. The local Docker mirror is the
one place that runs these on aarch64 Linux, so nothing else ever saw it.

Measured in the container, one test binary on its own:

```
PEAK-AFTER-COMPILE: 2154512384
running target/debug/deps/arithmetic_large_input_fallible_alloc-...
test hough_circle_oversize_scratch_panics_not_aborts ... EXIT=137
Killed
PEAK-AFTER-TEST:    3696230400     <- the ceiling
oom_kill 1
```

It is not a bug in libviprs. The size the cells pick is simply not
over-capacity on that host, so the fallible path they exist to exercise is
never reached.

So the cells stop asking the host what it will refuse and bring their own
ceiling: each re-runs itself in a child with `RLIMIT_AS` set well below the
request, where the reservation is refused everywhere, at once, with no page
touched. The contract and the sizes are unchanged. Same run, same container,
same `3525m`:

```
PEAK-AFTER-COMPILE: 2258055168
test result: ok. 3 passed; 0 failed
PEAK-AFTER-TEST:    2258055168     <- did not move
oom_kill 0
```

They also take a slot in turn, because they build the same 576 MB raster and
cargo runs the cells of one binary on a thread pool.

## The reporting around it was wrong in its own right

The ceiling was a hardcoded `--memory=4g`, and this host's Docker VM holds
3.8 GiB in total, so the cgroup never bound: the VM ran out first, the kernel
picked a victim inside the container, and `docker inspect` reported
`OOMKilled=false` because as far as the daemon was concerned nothing had hit
its limit. That is why these arrived as a bare `signal: 9, SIGKILL` under
whichever test name was unlucky, with nothing to say it was memory.

The ceiling is clamped under what the daemon actually has now, which puts a
kill back inside the container where it gets recorded, and a run that is killed
says so in those words with the three things worth trying. Concurrent rustc
processes come off the same budget, because rustc is what holds the memory
during the compile: around 130 test binaries, one per container CPU.
`RUN_TESTS_MEMORY`, `RUN_TESTS_BUILD_JOBS` and `RUN_TESTS_TEST_THREADS`
override any of it. The test threads keep cargo's own default, because the
Dockerfile explains why the pdfium suites want the full pool.

The integration step also compiles and runs in two calls with a `sync` between
them rather than in the one `cargo test` that does both. Building ~130 test
binaries leaves gigabytes of dirty page cache in the cgroup, and dirty pages
cannot be reclaimed until they are written back, so the first memory-hungry
binary to start could push the group past its ceiling faster than reclaim could
answer. That was what was left once the arithmetic cell stopped growing without
bound: the suite got as far as `streaming_pdfium_matrix` and died there instead.

With both in place the whole suite passes under the clamped ceiling, and **this
branch went up through the gate itself with no `--no-verify`**:

```
Green ported cells passed.
================================================================
All tests passed (arm64).
  libviprs:       /Users/rom/workspace/libviprs/libviprs (8e189be+dirty)
  libviprs-tests: /Users/rom/workspace/lv684/libviprs-tests (3024879)
```

(The one force-push after that carried a commit-message edit on a byte-identical
tree.)

## It ran unconditionally

The hook reads the refs git hands it, works out what the push actually changes,
and skips only where the answer is knowable.

## What it will not skip

Worth being explicit, because "touches no Rust" turned out not to mean "the
suite cannot see it":

| path | verdict | why |
| --- | --- | --- |
| `.github/**` in libviprs | skip | nothing in either repo reads it |
| `.github/**` in libviprs-tests | run | `tests/common/workflows.rs` reads `.github/workflows/*.yml`, and four pinning guards go through it |
| `README.md`, `CHANGELOG.md` | run | `tests/feature_rename_docs_present.rs` reads both, out of `../libviprs` as well as out of this repo |
| `docs/**`, `LICENSE`, `.gitignore`, `.gitattributes`, `.editorconfig` | skip | nothing reads them |
| anything else | run | |

So the two-file case in the issue, `merge-gate.yml` plus `CHANGELOG.md`, still
runs, on the CHANGELOG half. The workflow half is genuinely inert and the
CHANGELOG half genuinely is not, and I would rather the list stay defensible
than cover that one example. `LIBVIPRS_PREPUSH_ALL=1` runs the suite whatever
the paths say, and the hook names either the path that made it run or the paths
that let it skip, so the decision is never silent.

Driven through the generated hook in a synthetic workspace, with real ref
updates on stdin and a stub suite:

```
libviprs       .github/workflows/ci.yml               -> skipped
libviprs       .github/workflows/ci.yml + docs/x.md   -> skipped
libviprs       .github/workflows/ci.yml + README.md   -> ran (README.md)
libviprs       src/lib.rs                             -> ran
libviprs       workflow only, LIBVIPRS_PREPUSH_ALL=1  -> ran
libviprs-tests .github/workflows/ci.yml               -> ran (.github/workflows/ci.yml)
```

And the budget reports itself before anything is built:

```
budget: --memory=3525m, 2 cargo build job(s) (clamped: the Docker VM holds 3916m in total)
```

## Reading it

This branch sits on top of libviprs/libviprs#684 (PR #169), so its two commits
are in the diff below as well. Read #169 first, or read only the third commit,
`fix(hooks): stop the pre-push gate OOMing...`, which is all of this one.

It targets `main` rather than #169's branch because GitHub only registers a
closing keyword on a pull request that targets the default branch, and the two
issues are worth closing automatically. Merge #169 first and this one reduces to
its own commit.

Closes libviprs/libviprs#683
