### PR TITLE
fix(hooks): stop installing a pre-push gate the cli's push cannot fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,9 @@ docker run --rm libviprs-tests cargo test --features pdfium -- --ignored pdfium_
 
 ## Git Hooks
 
-`install-hooks.sh` installs pre-commit and pre-push hooks into all three
-repos (libviprs, libviprs-cli, libviprs-tests):
+`install-hooks.sh` installs the pre-commit hook into all four repos
+(libviprs, libviprs-cli, libviprs-tests, pdfium-render) and the pre-push hook
+into the two the suite can see:
 
 ```bash
 # From libviprs-tests/
@@ -152,10 +153,19 @@ repos (libviprs, libviprs-cli, libviprs-tests):
 - `cargo fmt -- --check` — rejects unformatted code
 - `cargo clippy --all-targets -- -D warnings` — rejects lint warnings
 
-**Pre-push** (runs on `git push`, when the push can reach the suite):
+**Pre-push** (libviprs and libviprs-tests only; runs on `git push`, when the
+push can reach the suite):
 - Runs the Docker test suite via `run-tests.sh`, against the working tree being
   pushed. A linked worktree gates on its own branch, not on the main checkout
   (libviprs/libviprs#684).
+- libviprs-cli does not get it. `run-tests.sh` wires two trees and the
+  `Dockerfile` copies two, so a cli push would build an image the cli is not in
+  and come back with a verdict independent of the commits going out
+  (libviprs/libviprs#691). The cli's differential coverage runs in the
+  `cli-differential` CI job, which lays the cli down at `CLI_COUNTERPART_REV`
+  and sets `VIPRS_REQUIRE_CLI=1` so a silent skip is a hard failure. Running
+  `install-hooks.sh` also clears a pre-push hook an older copy of it left in
+  the cli, so the misleading gate goes away in clones that already have it.
 - Skips the run when nothing in the push can reach a test. The list of paths
   that count as inert is deliberately short and partly per-repo: `.github/` and
   `.gitignore` are inert for a libviprs push and *not* for a libviprs-tests

--- a/tests/install_hooks_pre_push_slots.rs
+++ b/tests/install_hooks_pre_push_slots.rs
@@ -1,0 +1,290 @@
+//! Guards on which repos `tools/install-hooks.sh` gives a pre-push gate to
+//! (libviprs/libviprs#691).
+//!
+//! The installer wrote the same pre-push hook into `libviprs`, `libviprs-cli`
+//! and `libviprs-tests`, and that hook runs `tools/run-tests.sh`, whose image
+//! holds the core crate and this harness and nothing else. A cli developer
+//! therefore paid a full image build and suite run on every push and got back
+//! a verdict that could not fail on the commits going out. That is the trade
+//! that teaches people to reach for `--no-verify`, which is what
+//! libviprs/libviprs#683 was opened on.
+//!
+//! CI still catches a bad cli change: the dedicated `cli-differential` job
+//! lays the cli down at `CLI_COUNTERPART_REV` and runs with
+//! `VIPRS_REQUIRE_CLI=1`, so a silent skip there is a hard panic
+//! (`tests/common/cli.rs`). This is a local-gate honesty problem, not a hole
+//! in CI coverage.
+//!
+//! Every guard here *runs* `tools/install-hooks.sh` against a throwaway
+//! workspace of stand-in repos and reads the answer off the files it leaves
+//! behind. None of them greps the installer: the whole reason
+//! libviprs/libviprs#695 exists is that two guards on this hook asserted by
+//! substring and stayed green while the behaviour they named was gone.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+mod common;
+use common::hooks::repo_root;
+
+/// The comment line every hook this installer writes carries. The installer
+/// uses it to tell its own output apart from a hand-written hook, so the
+/// guards have to agree with it byte for byte.
+const INSTALLER_MARKER: &str = "Installed by libviprs-tests/tools/install-hooks.sh";
+
+/// The four repos `install-hooks.sh` looks for as siblings.
+const REPOS: &[&str] = &[
+    "libviprs",
+    "libviprs-cli",
+    "libviprs-tests",
+    "pdfium-render",
+];
+
+/// A throwaway workspace with the four sibling repos the installer expects and
+/// a copy of the installer itself, so it can be run for real without touching
+/// a developer's checkouts. It removes hooks it recognises as its own, so
+/// running it against the live workspace from a test would be destructive.
+struct Workspace {
+    _dir: tempfile::TempDir,
+    root: PathBuf,
+}
+
+impl Workspace {
+    fn new() -> Workspace {
+        let dir = tempfile::tempdir().expect("temp dir for a stand-in workspace");
+        let root = dir.path().canonicalize().expect("canonical temp path");
+
+        for repo in REPOS {
+            let repo_root = root.join(repo);
+            std::fs::create_dir_all(&repo_root).expect("create a stand-in repo");
+            git(&repo_root, &["init", "-q"]);
+        }
+
+        // The installer resolves the workspace from its own location, so it
+        // has to be run from inside the stand-in harness rather than from the
+        // real one.
+        let tools = root.join("libviprs-tests/tools");
+        std::fs::create_dir_all(&tools).expect("create the stand-in tools directory");
+        for script in ["install-hooks.sh", "run-tests.sh", "run_ported_cells.sh"] {
+            let to = tools.join(script);
+            std::fs::copy(repo_root().join("tools").join(script), &to)
+                .unwrap_or_else(|e| panic!("copy tools/{script} into the stand-in workspace: {e}"));
+            make_executable(&to);
+        }
+
+        Workspace { _dir: dir, root }
+    }
+
+    /// Run the installer the way a developer does, and hand back everything it
+    /// printed.
+    fn install(&self) -> String {
+        let out = Command::new("bash")
+            .arg(self.root.join("libviprs-tests/tools/install-hooks.sh"))
+            .current_dir(self.root.join("libviprs-tests"))
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .output()
+            .expect("run tools/install-hooks.sh");
+        let text = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            out.status.success(),
+            "tools/install-hooks.sh exited {}:\n{text}",
+            out.status
+        );
+        text
+    }
+
+    fn hook(&self, repo: &str, name: &str) -> PathBuf {
+        self.root.join(repo).join(".git/hooks").join(name)
+    }
+
+    fn write_hook(&self, repo: &str, name: &str, body: &str) {
+        let path = self.hook(repo, name);
+        std::fs::create_dir_all(path.parent().expect("hooks dir")).expect("create hooks dir");
+        std::fs::write(&path, body).expect("write a stand-in hook");
+        make_executable(&path);
+    }
+}
+
+fn git(dir: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .output()
+        .unwrap_or_else(|e| {
+            panic!(
+                "these guards drive the real installer, which needs git on PATH: \
+                 `git {}` in {}: {e}",
+                args.join(" "),
+                dir.display()
+            )
+        });
+    assert!(
+        out.status.success(),
+        "git {} failed in {}: {}",
+        args.join(" "),
+        dir.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn make_executable(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+            .expect("make a stand-in script executable");
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+}
+
+/// #691: the pre-push gate only goes where the suite it runs can see the
+/// repo. `run-tests.sh` builds an image holding the core crate and this
+/// harness, so those two get it and the other two do not.
+///
+/// The pre-commit hook is a different story and stays everywhere: it runs the
+/// repo's own `cargo fmt` and `cargo clippy` in the repo it is installed in,
+/// so for the cli it gates the cli.
+#[test]
+fn a_pre_push_hook_only_lands_where_the_suite_has_a_slot() {
+    let ws = Workspace::new();
+    let printed = ws.install();
+
+    let expected: &[(&str, bool, &str)] = &[
+        (
+            "libviprs",
+            true,
+            "run-tests.sh builds the core crate, so the gate can fail on a core change",
+        ),
+        (
+            "libviprs-tests",
+            true,
+            "run-tests.sh builds this harness, so the gate can fail on a harness change",
+        ),
+        (
+            "libviprs-cli",
+            false,
+            "the suite has no slot for the cli, so the gate would report a verdict \
+             independent of the commits going out (#691)",
+        ),
+        (
+            "pdfium-render",
+            false,
+            "the fork has no run-tests.sh integration at all",
+        ),
+    ];
+
+    for (repo, wants_pre_push, why) in expected {
+        assert!(
+            ws.hook(repo, "pre-commit").is_file(),
+            "{repo} got no pre-commit hook, and that one is per-repo and cheap. \
+             The installer said:\n{printed}"
+        );
+        assert_eq!(
+            ws.hook(repo, "pre-push").is_file(),
+            *wants_pre_push,
+            "{repo} must {} a pre-push hook, because {why}. The installer said:\n{printed}",
+            if *wants_pre_push { "get" } else { "not get" }
+        );
+    }
+}
+
+/// The installer has to clear a pre-push hook an older copy of itself put in
+/// a repo that no longer gets one. Every clone that ran the old installer is
+/// still carrying that hook, and it does not go away on its own: nothing but
+/// this script ever writes to `.git/hooks`, so "stop writing it" leaves the
+/// misleading gate running everywhere it already landed.
+#[test]
+fn a_previously_installed_pre_push_is_cleared_from_a_repo_with_no_slot() {
+    let ws = Workspace::new();
+    ws.write_hook(
+        "libviprs-cli",
+        "pre-push",
+        &format!("#!/usr/bin/env bash\n# {INSTALLER_MARKER}\nexit 0\n"),
+    );
+
+    let printed = ws.install();
+
+    assert!(
+        !ws.hook("libviprs-cli", "pre-push").is_file(),
+        "the installer left an older copy of its own pre-push hook in \
+         libviprs-cli. A cli push still gates on a suite that cannot see the \
+         cli, which is #691 surviving the fix. The installer said:\n{printed}"
+    );
+}
+
+/// Clearing is scoped to hooks this installer wrote. Somebody else's pre-push
+/// hook is not ours to remove, and removing it silently would be a worse bug
+/// than the one being fixed.
+#[test]
+fn a_hand_written_pre_push_hook_is_left_alone() {
+    let ws = Workspace::new();
+    let body = "#!/bin/sh\n# mine, not the installer's\nexit 0\n";
+    ws.write_hook("libviprs-cli", "pre-push", body);
+
+    let printed = ws.install();
+
+    let path = ws.hook("libviprs-cli", "pre-push");
+    assert!(
+        path.is_file(),
+        "the installer removed a pre-push hook it did not write. It said:\n{printed}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("read the hand-written hook"),
+        body,
+        "the installer rewrote a pre-push hook it did not write. It said:\n{printed}"
+    );
+}
+
+/// The other half of the coupling, so the two facts cannot drift apart: the
+/// cli gets no pre-push *because* the suite has no cli slot. Ask the suite
+/// directly rather than asserting it about a script.
+///
+/// If someone gives `run-tests.sh` a cli tree (option 1 on #691: a `CLI_DIR`,
+/// a `COPY libviprs-cli/` in the Dockerfile, `VIPRS_CLI_DIR` and
+/// `VIPRS_REQUIRE_CLI=1` so the 18 differential binaries run against the
+/// pushed tree) this goes red, and the fix is to give the cli its pre-push
+/// arm back rather than to delete this.
+#[test]
+fn the_suite_still_has_no_slot_for_the_cli() {
+    let script = repo_root().join("tools/run-tests.sh");
+
+    let rejected = Command::new("bash")
+        .arg(&script)
+        .args(["--plan", "--libviprs-cli", "/nonexistent"])
+        .output()
+        .expect("run tools/run-tests.sh --plan --libviprs-cli");
+    assert!(
+        !rejected.status.success(),
+        "tools/run-tests.sh now accepts a cli tree, so the suite has a cli slot \
+         and libviprs-cli should get the pre-push gate back (#691). It said:\n{}",
+        String::from_utf8_lossy(&rejected.stdout)
+    );
+
+    let plan = Command::new("bash")
+        .arg(&script)
+        .arg("--plan")
+        .output()
+        .expect("run tools/run-tests.sh --plan");
+    assert!(
+        plan.status.success(),
+        "`run-tests.sh --plan` failed: {}",
+        String::from_utf8_lossy(&plan.stderr)
+    );
+    let plan = String::from_utf8_lossy(&plan.stdout);
+    assert!(
+        !plan.contains("libviprs-cli:"),
+        "tools/run-tests.sh plans a cli tree, so the suite has a cli slot and \
+         libviprs-cli should get the pre-push gate back (#691). It planned:\n{plan}"
+    );
+}

--- a/tools/install-hooks.sh
+++ b/tools/install-hooks.sh
@@ -13,7 +13,9 @@ set -euo pipefail
 #   pre-push    — Docker test suite via run-tests.sh (slow, on every push)
 #                 Runs against the working tree being pushed, which for a
 #                 linked worktree is not the main checkout the hooks
-#                 directory lives in (libviprs/libviprs#684).
+#                 directory lives in (libviprs/libviprs#684). Only where the
+#                 suite has a slot for the repo, which is libviprs and
+#                 libviprs-tests (libviprs/libviprs#691).
 #
 # Usage:  ./tools/install-hooks.sh          # from libviprs-tests/
 #         ./libviprs-tests/tools/install-hooks.sh  # from workspace root
@@ -76,6 +78,53 @@ cargo_steps_for_repo() {
         libviprs-tests)  printf '%s\n' "${LIBVIPRS_TESTS_CARGO_STEPS[@]}" ;;
         *)               printf '%s\n' "cargo clippy --all-targets -- -D warnings" ;;
     esac
+}
+
+# ---------------------------------------------------------------------------
+# Which repos get the pre-push gate
+# ---------------------------------------------------------------------------
+# The gate runs tools/run-tests.sh, whose image holds the core crate and this
+# harness and nothing else, so those two are the only repos where a green
+# verdict says anything about the commits going out. libviprs-cli used to get
+# the hook as well and paid a full image build plus a suite run for an answer
+# that could not fail on its own change, which is exactly the trade that
+# teaches people to reach for --no-verify (libviprs/libviprs#691).
+#
+# The cli is not left unguarded: the dedicated `cli-differential` CI job lays
+# it down at CLI_COUNTERPART_REV and runs with VIPRS_REQUIRE_CLI=1, so a silent
+# skip there is a hard panic (tests/common/cli.rs, CLI_CONTRACT.md §7). What
+# goes away is a local promise the suite could not keep.
+#
+# tests/install_hooks_pre_push_slots.rs runs this script against a stand-in
+# workspace and pins the answer per repo. It also asks run-tests.sh whether it
+# has grown a cli slot, so giving the suite one turns that guard red pointing
+# back here rather than leaving the two facts to drift.
+has_suite_slot() {
+    case "$1" in
+        libviprs|libviprs-tests) return 0 ;;
+        *)                       return 1 ;;
+    esac
+}
+
+# The comment line every hook this script writes carries. It is what tells our
+# own output apart from a hook somebody wrote by hand.
+INSTALLER_MARKER="Installed by libviprs-tests/tools/install-hooks.sh"
+
+# A repo that no longer gets the gate must not keep the copy an older version
+# of this script left in it. Nothing but this script writes to .git/hooks, so
+# "stop writing it" on its own leaves the misleading gate running in every
+# clone it already reached, for as long as that clone lives.
+drop_generated_pre_push() {
+    local hooks_dir="$1"
+    local pre_push="$hooks_dir/pre-push"
+
+    [ -f "$pre_push" ] || return 0
+    if grep -q "$INSTALLER_MARKER" "$pre_push"; then
+        rm -f "$pre_push"
+        echo "        removed the pre-push hook an older install left here"
+    else
+        echo "        left a pre-push hook this script did not write alone"
+    fi
 }
 
 write_pre_commit() {
@@ -158,7 +207,8 @@ RUN_TESTS="$WORKSPACE_ROOT/libviprs-tests/tools/run-tests.sh"
 
 # Hand the pushed tree to the suite in whichever slot it belongs. Without
 # this run-tests.sh falls back to the sibling checkouts, which is the whole
-# defect. libviprs-cli has no slot in this suite and keeps the old behaviour.
+# defect. There are two slots and this hook is only installed into the two
+# repos that have one (libviprs/libviprs#691).
 # Both slots get pinned, not just the one being pushed. run-tests.sh falls
 # back to the siblings of wherever the script itself sits, and the script the
 # line below may pick sits inside the worktree, whose neighbours are other
@@ -475,11 +525,20 @@ for REPO_DIR in "${REPOS[@]}"; do
             # pre-push (no `run-tests.sh` integration on this repo).
             write_pdfium_pre_commit "$HOOKS_DIR"
             echo "  done: $REPO_NAME (scoped pre-commit)"
+            drop_generated_pre_push "$HOOKS_DIR"
             ;;
         *)
+            # The pre-commit hook goes everywhere: it runs the repo's own
+            # `cargo fmt` and `cargo clippy` in the repo it is installed in, so
+            # for the cli it gates the cli.
             write_pre_commit "$HOOKS_DIR" "$REPO_NAME"
-            write_pre_push "$HOOKS_DIR"
-            echo "  done: $REPO_NAME (pre-commit + pre-push)"
+            if has_suite_slot "$REPO_NAME"; then
+                write_pre_push "$HOOKS_DIR"
+                echo "  done: $REPO_NAME (pre-commit + pre-push)"
+            else
+                echo "  done: $REPO_NAME (pre-commit only; the suite has no slot for it)"
+                drop_generated_pre_push "$HOOKS_DIR"
+            fi
             ;;
     esac
     installed=$((installed + 1))


### PR DESCRIPTION
`tools/install-hooks.sh` wrote the pre-push hook into `libviprs-cli` alongside the other two repos, and the suite that hook runs has no cli slot. `tools/run-tests.sh` wires exactly `LIBVIPRS_DIR` and `LIBVIPRS_TESTS_DIR`, and the `Dockerfile` copies `libviprs/` and `libviprs-tests/`. So a cli push built an image the cli was not in, ran the suite, and reported a verdict that could not fail on the commits going out. Full image build, full suite run, no information, which is precisely the trade that taught everyone to reach for `--no-verify` and is what libviprs/libviprs#683 was opened on.

I took option 3 off the issue. Option 1 (a real `CLI_DIR`, a `COPY libviprs-cli/`, `VIPRS_CLI_DIR` plus `VIPRS_REQUIRE_CLI=1` so the 18 differential binaries run against the pushed tree) puts the cli into the image for every push from every repo, which spends the cost that #683 just finished cutting, in the harness whose gate is already the slowest thing in the loop. Option 2 adds a code path neither CI nor the other two repos exercise. Option 3 costs the cli nothing it actually had: the gate could not see the cli before this change either.

What the cli keeps is real coverage. The pre-commit hook still goes in and still runs the cli's own `cargo fmt` and `cargo clippy` in the cli. The `cli-differential` CI job still lays the cli down at `CLI_COUNTERPART_REV` and runs with `VIPRS_REQUIRE_CLI=1`, so `cli_available()` turns a would-be silent skip into a hard panic. What goes away is a local promise the suite could not keep.

## Not writing it is only half of it

Nothing but this script ever writes to `.git/hooks`, so "stop writing the hook" leaves it running in every clone it already reached, forever. That is not hypothetical. On this machine, right now:

```
$ head -9 /Users/rom/workspace/libviprs/libviprs-cli/.git/hooks/pre-push
#!/usr/bin/env bash
set -euo pipefail

# Pre-push hook: run Docker test suite before pushing.
# Installed by libviprs-tests/tools/install-hooks.sh
# To skip (emergency only): git push --no-verify

REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
WORKSPACE_ROOT="$(cd "$REPO_DIR/.." && pwd)"
```

That is the **pre-#684, pre-#683** body: it resolves the repo from `$0`, has no skip decision and no `LIBVIPRS_DIR` export. Two fixes have landed since and neither reached this file. So the installer now also clears a pre-push hook it recognises as its own (by the `Installed by libviprs-tests/tools/install-hooks.sh` marker line) out of a repo with no slot, and leaves a hook it did not write alone.

## The guards run the installer, they do not read it

Four guards in `tests/install_hooks_pre_push_slots.rs`. Each one builds a throwaway workspace of stand-in git repos, copies the installer in, **runs it**, and reads the answer off the files it leaves behind. None of them greps the script. libviprs/libviprs#695 exists because two guards on this same hook asserted by substring and stayed green while the behaviour they named had been deleted, and I am not adding a third.

`the_suite_still_has_no_slot_for_the_cli` is green from the first commit on purpose. It pins the premise the other three rest on, by asking `run-tests.sh` itself: it must reject `--libviprs-cli` and must not plan a cli tree. Give the suite a cli slot and it goes red pointing at `has_suite_slot()`, so the two facts cannot drift apart.

## Mutation table

Every mutation was applied to the tree, measured, and reverted. `git diff --stat` is clean afterwards.

| # | mutation | guard | result |
|---|---|---|---|
| M1 | install the pre-push hook into every repo again, exactly as before this PR (`if has_suite_slot ...` → `if true`) | `a_pre_push_hook_only_lands_where_the_suite_has_a_slot` | **RED** |
| M2 | stop clearing a pre-push an older install left in a slotless repo (drop the `drop_generated_pre_push` call) | `a_previously_installed_pre_push_is_cleared_from_a_repo_with_no_slot` | **RED** |
| M3 | clear any pre-push hook, not only ones this script wrote (drop the marker check) | `a_hand_written_pre_push_hook_is_left_alone` | **RED** |
| M4 | give `run-tests.sh` a cli slot, option 1 in miniature (`--libviprs-cli` accepted) | `the_suite_still_has_no_slot_for_the_cli` | **RED** |

And the row that says why the new guards had to exist. Under **M1**, which is a full revert of this PR's behaviour, every pre-existing hook guard stays green:

| suite | under M1 |
|---|---|
| `prepush_gate_tests_the_pushed_tree` | 7 passed, 0 failed |
| `prepush_gate_cost_controls` | 7 passed, 0 failed |

Fourteen guards on this hook, and not one of them could see the cli getting a gate it cannot fail.

## Gate

Run in this worktree, with the core crate at the sibling checkout.

```
cargo fmt -- --check                                    clean
RUSTFLAGS="-Dwarnings" cargo clippy --all-targets -- -D warnings   silent
cargo test                                              766 passed, 0 failed, 11 ignored
```

The four new tests are the whole delta on the count. `bash -n tools/install-hooks.sh` is clean.

I did not run `install-hooks.sh` against the live workspace from a test, and neither do the guards: it removes hooks it recognises as its own, so it only ever runs against a temp workspace here.

Closes libviprs/libviprs#691
