### PR TITLE
fix(hooks): check the pre-push hook in as a real file and install a shim that runs it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,3 +131,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt -- --check
       - run: cargo clippy --all-targets -- -D warnings
+      # The pre-push hook is a real file rather than a heredoc inside
+      # install-hooks.sh (libviprs/libviprs#695), so it gets linted like the
+      # rest of the shell. shellcheck ships on the ubuntu-latest image.
+      - run: shellcheck tools/*.sh tools/hooks/pre-push

--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ into the two the suite can see:
 
 **Pre-push** (libviprs and libviprs-tests only; runs on `git push`, when the
 push can reach the suite):
+- The hook is `tools/hooks/pre-push`, a tracked file. What lands in
+  `.git/hooks/pre-push` is a shim that runs it, so a `git pull` here updates
+  the hook in every repo at once and no clone is left running a vintage nobody
+  can name (libviprs/libviprs#695). Re-run `install-hooks.sh` only when the
+  workspace layout moves. A harness push runs the hook out of the tree it is
+  pushing, so a change to the hook is gated by the changed hook.
 - Runs the Docker test suite via `run-tests.sh`, against the working tree being
   pushed. A linked worktree gates on its own branch, not on the main checkout
   (libviprs/libviprs#684).
@@ -302,6 +308,7 @@ libviprs-tests/
 ├── Dockerfile
 ├── README.md
 ├── tools/
+│   ├── hooks/pre-push
 │   ├── install-hooks.sh
 │   └── run-tests.sh
 ├── .github/

--- a/tests/common/hooks.rs
+++ b/tests/common/hooks.rs
@@ -1,15 +1,20 @@
-//! Reads the git hooks `tools/install-hooks.sh` writes, so the guards on them
-//! can assert against the text that actually lands in `.git/hooks/`.
+//! The pre-push hook, and a stand-in workspace for driving it.
 //!
-//! Two suites need this (`prepush_gate_tests_the_pushed_tree` for #684 and
-//! `prepush_gate_cost_controls` for #683) and both used to carry their own
-//! copy, including the heredoc marker string byte for byte. That marker is the
-//! fragile part: change the quoting in `install-hooks.sh` and every copy has to
-//! follow, and the one that does not follow fails with "no longer writes the
-//! pre-push hook from a heredoc" rather than with anything about the change
-//! that broke it. One copy, here.
+//! The hook is a real tracked file, `tools/hooks/pre-push`
+//! (libviprs/libviprs#695). It used to be a heredoc inside
+//! `tools/install-hooks.sh`, which meant the only thing a guard could do with
+//! it was grep it, and two guards that did exactly that passed while the
+//! behaviour they named had been deleted. So nothing here asserts on the
+//! hook's text. [`Workspace`] builds a throwaway workspace of stand-in repos,
+//! runs `tools/install-hooks.sh` in it for real, and drives the installed hook
+//! with a synthetic ref-update on stdin, the way git does.
+//!
+//! Two suites use it: `prepush_gate_tests_the_pushed_tree` for #684 and
+//! `prepush_gate_cost_controls` for #683.
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 /// This crate's root, which is also the repo root for the harness checkout.
 pub fn repo_root() -> PathBuf {
@@ -22,28 +27,354 @@ pub fn read(rel: &str) -> String {
     std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
 }
 
-/// The marker `install-hooks.sh` opens the pre-push heredoc with. Kept as one
-/// constant so the two guards cannot drift apart on it.
-const PRE_PUSH_HEREDOC: &str = "cat > \"$pre_push\" << 'HOOK'\n";
+/// The hook, relative to the repo root.
+pub const PRE_PUSH_HOOK: &str = "tools/hooks/pre-push";
 
-/// The pre-push hook body exactly as `install-hooks.sh` writes it: the heredoc
-/// between `<< 'HOOK'` and the closing `HOOK`. Reading the generated text
-/// rather than the generator keeps the assertions pointed at what actually
-/// lands in `.git/hooks/pre-push`.
-pub fn generated_pre_push() -> String {
-    let script = read("tools/install-hooks.sh");
-    let start = script
-        .find(PRE_PUSH_HEREDOC)
-        .map(|i| i + PRE_PUSH_HEREDOC.len())
-        .expect(
-            "tools/install-hooks.sh no longer writes the pre-push hook from a \
-             `cat > \"$pre_push\" << 'HOOK'` heredoc; update PRE_PUSH_HEREDOC in \
-             tests/common/hooks.rs to follow it rather than deleting the guards \
-             that read it",
+/// The pre-push hook body, read from the file that *is* the hook rather than
+/// from a generator that writes one.
+pub fn pre_push_hook() -> String {
+    let path = repo_root().join(PRE_PUSH_HOOK);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "cannot read {}: {e}\nThe pre-push hook is a tracked file and \
+             tools/install-hooks.sh installs a shim that runs it, rather than \
+             generating a copy of it (libviprs/libviprs#695).",
+            path.display()
+        )
+    })
+}
+
+/// What the stub `run-tests.sh` prints when the hook decides to run the suite.
+pub const RAN_MARKER: &str = "STUB-RAN-THE-SUITE";
+
+/// A stand-in for `run-tests.sh` that reports the environment the hook handed
+/// it, so both halves of a decision (did it run, and what did it run against)
+/// are readable off one push without Docker.
+pub const STUB_RUN_TESTS: &str = r#"#!/bin/sh
+echo "STUB-RAN-THE-SUITE"
+echo "STUB-SCRIPT=$0"
+echo "STUB-LIBVIPRS_DIR=${LIBVIPRS_DIR-unset}"
+echo "STUB-LIBVIPRS_TESTS_DIR=${LIBVIPRS_TESTS_DIR-unset}"
+echo "STUB-GIT_DIR=${GIT_DIR-unset}"
+echo "STUB-GIT_WORK_TREE=${GIT_WORK_TREE-unset}"
+echo "STUB-GIT_INDEX_FILE=${GIT_INDEX_FILE-unset}"
+echo "STUB-GIT_PREFIX=${GIT_PREFIX-unset}"
+echo "STUB-GIT_QUARANTINE_PATH=${GIT_QUARANTINE_PATH-unset}"
+"#;
+
+/// One `STUB-<name>=` line out of what a push printed.
+pub fn reported(out: &str, name: &str) -> String {
+    let prefix = format!("STUB-{name}=");
+    out.lines()
+        .find_map(|line| line.trim().strip_prefix(&prefix))
+        .unwrap_or_else(|| {
+            panic!("the stub suite never reported {name}, so it did not run:\n{out}")
+        })
+        .to_string()
+}
+
+/// A throwaway workspace holding the two repos the hook expects as siblings,
+/// with the hooks installed by the real `tools/install-hooks.sh` and a stub in
+/// place of `run-tests.sh`.
+///
+/// The evidence that #683 and #684 work was rows of skip/run decisions
+/// produced by hand. For changes whose failure mode is the gate silently
+/// ceasing to run, or silently gating the wrong tree, by hand and uncommitted
+/// is the wrong place for it.
+pub struct Workspace {
+    _dir: tempfile::TempDir,
+    pub root: PathBuf,
+}
+
+impl Default for Workspace {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Workspace {
+    pub fn new() -> Workspace {
+        let dir = tempfile::tempdir().expect("temp dir for a stand-in workspace");
+        let root = dir.path().canonicalize().expect("canonical temp path");
+
+        for repo in ["libviprs", "libviprs-tests"] {
+            let repo_root = root.join(repo);
+            std::fs::create_dir_all(&repo_root).expect("create the stand-in repo");
+            git(&repo_root, &["init", "-q", "-b", "main"]);
+        }
+
+        // The harness carries both the installer and the hook it installs, so
+        // both have to be here before the installer runs and committed before
+        // a linked worktree can see them.
+        let tests_root = root.join("libviprs-tests");
+        std::fs::create_dir_all(tests_root.join("tools/hooks"))
+            .expect("create the stand-in tools directory");
+        for rel in ["tools/install-hooks.sh", PRE_PUSH_HOOK] {
+            let to = tests_root.join(rel);
+            let from = repo_root().join(rel);
+            std::fs::copy(&from, &to).unwrap_or_else(|e| {
+                panic!("copy {} into the stand-in workspace: {e}", from.display())
+            });
+            make_executable(&to);
+        }
+        let stub = tests_root.join("tools/run-tests.sh");
+        std::fs::write(&stub, STUB_RUN_TESTS).expect("write the stub run-tests.sh");
+        make_executable(&stub);
+
+        let ws = Workspace { _dir: dir, root };
+        ws.commit("libviprs-tests", "harness tooling", &[]);
+        ws.commit(
+            "libviprs",
+            "stand-in core crate",
+            &[("src/lib.rs", "// stand-in\n")],
         );
-    let rest = &script[start..];
-    let end = rest
-        .find("\nHOOK\n")
-        .expect("unterminated pre-push heredoc in tools/install-hooks.sh");
-    rest[..end].to_string()
+        ws.install_hooks();
+        ws
+    }
+
+    /// Run `tools/install-hooks.sh` from inside the stand-in harness, the way
+    /// a developer does, and hand back everything it printed.
+    pub fn install_hooks(&self) -> String {
+        let out = Command::new("bash")
+            .arg(self.repo("libviprs-tests").join("tools/install-hooks.sh"))
+            .current_dir(self.repo("libviprs-tests"))
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .output()
+            .expect("run tools/install-hooks.sh");
+        let text = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            out.status.success(),
+            "tools/install-hooks.sh exited {}:\n{text}",
+            out.status
+        );
+        text
+    }
+
+    pub fn repo(&self, name: &str) -> PathBuf {
+        self.root.join(name)
+    }
+
+    /// The checked-in hook inside the stand-in harness, which is what the
+    /// installed shim points at.
+    pub fn checked_in_hook(&self) -> PathBuf {
+        self.repo("libviprs-tests").join(PRE_PUSH_HOOK)
+    }
+
+    /// A linked worktree of `repo`, on a new branch, somewhere that is not a
+    /// sibling of the checkouts. Epic #520 runs every lane in one of these,
+    /// and it is the case the shared hooks directory gets wrong.
+    pub fn worktree(&self, repo: &str, branch: &str) -> PathBuf {
+        let path = self.root.join("lanes").join(branch);
+        std::fs::create_dir_all(path.parent().expect("lanes dir")).expect("create the lanes dir");
+        git(
+            &self.repo(repo),
+            &[
+                "worktree",
+                "add",
+                "-q",
+                "-b",
+                branch,
+                path.to_str().expect("utf-8 worktree path"),
+            ],
+        );
+        path.canonicalize().expect("canonical worktree path")
+    }
+
+    /// Commit `files` in `tree` and return the commit's oid. `tree` can be a
+    /// main checkout or a linked worktree.
+    pub fn commit_in(&self, tree: &Path, message: &str, files: &[(&str, &str)]) -> String {
+        for (rel, contents) in files {
+            let path = tree.join(rel);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("create a directory for a stand-in file");
+            }
+            std::fs::write(&path, contents).expect("write a stand-in file");
+        }
+        git(tree, &["add", "-A"]);
+        git(
+            tree,
+            &[
+                "-c",
+                "user.name=prepush guard",
+                "-c",
+                "user.email=guard@example.invalid",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-q",
+                "--allow-empty",
+                "-m",
+                message,
+            ],
+        );
+        git(tree, &["rev-parse", "HEAD"]).trim().to_string()
+    }
+
+    /// The same, on a repo's main checkout.
+    pub fn commit(&self, repo: &str, message: &str, files: &[(&str, &str)]) -> String {
+        self.commit_in(&self.repo(repo), message, files)
+    }
+
+    /// Start describing a push. Nothing happens until [`Push::run`].
+    pub fn push<'a>(&'a self, repo: &'a str) -> Push<'a> {
+        Push {
+            ws: self,
+            repo,
+            from: None,
+            before: String::new(),
+            after: String::new(),
+            force_all: false,
+            git_env: false,
+        }
+    }
+}
+
+/// One push at the installed hook.
+pub struct Push<'a> {
+    ws: &'a Workspace,
+    repo: &'a str,
+    from: Option<PathBuf>,
+    before: String,
+    after: String,
+    force_all: bool,
+    git_env: bool,
+}
+
+impl<'a> Push<'a> {
+    /// Push from a linked worktree rather than from the main checkout. git
+    /// still runs the hook out of the main checkout's shared hooks directory,
+    /// which is the whole of #684.
+    pub fn from(mut self, tree: &Path) -> Push<'a> {
+        self.from = Some(tree.to_path_buf());
+        self
+    }
+
+    pub fn range(mut self, before: &str, after: &str) -> Push<'a> {
+        self.before = before.to_string();
+        self.after = after.to_string();
+        self
+    }
+
+    pub fn force_all(mut self) -> Push<'a> {
+        self.force_all = true;
+        self
+    }
+
+    /// Hand the hook the git environment git itself exports into it. It beats
+    /// `git -C` and the working directory for every git command anything
+    /// downstream runs, so a hook that does not drop it makes the suite answer
+    /// for the pushing repository whatever tree it was aimed at.
+    pub fn with_git_env(mut self) -> Push<'a> {
+        self.git_env = true;
+        self
+    }
+
+    /// Run the hook and require it to allow the push.
+    pub fn run(self) -> String {
+        let (ok, text) = self.try_run();
+        assert!(ok, "the pre-push hook rejected the push:\n{text}");
+        text
+    }
+
+    /// Run the hook and hand back whether it allowed the push, and everything
+    /// it printed.
+    pub fn try_run(self) -> (bool, String) {
+        let main = self.ws.repo(self.repo);
+        let tree = self.from.clone().unwrap_or_else(|| main.clone());
+
+        let mut cmd = Command::new("bash");
+        cmd.arg(main.join(".git/hooks/pre-push"))
+            .arg("origin")
+            .arg("git@example.invalid:libviprs/x.git")
+            .current_dir(&tree)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        for leaked in [
+            "GIT_DIR",
+            "GIT_WORK_TREE",
+            "GIT_INDEX_FILE",
+            "GIT_PREFIX",
+            "GIT_QUARANTINE_PATH",
+            "LIBVIPRS_PREPUSH_ALL",
+        ] {
+            cmd.env_remove(leaked);
+        }
+        if self.force_all {
+            cmd.env("LIBVIPRS_PREPUSH_ALL", "1");
+        }
+        if self.git_env {
+            let dir = git(&tree, &["rev-parse", "--absolute-git-dir"])
+                .trim()
+                .to_string();
+            cmd.env("GIT_DIR", &dir)
+                .env("GIT_INDEX_FILE", format!("{dir}/index"))
+                .env("GIT_PREFIX", "")
+                .env("GIT_QUARANTINE_PATH", format!("{dir}/incoming"));
+        }
+
+        let mut child = cmd.spawn().expect("run the installed pre-push hook");
+        {
+            let stdin = child.stdin.as_mut().expect("hook stdin");
+            writeln!(
+                stdin,
+                "refs/heads/main {} refs/heads/main {}",
+                self.after, self.before
+            )
+            .expect("feed the ref update to the hook");
+        }
+        let out = child
+            .wait_with_output()
+            .expect("collect the hook's decision");
+        let text = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        (out.status.success(), text)
+    }
+}
+
+pub fn git(dir: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .output()
+        .unwrap_or_else(|e| {
+            panic!(
+                "these guards drive the real hook, which needs git on PATH: \
+                 `git {}` in {}: {e}",
+                args.join(" "),
+                dir.display()
+            )
+        });
+    assert!(
+        out.status.success(),
+        "git {} failed in {}: {}",
+        args.join(" "),
+        dir.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+pub fn make_executable(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+            .expect("make the stand-in script executable");
+    }
+    #[cfg(not(unix))]
+    let _ = path;
 }

--- a/tests/common/hooks.rs
+++ b/tests/common/hooks.rs
@@ -208,6 +208,10 @@ impl Workspace {
                 "commit.gpgsign=false",
                 "commit",
                 "-q",
+                // These guards are about the pre-push hook. The pre-commit
+                // hook the installer also writes runs `cargo fmt` in the repo
+                // it is installed in, and a stand-in repo is not a crate.
+                "--no-verify",
                 "--allow-empty",
                 "-m",
                 message,

--- a/tests/install_hooks_pre_push_slots.rs
+++ b/tests/install_hooks_pre_push_slots.rs
@@ -65,7 +65,16 @@ impl Workspace {
         // real one.
         let tools = root.join("libviprs-tests/tools");
         std::fs::create_dir_all(&tools).expect("create the stand-in tools directory");
-        for script in ["install-hooks.sh", "run-tests.sh", "run_ported_cells.sh"] {
+        std::fs::create_dir_all(tools.join("hooks")).expect("create the stand-in hooks directory");
+        // The installer points the shim it writes at tools/hooks/pre-push and
+        // refuses to install without it, so the stand-in harness carries the
+        // real one (libviprs/libviprs#695).
+        for script in [
+            "install-hooks.sh",
+            "run-tests.sh",
+            "run_ported_cells.sh",
+            "hooks/pre-push",
+        ] {
             let to = tools.join(script);
             std::fs::copy(repo_root().join("tools").join(script), &to)
                 .unwrap_or_else(|e| panic!("copy tools/{script} into the stand-in workspace: {e}"));

--- a/tests/prepush_gate_cost_controls.rs
+++ b/tests/prepush_gate_cost_controls.rs
@@ -11,11 +11,11 @@
 //!
 //! The failure mode of the whole change is the gate quietly ceasing to run, so
 //! these guards are built to fail when that happens rather than to describe it.
-//! Two of them lift `inert_path()` out of the generated hook and *execute* it:
-//! one runs every tracked path in both repos through it and pins the set that
-//! comes back inert, the other installs the whole hook in a throwaway workspace
-//! and drives real pushes past it. An earlier pair of text guards here could
-//! not fail for the reason they claimed: a reviewer flipped `inert_path`'s
+//! Two of them lift `inert_path()` out of the hook and *execute* it: one runs
+//! every tracked path in both repos through it and pins the set that comes
+//! back inert, the other installs the whole hook in a throwaway workspace and
+//! drives real pushes past it. An earlier pair of text guards here could not
+//! fail for the reason they claimed: a reviewer flipped `inert_path`'s
 //! fallthrough to `true`, disabling the gate for every push in every repo, and
 //! both stayed green.
 
@@ -25,22 +25,22 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 mod common;
-use common::hooks::{generated_pre_push, read, repo_root};
+use common::hooks::{RAN_MARKER, STUB_RUN_TESTS, Workspace, pre_push_hook, read, repo_root};
 
 // ---------------------------------------------------------------------------
 // Running the hook's own `inert_path()`
 // ---------------------------------------------------------------------------
 
-/// The `inert_path()` shell function, lifted verbatim out of the generated
-/// hook and wrapped in a driver that prints the inert ones from a list of
-/// paths on stdin.
+/// The `inert_path()` shell function, lifted verbatim out of the hook and
+/// wrapped in a driver that prints the inert ones from a list of paths on
+/// stdin.
 ///
 /// Lifting the real text is the point. A guard that re-implements the case
 /// statement in Rust tests the re-implementation, and a guard that greps the
 /// text tests the grep; both were tried here and both waved through six
 /// poisoned entries and a flipped fallthrough.
 fn inert_path_driver() -> String {
-    let hook = generated_pre_push();
+    let hook = pre_push_hook();
     let start = hook.find("inert_path() {").expect(
         "the pre-push hook must decide what it may skip in one place, a shell \
          function called inert_path()",
@@ -286,170 +286,6 @@ fn the_skip_list_never_exempts_what_the_suite_reads() {
 // Driving the whole hook
 // ---------------------------------------------------------------------------
 
-/// What the stub `run-tests.sh` prints when the hook decides to run the suite.
-const RAN_MARKER: &str = "STUB-RAN-THE-SUITE";
-
-/// A throwaway workspace holding the two repos the hook expects as siblings,
-/// with the generated pre-push hook installed in both and a stub in place of
-/// `run-tests.sh`, so a decision can be observed without Docker.
-///
-/// The evidence that this change works was six rows of skip/run decisions
-/// produced by hand. For a change whose failure mode is the gate silently
-/// ceasing to run, by hand and uncommitted is the wrong place for it.
-struct Workspace {
-    _dir: tempfile::TempDir,
-    root: PathBuf,
-}
-
-impl Workspace {
-    fn new() -> Workspace {
-        let dir = tempfile::tempdir().expect("temp dir for a stand-in workspace");
-        let root = dir.path().canonicalize().expect("canonical temp path");
-        let hook_body = generated_pre_push();
-
-        for repo in ["libviprs", "libviprs-tests"] {
-            let repo_root = root.join(repo);
-            std::fs::create_dir_all(repo_root.join("tools")).expect("create the stand-in repo");
-            git(&repo_root, &["init", "-q"]);
-
-            let hook = repo_root.join(".git/hooks/pre-push");
-            std::fs::create_dir_all(hook.parent().expect("hooks dir")).expect("create hooks dir");
-            std::fs::write(&hook, &hook_body).expect("install the generated pre-push hook");
-            make_executable(&hook);
-        }
-
-        // The hook points a libviprs push at the sibling harness's script and a
-        // libviprs-tests push at the pushed tree's own copy; in this workspace
-        // those are the same file, and it must exist or the hook bails out
-        // before it ever reaches the skip decision.
-        let stub = root.join("libviprs-tests/tools/run-tests.sh");
-        std::fs::write(&stub, format!("#!/bin/sh\necho \"{RAN_MARKER}\"\n"))
-            .expect("write the stub run-tests.sh");
-        make_executable(&stub);
-
-        Workspace { _dir: dir, root }
-    }
-
-    fn repo(&self, name: &str) -> PathBuf {
-        self.root.join(name)
-    }
-
-    /// Commit `files` in `repo` and return the commit's oid.
-    fn commit(&self, repo: &str, message: &str, files: &[(&str, &str)]) -> String {
-        let root = self.repo(repo);
-        for (rel, contents) in files {
-            let path = root.join(rel);
-            if let Some(parent) = path.parent() {
-                std::fs::create_dir_all(parent).expect("create a directory for a stand-in file");
-            }
-            std::fs::write(&path, contents).expect("write a stand-in file");
-        }
-        git(&root, &["add", "-A"]);
-        git(
-            &root,
-            &[
-                "-c",
-                "user.name=prepush guard",
-                "-c",
-                "user.email=guard@example.invalid",
-                "-c",
-                "commit.gpgsign=false",
-                "commit",
-                "-q",
-                "--allow-empty",
-                "-m",
-                message,
-            ],
-        );
-        git(&root, &["rev-parse", "HEAD"]).trim().to_string()
-    }
-
-    /// Run the installed hook the way git does: from the top of the working
-    /// tree, with the ref updates on stdin.
-    fn push(&self, repo: &str, before: &str, after: &str, force_all: bool) -> String {
-        let root = self.repo(repo);
-        let mut cmd = Command::new("bash");
-        cmd.arg(root.join(".git/hooks/pre-push"))
-            .arg("origin")
-            .arg("git@example.invalid:libviprs/x.git")
-            .current_dir(&root)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        for leaked in [
-            "GIT_DIR",
-            "GIT_WORK_TREE",
-            "GIT_INDEX_FILE",
-            "GIT_PREFIX",
-            "LIBVIPRS_PREPUSH_ALL",
-        ] {
-            cmd.env_remove(leaked);
-        }
-        if force_all {
-            cmd.env("LIBVIPRS_PREPUSH_ALL", "1");
-        }
-
-        let mut child = cmd.spawn().expect("run the generated pre-push hook");
-        {
-            let stdin = child.stdin.as_mut().expect("hook stdin");
-            writeln!(stdin, "refs/heads/main {after} refs/heads/main {before}")
-                .expect("feed the ref update to the hook");
-        }
-        let out = child
-            .wait_with_output()
-            .expect("collect the hook's decision");
-        let text = format!(
-            "{}{}",
-            String::from_utf8_lossy(&out.stdout),
-            String::from_utf8_lossy(&out.stderr)
-        );
-        assert!(
-            out.status.success(),
-            "the pre-push hook exited {} on a {repo} push:\n{text}",
-            out.status
-        );
-        text
-    }
-}
-
-fn git(dir: &Path, args: &[&str]) -> String {
-    let out = Command::new("git")
-        .arg("-C")
-        .arg(dir)
-        .args(args)
-        .env_remove("GIT_DIR")
-        .env_remove("GIT_WORK_TREE")
-        .env_remove("GIT_INDEX_FILE")
-        .output()
-        .unwrap_or_else(|e| {
-            panic!(
-                "these guards drive the real hook, which needs git on PATH: \
-                 `git {}` in {}: {e}",
-                args.join(" "),
-                dir.display()
-            )
-        });
-    assert!(
-        out.status.success(),
-        "git {} failed in {}: {}",
-        args.join(" "),
-        dir.display(),
-        String::from_utf8_lossy(&out.stderr)
-    );
-    String::from_utf8_lossy(&out.stdout).into_owned()
-}
-
-fn make_executable(path: &Path) {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
-            .expect("make the stand-in script executable");
-    }
-    #[cfg(not(unix))]
-    let _ = path;
-}
-
 /// The skip list decides nothing on its own; the hook does. So install the
 /// hook, push at it, and read the answer off the run.
 ///
@@ -466,10 +302,7 @@ fn the_hook_skips_and_runs_the_way_the_list_says() {
         ("LICENSE", "stand-in licence\n"),
         ("docs/note.md", "stand-in note\n"),
         ("src/lib.rs", "// stand-in\n"),
-        (
-            "tools/run-tests.sh",
-            "#!/bin/sh\necho \"STUB-RAN-THE-SUITE\"\n",
-        ),
+        ("tools/run-tests.sh", STUB_RUN_TESTS),
     ];
 
     let cases: &[(&str, &str, &str, bool, &str)] = &[
@@ -499,7 +332,7 @@ fn the_hook_skips_and_runs_the_way_the_list_says() {
         (
             "libviprs-tests",
             "tools/run-tests.sh",
-            "#!/bin/sh\necho \"STUB-RAN-THE-SUITE\"\n# changed\n",
+            "#!/bin/sh\n# changed\necho \"STUB-RAN-THE-SUITE\"\n",
             true,
             "it is the suite",
         ),
@@ -529,7 +362,7 @@ fn the_hook_skips_and_runs_the_way_the_list_says() {
     for (repo, path, contents, should_run, why) in cases {
         let before = ws.commit(repo, "base", &base);
         let after = ws.commit(repo, "change", &[(path, contents)]);
-        let out = ws.push(repo, &before, &after, false);
+        let out = ws.push(repo).range(&before, &after).run();
 
         let ran = out.contains(RAN_MARKER);
         let skipped = out.contains("skipping it");
@@ -552,33 +385,19 @@ fn the_hook_skips_and_runs_the_way_the_list_says() {
 /// the next person who does not trust the filter goes back to `--no-verify`
 /// and takes the whole gate with them.
 ///
-/// Asserted twice over, because the bare name `LIBVIPRS_PREPUSH_ALL` appears
-/// three times in the hook and is expanded once: delete the one line that
-/// reads it, keep the comment, and a `contains("LIBVIPRS_PREPUSH_ALL")` guard
-/// stays green with the escape hatch gone.
+/// This used to assert `hook.contains("${LIBVIPRS_PREPUSH_ALL")` as well. The
+/// bare name appears three times in the hook and is expanded once, so that
+/// half was there to catch "delete the line that reads it, keep the comment",
+/// and it is worth exactly nothing next to running the push twice.
 #[test]
 fn the_skip_can_be_overridden() {
-    let hook = generated_pre_push();
-    assert!(
-        hook.contains("${LIBVIPRS_PREPUSH_ALL"),
-        "the pre-push hook mentions LIBVIPRS_PREPUSH_ALL but never expands it, \
-         so the escape hatch is documentation only. Without a real one the only \
-         way past a wrong skip decision is --no-verify, which is what #683 is \
-         about"
-    );
-
-    // And the same thing again through the hook itself, on a push it would
-    // otherwise skip.
     let ws = Workspace::new();
     let before = ws.commit(
         "libviprs-tests",
         "base",
         &[
             ("LICENSE", "stand-in licence\n"),
-            (
-                "tools/run-tests.sh",
-                "#!/bin/sh\necho \"STUB-RAN-THE-SUITE\"\n",
-            ),
+            ("tools/run-tests.sh", STUB_RUN_TESTS),
         ],
     );
     let after = ws.commit(
@@ -587,14 +406,18 @@ fn the_skip_can_be_overridden() {
         &[("LICENSE", "stand-in licence, revised\n")],
     );
 
-    let skipped = ws.push("libviprs-tests", &before, &after, false);
+    let skipped = ws.push("libviprs-tests").range(&before, &after).run();
     assert!(
         !skipped.contains(RAN_MARKER),
         "a LICENSE-only push should have been skipped, so the override below \
          proves nothing. The hook said:\n{skipped}"
     );
 
-    let forced = ws.push("libviprs-tests", &before, &after, true);
+    let forced = ws
+        .push("libviprs-tests")
+        .range(&before, &after)
+        .force_all()
+        .run();
     assert!(
         forced.contains(RAN_MARKER),
         "LIBVIPRS_PREPUSH_ALL=1 must run the suite on a push the list would \

--- a/tests/prepush_gate_tests_the_pushed_tree.rs
+++ b/tests/prepush_gate_tests_the_pushed_tree.rs
@@ -10,83 +10,189 @@
 //! as "my branch passes" and meant nothing of the kind.
 //!
 //! Two properties have to hold together, and neither is visible from the
-//! other side, which is why both are pinned here:
+//! other side, which is why both are driven here:
 //!
 //!   * the hook has to *find* the pushed tree, and it cannot do that from
 //!     `$0` (shared hooks directory) or by walking up from `.git` (in a
 //!     worktree that is a file holding a `gitdir:` pointer, not a directory).
-//!     Only `git rev-parse` knows.
 //!   * `run-tests.sh` has to *accept* it. It did not have a parameter for it
 //!     at all, so passing one from the hook was not enough on its own.
 //!
-//! These are text and behaviour guards on the harness rather than on library
-//! output, in the same shape as `counterpart_pinning` and
-//! `feature_rename_docs_present`: there is no libvips analogue for "the local
-//! gate is honest", and the failure mode is silent by construction.
+//! Everything about the hook here is measured by running it. The guards that
+//! stood here before asserted `hook.contains("git rev-parse --show-toplevel")`
+//! and `hook.contains("unset GIT_DIR")`, and both of those stay green when the
+//! line they name is deleted and the comment above it is left behind, which is
+//! libviprs/libviprs#695. So instead: install the hooks with the real
+//! installer, push at them from a linked worktree with a ref-update on stdin,
+//! and read the trees off what the suite was handed.
 
 use std::process::Command;
 
 mod common;
-use common::hooks::{generated_pre_push, read, repo_root};
+use common::hooks::{Workspace, repo_root, reported};
 
-/// #684: the hook must ask git which tree is being pushed. `$0` points into
-/// the hooks directory, which a main checkout shares with every worktree
-/// hanging off it, so anything resolved from it names the main checkout.
+/// #684, end to end and per push shape. `run-tests.sh` falls back to the
+/// siblings of wherever the script itself sits, and for a worktree push that
+/// script is inside the worktree, whose neighbours are other lanes rather than
+/// the workspace, so both slots have to be named on every push and not just
+/// the one being pushed.
 #[test]
-fn pre_push_hook_resolves_the_pushed_tree_from_git() {
-    let hook = generated_pre_push();
+fn the_gate_is_handed_the_tree_being_pushed_and_its_sibling() {
+    let ws = Workspace::new();
 
-    assert!(
-        hook.contains("git rev-parse --show-toplevel"),
-        "the pre-push hook must take the tree under test from \
-         `git rev-parse --show-toplevel`, which is the working tree whose \
-         commits are going out (#684)"
+    let core_lane = ws.worktree("libviprs", "core-lane");
+    let harness_lane = ws.worktree("libviprs-tests", "harness-lane");
+
+    let cases: &[(&str, Option<&std::path::Path>, &str, &str)] = &[
+        (
+            "libviprs",
+            None,
+            "libviprs",
+            "a core push from the main checkout gates on the main checkout",
+        ),
+        (
+            "libviprs",
+            Some(&core_lane),
+            "lanes/core-lane",
+            "a core push from a lane worktree must gate on the lane, not on \
+             the main checkout whose hooks directory ran the hook",
+        ),
+        (
+            "libviprs-tests",
+            None,
+            "libviprs-tests",
+            "a harness push from the main checkout gates on the main checkout",
+        ),
+        (
+            "libviprs-tests",
+            Some(&harness_lane),
+            "lanes/harness-lane",
+            "a harness push from a lane worktree must gate on the lane",
+        ),
+    ];
+
+    for (repo, from, expected_rel, why) in cases {
+        let tree = from
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| ws.repo(repo));
+
+        let before = common::hooks::git(&tree, &["rev-parse", "HEAD"])
+            .trim()
+            .to_string();
+        // Something no skip list can call inert, so the gate reaches the suite.
+        let after = ws.commit_in(
+            &tree,
+            "a change the suite can see",
+            &[("src/lib.rs", "// changed\n")],
+        );
+
+        let out = ws
+            .push(repo)
+            .from(&tree)
+            .range(&before, &after)
+            .with_git_env()
+            .run();
+
+        let expected = ws.root.join(expected_rel);
+        let (pushed_slot, sibling_slot, sibling_rel) = match *repo {
+            "libviprs" => ("LIBVIPRS_DIR", "LIBVIPRS_TESTS_DIR", "libviprs-tests"),
+            _ => ("LIBVIPRS_TESTS_DIR", "LIBVIPRS_DIR", "libviprs"),
+        };
+
+        assert_eq!(
+            reported(&out, pushed_slot),
+            expected.display().to_string(),
+            "{pushed_slot} named the wrong tree, because {why}. The hook said:\n{out}"
+        );
+        assert_eq!(
+            reported(&out, sibling_slot),
+            ws.root.join(sibling_rel).display().to_string(),
+            "{sibling_slot} was not pinned to the workspace sibling on a {repo} \
+             push, so run-tests.sh is left to infer it from wherever the script \
+             it picked happens to sit (#684). The hook said:\n{out}"
+        );
+    }
+}
+
+/// A push that changes the harness has to gate through the harness it is
+/// changing, not through the copy in the main checkout. Finding the tree is
+/// only half of #684; running the pushed tree's script is the other half.
+#[test]
+fn a_harness_push_runs_the_suite_script_it_is_pushing() {
+    let ws = Workspace::new();
+    let lane = ws.worktree("libviprs-tests", "harness-lane");
+
+    let before = common::hooks::git(&lane, &["rev-parse", "HEAD"])
+        .trim()
+        .to_string();
+    let after = ws.commit_in(
+        &lane,
+        "a harness change",
+        &[("tests/something.rs", "// changed\n")],
     );
-    assert!(
-        hook.contains("git rev-parse --git-common-dir"),
-        "the pre-push hook must find the repo's main checkout through \
-         `git rev-parse --git-common-dir`; a linked worktree's `.git` is a \
-         file holding a `gitdir:` pointer, so walking up from it does not \
-         give a repository root (#684)"
-    );
-    assert!(
-        !hook.contains(r#"$(dirname "$0")/../.."#),
-        "the pre-push hook still derives a repository from its own path. \
-         Every worktree of a repo runs the same hook file out of the main \
-         checkout's hooks directory, so that always names the main checkout \
-         and never the branch being pushed (#684)"
+
+    let out = ws
+        .push("libviprs-tests")
+        .from(&lane)
+        .range(&before, &after)
+        .with_git_env()
+        .run();
+
+    assert_eq!(
+        reported(&out, "SCRIPT"),
+        lane.join("tools/run-tests.sh").display().to_string(),
+        "the gate ran a run-tests.sh from outside the tree being pushed, so a \
+         change to the suite is gated by the suite it is replacing (#684). \
+         The hook said:\n{out}"
     );
 }
 
-/// #684: finding the tree is only half of it. The hook has to hand it over,
-/// and `run-tests.sh` has to have somewhere to put it.
+/// git hands every hook a `GIT_DIR`, and in a worktree it points at that
+/// worktree's admin directory. It beats both `git -C` and the working
+/// directory, so a `git` call made downstream answers for the repository doing
+/// the pushing whatever directory it was aimed at. The first run of the fixed
+/// hook reported the pushing branch's HEAD as the revision of an unrelated
+/// tree, which is #684 wearing a different hat: a banner that names the wrong
+/// commit is no better than a gate that builds the wrong one.
 #[test]
-fn pre_push_hook_hands_the_tree_to_run_tests() {
-    let hook = generated_pre_push();
+fn the_gate_drops_the_git_environment_it_inherited() {
+    let ws = Workspace::new();
+    let lane = ws.worktree("libviprs-tests", "harness-lane");
 
-    for slot in ["LIBVIPRS_DIR", "LIBVIPRS_TESTS_DIR"] {
-        assert!(
-            hook.contains(&format!("export {slot}=")),
-            "the pre-push hook must export {slot} so run-tests.sh builds the \
-             pushed tree; without it the script falls back to the sibling \
-             checkout, which is the whole of #684"
-        );
-    }
+    let before = common::hooks::git(&lane, &["rev-parse", "HEAD"])
+        .trim()
+        .to_string();
+    let after = ws.commit_in(&lane, "a harness change", &[("tests/x.rs", "// c\n")]);
 
-    let script = read("tools/run-tests.sh");
-    for slot in ["LIBVIPRS_DIR", "LIBVIPRS_TESTS_DIR"] {
-        assert!(
-            script.contains(slot),
-            "tools/run-tests.sh must read {slot}, or the hook exporting it \
-             has no effect (#684)"
+    let out = ws
+        .push("libviprs-tests")
+        .from(&lane)
+        .range(&before, &after)
+        .with_git_env()
+        .run();
+
+    for leaked in [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_PREFIX",
+        "GIT_QUARANTINE_PATH",
+    ] {
+        assert_eq!(
+            reported(&out, leaked),
+            "unset",
+            "the gate handed {leaked} through to the suite. git exports it into \
+             hooks and it wins over `git -C`, so everything the suite asks git \
+             answers for the pushing repository rather than for the tree it was \
+             handed (#684). The hook said:\n{out}"
         );
     }
 }
 
-/// The behavioural half: hand `run-tests.sh` a tree and it must say, before
-/// it builds anything, that it is going to build that tree. `--plan` exists
-/// so this is answerable without Docker, and so a human can ask the same
-/// question from a worktree in under a second.
+/// The behavioural half on the `run-tests.sh` side: hand it a tree and it must
+/// say, before it builds anything, that it is going to build that tree.
+/// `--plan` exists so this is answerable without Docker, and so a human can
+/// ask the same question from a worktree in under a second.
 #[test]
 fn run_tests_plan_reports_the_tree_it_was_handed() {
     let core = tempfile::tempdir().expect("temp dir for a stand-in core crate");
@@ -176,13 +282,9 @@ fn run_tests_still_defaults_to_the_sibling_layout() {
     );
 }
 
-/// git hands every hook a `GIT_DIR`, and in a worktree it points at that
-/// worktree's admin directory. It beats both `git -C` and the working
-/// directory, so a `git` call made from inside the gate answers for the
-/// repository doing the pushing whatever directory it was aimed at. The first
-/// run of the fixed hook reported the pushing branch's HEAD as the revision of
-/// an unrelated tree, which is #684 wearing a different hat: a banner that
-/// names the wrong commit is no better than a gate that builds the wrong one.
+/// The same leak as `the_gate_drops_the_git_environment_it_inherited`, from
+/// the other side: even with a `GIT_DIR` set, `run-tests.sh` must describe the
+/// tree it was handed rather than the repository that exported it.
 #[test]
 fn run_tests_does_not_report_the_pushing_repo_as_another_tree() {
     let core = tempfile::tempdir().expect("temp dir for a stand-in core crate");
@@ -235,40 +337,5 @@ fn run_tests_does_not_report_the_pushing_repo_as_another_tree() {
         "run-tests.sh described a directory that is not a git checkout as though \
          it were one, which means it answered from the inherited GIT_DIR rather \
          than from the tree it was handed. Line was: {line}"
-    );
-}
-
-/// The same leak, from the hook's side: it has to drop the git environment
-/// before handing over, or every `git` call the suite makes inherits it.
-#[test]
-fn pre_push_hook_clears_the_inherited_git_environment() {
-    let hook = generated_pre_push();
-    assert!(
-        hook.contains("unset GIT_DIR"),
-        "the pre-push hook must unset GIT_DIR before running the suite; git \
-         exports it into hooks and it wins over `git -C`, so anything the \
-         suite asks git answers for the pushing repository (#684)"
-    );
-}
-
-/// Both slots get named, not just the one being pushed. run-tests.sh falls
-/// back to the siblings of wherever the script sits, and for a libviprs-tests
-/// push that script is inside the worktree, whose neighbours are other lanes.
-#[test]
-fn pre_push_hook_pins_both_trees_not_just_the_pushed_one() {
-    let hook = generated_pre_push();
-    let libviprs_arm = hook
-        .split("libviprs-tests)")
-        .next()
-        .expect("the case statement has a libviprs arm");
-    assert!(
-        libviprs_arm.contains("LIBVIPRS_TESTS_DIR=\"$WORKSPACE_ROOT/libviprs-tests\""),
-        "a libviprs push must also pin the test tree to the workspace sibling, \
-         rather than leaving run-tests.sh to infer it (#684)"
-    );
-    assert!(
-        hook.contains("LIBVIPRS_DIR=\"$WORKSPACE_ROOT/libviprs\""),
-        "a libviprs-tests push must also pin the core tree to the workspace \
-         sibling, rather than leaving run-tests.sh to infer it (#684)"
     );
 }

--- a/tests/prepush_hook_is_a_file.rs
+++ b/tests/prepush_hook_is_a_file.rs
@@ -1,0 +1,162 @@
+//! Guards on how the pre-push hook is delivered (libviprs/libviprs#695).
+//!
+//! It used to be a heredoc inside `tools/install-hooks.sh`, and three problems
+//! followed from that shape rather than from anything the hook does. A linter
+//! saw a string literal, so ~120 lines of shell got no static checking. A
+//! guard could only assert on it by substring, and two that did stayed green
+//! while the behaviour they named had been removed. And it reached a repo only
+//! when somebody re-ran the installer, with no version stamp in the generated
+//! file, so a stale install was undetectable: at any moment an unknown subset
+//! of checkouts was running an unknown vintage.
+//!
+//! That third one has bite. libviprs/libviprs#684 existed because a hook
+//! silently gated the wrong tree and read green, and the delivery mechanism
+//! guaranteed the next such fix would ship the same way.
+//!
+//! So the hook is a tracked file and the installer writes a shim that runs it.
+//! These guards are about that arrangement holding: they install into a
+//! throwaway workspace with the real installer, change the checked-in file
+//! without reinstalling, and check the change reaches the push.
+
+use std::path::Path;
+
+mod common;
+use common::hooks::{PRE_PUSH_HOOK, Workspace, git, repo_root};
+
+/// A line the hook prints so a push can say which copy of it ran.
+fn marked(hook: &Path, marker: &str) {
+    let body = std::fs::read_to_string(hook).expect("read the checked-in hook");
+    let (shebang, rest) = body.split_once('\n').expect("the hook has a shebang");
+    std::fs::write(hook, format!("{shebang}\necho \"{marker}\"\n{rest}"))
+        .expect("mark the checked-in hook");
+}
+
+/// Commit something the skip list cannot call inert, and hand back the range.
+fn a_change(ws: &Workspace, tree: &Path) -> (String, String) {
+    let before = git(tree, &["rev-parse", "HEAD"]).trim().to_string();
+    let after = ws.commit_in(
+        tree,
+        "a change the suite can see",
+        &[("src/lib.rs", "// c\n")],
+    );
+    (before, after)
+}
+
+/// The point of the whole change. Edit the checked-in hook, do not reinstall
+/// anything, and the next push runs the edited hook.
+///
+/// While it was a heredoc this could not hold: a fix reached a repo only when
+/// somebody re-ran `install-hooks.sh` there, and nothing anywhere could tell
+/// you which vintage a given clone was on.
+#[test]
+fn a_push_runs_the_checked_in_hook_without_a_reinstall() {
+    let ws = Workspace::new();
+    marked(&ws.checked_in_hook(), "HOOK-EDITED-AFTER-INSTALL");
+
+    let tree = ws.repo("libviprs");
+    let (before, after) = a_change(&ws, &tree);
+    let out = ws
+        .push("libviprs")
+        .range(&before, &after)
+        .with_git_env()
+        .run();
+
+    assert!(
+        out.contains("HOOK-EDITED-AFTER-INSTALL"),
+        "a push ran a copy of the hook rather than the checked-in file, so a \
+         fix to the hook reaches a repo only when somebody re-runs \
+         install-hooks.sh there and no clone can say which vintage it is on \
+         (#695). The hook said:\n{out}"
+    );
+}
+
+/// The same property under the case that produced #684: a harness push runs
+/// the hook it is pushing, out of the worktree, not the copy in the main
+/// checkout. Otherwise a change to the hook is gated by the hook it replaces.
+#[test]
+fn a_harness_push_runs_the_hook_it_is_pushing() {
+    let ws = Workspace::new();
+    marked(&ws.checked_in_hook(), "HOOK-FROM-THE-MAIN-CHECKOUT");
+    ws.commit("libviprs-tests", "mark the main checkout's hook", &[]);
+
+    let lane = ws.worktree("libviprs-tests", "harness-lane");
+    marked(&lane.join(PRE_PUSH_HOOK), "HOOK-FROM-THE-LANE");
+    let before = git(&lane, &["rev-parse", "HEAD"]).trim().to_string();
+    let after = ws.commit_in(&lane, "change the hook", &[]);
+
+    let out = ws
+        .push("libviprs-tests")
+        .from(&lane)
+        .range(&before, &after)
+        .with_git_env()
+        .run();
+
+    assert!(
+        out.contains("HOOK-FROM-THE-LANE"),
+        "a harness push ran a hook from outside the tree being pushed, so a \
+         change to the hook is gated by the hook it replaces (#684, #695). \
+         The hook said:\n{out}"
+    );
+    assert!(
+        !out.contains("HOOK-FROM-THE-MAIN-CHECKOUT"),
+        "the push ran the main checkout's hook as well as the lane's. \
+         The hook said:\n{out}"
+    );
+}
+
+/// Installing by reference has one failure mode a copy does not: the thing
+/// pointed at can go away. It must say so rather than let the push through,
+/// because a gate that disappears quietly is the failure #684 and #683 were
+/// both about.
+#[test]
+fn the_installed_shim_refuses_the_push_when_the_hook_is_gone() {
+    let ws = Workspace::new();
+    let hooks_dir = ws.repo("libviprs-tests").join("tools/hooks");
+    std::fs::rename(&hooks_dir, hooks_dir.with_extension("moved"))
+        .expect("move the checked-in hook out of the way");
+
+    let tree = ws.repo("libviprs");
+    let (before, after) = a_change(&ws, &tree);
+    let (allowed, out) = ws
+        .push("libviprs")
+        .range(&before, &after)
+        .with_git_env()
+        .try_run();
+
+    assert!(
+        !allowed,
+        "the push went through with no hook to run. A gate installed by \
+         reference has to fail loudly when the reference breaks, or moving a \
+         checkout turns the gate off in silence (#695). It said:\n{out}"
+    );
+    assert!(
+        out.contains(&hooks_dir.join("pre-push").display().to_string()),
+        "the refusal did not name the path it could not find, so nobody can \
+         act on it. It said:\n{out}"
+    );
+    assert!(
+        out.contains("install-hooks.sh"),
+        "the refusal did not say how to fix it. It said:\n{out}"
+    );
+}
+
+/// A copied-and-chmodded hook was executable because the installer made it so.
+/// A hook reached by reference is executable because git tracked the bit, and
+/// git will happily track it without one. A non-executable hook is not a
+/// broken hook, it is no hook: git skips it and says nothing.
+#[test]
+fn the_hook_is_tracked_executable() {
+    let entry = git(&repo_root(), &["ls-files", "-s", "--", PRE_PUSH_HOOK]);
+    let entry = entry.trim();
+    assert!(
+        !entry.is_empty(),
+        "git does not track {PRE_PUSH_HOOK}, so nothing ships it to a clone \
+         and every install points at a file that is not there (#695)"
+    );
+    assert!(
+        entry.starts_with("100755 "),
+        "{PRE_PUSH_HOOK} is tracked without the executable bit ({entry}). git \
+         skips a hook it cannot execute and prints nothing, so the gate would \
+         be off in every fresh clone with no sign of it"
+    );
+}

--- a/tests/prepush_hook_is_a_file.rs
+++ b/tests/prepush_hook_is_a_file.rs
@@ -21,14 +21,18 @@
 use std::path::Path;
 
 mod common;
-use common::hooks::{PRE_PUSH_HOOK, Workspace, git, repo_root};
+use common::hooks::{PRE_PUSH_HOOK, Workspace, git, make_executable, repo_root};
 
-/// A line the hook prints so a push can say which copy of it ran.
-fn marked(hook: &Path, marker: &str) {
-    let body = std::fs::read_to_string(hook).expect("read the checked-in hook");
+/// Write the real hook to `dest` with one extra line saying which copy of it
+/// ran. Always built from this repo's pristine copy, so marking a file never
+/// inherits a marker from whatever it is overwriting.
+fn marked(dest: &Path, marker: &str) {
+    let body = std::fs::read_to_string(repo_root().join(PRE_PUSH_HOOK))
+        .expect("read this repo's checked-in hook");
     let (shebang, rest) = body.split_once('\n').expect("the hook has a shebang");
-    std::fs::write(hook, format!("{shebang}\necho \"{marker}\"\n{rest}"))
-        .expect("mark the checked-in hook");
+    std::fs::write(dest, format!("{shebang}\necho \"{marker}\"\n{rest}"))
+        .expect("write a marked hook");
+    make_executable(dest);
 }
 
 /// Commit something the skip list cannot call inert, and hand back the range.

--- a/tools/hooks/pre-push
+++ b/tools/hooks/pre-push
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# pre-push: run the Docker test suite before pushing.
+#
+# This is a real file, tracked in libviprs-tests, and it is the hook: what
+# `tools/install-hooks.sh` puts in `.git/hooks/pre-push` is a shim that runs
+# this. It used to be a heredoc inside that script, and three things followed
+# from the shape rather than from anything it does (libviprs/libviprs#695):
+# a linter saw a string literal so ~120 lines of shell got no static checking,
+# a guard could only assert on it by substring (two of them passed
+# while the behaviour they named had been deleted), and it reached a repo only
+# when somebody re-ran the installer, so at any moment an unknown set of
+# checkouts was running an unknown vintage.
+#
+# Being a file fixes all three. It is linted in CI, the guards in
+# `tests/prepush_gate_tests_the_pushed_tree.rs` and
+# `tests/prepush_gate_cost_controls.rs` execute it with a synthetic ref-update
+# on stdin, and a pull updates every repo pointing at it.
+#
+# To skip (emergency only): git push --no-verify. For a skip decision you do
+# not trust, LIBVIPRS_PREPUSH_ALL=1 first.
+# ---------------------------------------------------------------------------
+
+# A repo's main checkout and all of its linked worktrees share one hooks
+# directory, and git invokes the hook with $0 inside that shared directory.
+# Anything resolved from $0 is therefore the main checkout, whichever tree is
+# actually being pushed, which is how every lane worktree on epic #520 gated
+# against `main` instead of against its own branch (libviprs/libviprs#684).
+# A worktree's .git is a file holding a gitdir: pointer rather than a
+# directory, so walking up from it does not work either. Ask git, which runs
+# hooks from the top of the working tree whose commits are going out.
+TREE="$(git rev-parse --show-toplevel)"
+
+# --git-common-dir is the *main* checkout's .git for a linked worktree, and a
+# path relative to here for the main checkout itself, so resolve it from the
+# tree rather than assuming it is absolute. Its parent tells us which repo
+# this is, and where the sibling libviprs-tests checkout lives.
+MAIN_CHECKOUT="$(cd "$TREE" && cd "$(dirname "$(git rev-parse --git-common-dir)")" && pwd)"
+REPO_NAME="$(basename "$MAIN_CHECKOUT")"
+WORKSPACE_ROOT="$(cd "$MAIN_CHECKOUT/.." && pwd)"
+RUN_TESTS="$WORKSPACE_ROOT/libviprs-tests/tools/run-tests.sh"
+
+# Hand the pushed tree to the suite in whichever slot it belongs. Without
+# this run-tests.sh falls back to the sibling checkouts, which is the whole
+# defect. There are two slots and this hook is only installed into the two
+# repos that have one (libviprs/libviprs#691).
+# Both slots get pinned, not just the one being pushed. run-tests.sh falls
+# back to the siblings of wherever the script itself sits, and the script the
+# line below may pick sits inside the worktree, whose neighbours are other
+# lanes rather than the workspace. Naming both leaves nothing to infer.
+case "$REPO_NAME" in
+    libviprs)
+        export LIBVIPRS_DIR="$TREE"
+        export LIBVIPRS_TESTS_DIR="$WORKSPACE_ROOT/libviprs-tests"
+        ;;
+    libviprs-tests)
+        export LIBVIPRS_TESTS_DIR="$TREE"
+        export LIBVIPRS_DIR="$WORKSPACE_ROOT/libviprs"
+        # A push that changes the harness gates on the harness it changes,
+        # not on the copy sitting in the main checkout.
+        if [ -x "$TREE/tools/run-tests.sh" ]; then
+            RUN_TESTS="$TREE/tools/run-tests.sh"
+        fi
+        ;;
+esac
+
+if [ ! -f "$RUN_TESTS" ]; then
+    echo "Warning: run-tests.sh not found at $RUN_TESTS"
+    echo "Skipping pre-push tests. Install libviprs-tests as a sibling directory."
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Is there anything in this push the suite could see?
+# ---------------------------------------------------------------------------
+# A full image build and suite run for a two-file workflow edit is what taught
+# everyone to reach for --no-verify, and a hook nobody runs protects nothing
+# (libviprs/libviprs#683). So skip, but only where the answer is knowable:
+# paths that no test in either repo reads. That list is deliberately short.
+#
+# README.md and CHANGELOG.md are NOT on it. This suite's documentation guards
+# read both, and they read them out of the *core* checkout as well as its own
+# (tests/feature_rename_docs_present.rs), so a docs-only push to either repo
+# can genuinely fail. Two entries are per-repo for the same reason: .github/
+# and .gitignore are inert for a libviprs push and read by a libviprs-tests
+# one, whose pinning guards read .github/workflows/*.yml (tests/common/
+# workflows.rs, tests/counterpart_pinning.rs) and whose provenance guard reads
+# .gitignore for the native-binary patterns (tests/pdfium_provenance.rs, issue
+# #56). A .gitignore-only push is exactly the push that can drop those
+# patterns, so it is the last one that should skip the guard on them.
+#
+# tests/prepush_gate_cost_controls.rs runs every tracked path in both repos
+# through this function for real and pins the set that comes back inert, so
+# adding an entry here fails there with the files it would newly exempt.
+#
+# Set LIBVIPRS_PREPUSH_ALL=1 to run the suite whatever the paths say.
+
+inert_path() {
+    case "$1" in
+        .github/*|.gitignore)
+            [ "$REPO_NAME" != "libviprs-tests" ]
+            ;;
+        docs/*|.gitattributes|.editorconfig|LICENSE|LICENSE-*)
+            true
+            ;;
+        *)
+            false
+            ;;
+    esac
+}
+
+REF_UPDATES="$(cat)"
+CHANGED=""
+SKIP_SUITE=false
+
+if [ "${LIBVIPRS_PREPUSH_ALL:-0}" != "1" ] && [ -n "$REF_UPDATES" ]; then
+    UNKNOWN=false
+    while read -r _local_ref local_oid _remote_ref remote_oid; do
+        if [ -z "${local_oid:-}" ]; then
+            continue
+        fi
+        # An all-zero local oid is a ref deletion: no content goes out.
+        case "$local_oid" in
+            *[!0]*) : ;;
+            *)      continue ;;
+        esac
+
+        BASE=""
+        case "${remote_oid:-}" in
+            *[!0]*)
+                if git cat-file -e "${remote_oid}^{commit}" 2>/dev/null; then
+                    BASE="$remote_oid"
+                fi
+                ;;
+        esac
+        if [ -z "$BASE" ]; then
+            # New branch. Compare against whatever the remote's default branch
+            # already has, and give up rather than guess if that is not here.
+            UPSTREAM="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+            if [ -z "$UPSTREAM" ]; then
+                UPSTREAM="origin/main"
+            fi
+            BASE="$(git merge-base "$local_oid" "$UPSTREAM" 2>/dev/null || true)"
+        fi
+        if [ -z "$BASE" ]; then
+            UNKNOWN=true
+            break
+        fi
+
+        # Unguarded this is a `set -e` exit: a git failure here would abort
+        # the push with nothing printed. A range we cannot diff is a range we
+        # cannot judge, which is the same answer as a base we could not find.
+        if ! REF_PATHS="$(git diff --name-only "$BASE" "$local_oid" --)"; then
+            UNKNOWN=true
+            break
+        fi
+        CHANGED="$CHANGED
+$REF_PATHS"
+    done <<REFS
+$REF_UPDATES
+REFS
+
+    if [ "$UNKNOWN" = false ]; then
+        SKIP_SUITE=true
+        while IFS= read -r changed_path; do
+            if [ -z "$changed_path" ]; then
+                continue
+            fi
+            if inert_path "$changed_path"; then
+                continue
+            fi
+            SKIP_SUITE=false
+            echo "Pre-push: $changed_path can reach the suite, running it."
+            break
+        done <<PATHS
+$CHANGED
+PATHS
+    fi
+fi
+
+if [ "$SKIP_SUITE" = true ]; then
+    echo "Pre-push: nothing in this push reaches the test suite, skipping it."
+    printf '%s\n' "$CHANGED" | sed '/^$/d; s/^/  /'
+    echo "  (LIBVIPRS_PREPUSH_ALL=1 runs it anyway)"
+    exit 0
+fi
+
+# git hands every hook a GIT_DIR (and, in a worktree, one pointing at the
+# per-worktree admin directory), and it wins over -C and over the working
+# directory for every git command anything below runs. Leaving it set made the
+# suite report this push's HEAD as the revision of trees it had never looked
+# at. The paths above are already resolved, so drop it here.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_QUARANTINE_PATH
+
+echo "Running pre-push test suite on $TREE..."
+if ! "$RUN_TESTS"; then
+    echo ""
+    echo "Pre-push tests failed. Push aborted."
+    echo "Fix the failures or use: git push --no-verify"
+    exit 1
+fi

--- a/tools/install-hooks.sh
+++ b/tools/install-hooks.sh
@@ -11,6 +11,9 @@ set -euo pipefail
 #                 Check & Lint. Update the per-repo cargo command lists below
 #                 when a repo's CI matrix changes, and re-run this script.
 #   pre-push    — Docker test suite via run-tests.sh (slow, on every push)
+#                 The hook itself is a tracked file, tools/hooks/pre-push;
+#                 what lands in .git/hooks is a shim that runs it
+#                 (libviprs/libviprs#695).
 #                 Runs against the working tree being pushed, which for a
 #                 linked worktree is not the main checkout the hooks
 #                 directory lives in (libviprs/libviprs#684). Only where the
@@ -175,195 +178,60 @@ HOOK
     chmod +x "$pre_commit"
 }
 
-write_pre_push() {
+# The pre-push hook is not generated. It is a real file at tools/hooks/pre-push
+# and this writes a shim that runs it, so a linter can see it, the guards can
+# execute it, and a pull into this checkout updates the hook in every repo
+# pointing at it instead of needing a redeploy per fix
+# (libviprs/libviprs#695).
+PRE_PUSH_HOOK="$SCRIPT_DIR/hooks/pre-push"
+
+install_pre_push() {
     local hooks_dir="$1"
     local pre_push="$hooks_dir/pre-push"
-    cat > "$pre_push" << 'HOOK'
-#!/usr/bin/env bash
-set -euo pipefail
 
-# Pre-push hook: run Docker test suite before pushing.
-# Installed by libviprs-tests/tools/install-hooks.sh
-# To skip (emergency only): git push --no-verify
-
-# A repo's main checkout and all of its linked worktrees share one hooks
-# directory, and git invokes the hook with $0 inside that shared directory.
-# Anything resolved from $0 is therefore the main checkout, whichever tree is
-# actually being pushed, which is how every lane worktree on epic #520 gated
-# against `main` instead of against its own branch (libviprs/libviprs#684).
-# A worktree's .git is a file holding a gitdir: pointer rather than a
-# directory, so walking up from it does not work either. Ask git, which runs
-# hooks from the top of the working tree whose commits are going out.
-TREE="$(git rev-parse --show-toplevel)"
-
-# --git-common-dir is the *main* checkout's .git for a linked worktree, and a
-# path relative to here for the main checkout itself, so resolve it from the
-# tree rather than assuming it is absolute. Its parent tells us which repo
-# this is, and where the sibling libviprs-tests checkout lives.
-MAIN_CHECKOUT="$(cd "$TREE" && cd "$(dirname "$(git rev-parse --git-common-dir)")" && pwd)"
-REPO_NAME="$(basename "$MAIN_CHECKOUT")"
-WORKSPACE_ROOT="$(cd "$MAIN_CHECKOUT/.." && pwd)"
-RUN_TESTS="$WORKSPACE_ROOT/libviprs-tests/tools/run-tests.sh"
-
-# Hand the pushed tree to the suite in whichever slot it belongs. Without
-# this run-tests.sh falls back to the sibling checkouts, which is the whole
-# defect. There are two slots and this hook is only installed into the two
-# repos that have one (libviprs/libviprs#691).
-# Both slots get pinned, not just the one being pushed. run-tests.sh falls
-# back to the siblings of wherever the script itself sits, and the script the
-# line below may pick sits inside the worktree, whose neighbours are other
-# lanes rather than the workspace. Naming both leaves nothing to infer.
-case "$REPO_NAME" in
-    libviprs)
-        export LIBVIPRS_DIR="$TREE"
-        export LIBVIPRS_TESTS_DIR="$WORKSPACE_ROOT/libviprs-tests"
-        ;;
-    libviprs-tests)
-        export LIBVIPRS_TESTS_DIR="$TREE"
-        export LIBVIPRS_DIR="$WORKSPACE_ROOT/libviprs"
-        # A push that changes the harness gates on the harness it changes,
-        # not on the copy sitting in the main checkout.
-        if [ -x "$TREE/tools/run-tests.sh" ]; then
-            RUN_TESTS="$TREE/tools/run-tests.sh"
-        fi
-        ;;
-esac
-
-if [ ! -f "$RUN_TESTS" ]; then
-    echo "Warning: run-tests.sh not found at $RUN_TESTS"
-    echo "Skipping pre-push tests. Install libviprs-tests as a sibling directory."
-    exit 0
-fi
-
-# ---------------------------------------------------------------------------
-# Is there anything in this push the suite could see?
-# ---------------------------------------------------------------------------
-# A full image build and suite run for a two-file workflow edit is what taught
-# everyone to reach for --no-verify, and a hook nobody runs protects nothing
-# (libviprs/libviprs#683). So skip, but only where the answer is knowable:
-# paths that no test in either repo reads. That list is deliberately short.
-#
-# README.md and CHANGELOG.md are NOT on it. This suite's documentation guards
-# read both, and they read them out of the *core* checkout as well as its own
-# (tests/feature_rename_docs_present.rs), so a docs-only push to either repo
-# can genuinely fail. Two entries are per-repo for the same reason: .github/
-# and .gitignore are inert for a libviprs push and read by a libviprs-tests
-# one, whose pinning guards read .github/workflows/*.yml (tests/common/
-# workflows.rs, tests/counterpart_pinning.rs) and whose provenance guard reads
-# .gitignore for the native-binary patterns (tests/pdfium_provenance.rs, issue
-# #56). A .gitignore-only push is exactly the push that can drop those
-# patterns, so it is the last one that should skip the guard on them.
-#
-# tests/prepush_gate_cost_controls.rs runs every tracked path in both repos
-# through this function for real and pins the set that comes back inert, so
-# adding an entry here fails there with the files it would newly exempt.
-#
-# Set LIBVIPRS_PREPUSH_ALL=1 to run the suite whatever the paths say.
-
-inert_path() {
-    case "$1" in
-        .github/*|.gitignore)
-            [ "$REPO_NAME" != "libviprs-tests" ]
-            ;;
-        docs/*|.gitattributes|.editorconfig|LICENSE|LICENSE-*)
-            true
-            ;;
-        *)
-            false
-            ;;
-    esac
-}
-
-REF_UPDATES="$(cat)"
-CHANGED=""
-SKIP_SUITE=false
-
-if [ "${LIBVIPRS_PREPUSH_ALL:-0}" != "1" ] && [ -n "$REF_UPDATES" ]; then
-    UNKNOWN=false
-    while read -r _local_ref local_oid _remote_ref remote_oid; do
-        if [ -z "${local_oid:-}" ]; then
-            continue
-        fi
-        # An all-zero local oid is a ref deletion: no content goes out.
-        case "$local_oid" in
-            *[!0]*) : ;;
-            *)      continue ;;
-        esac
-
-        BASE=""
-        case "${remote_oid:-}" in
-            *[!0]*)
-                if git cat-file -e "${remote_oid}^{commit}" 2>/dev/null; then
-                    BASE="$remote_oid"
-                fi
-                ;;
-        esac
-        if [ -z "$BASE" ]; then
-            # New branch. Compare against whatever the remote's default branch
-            # already has, and give up rather than guess if that is not here.
-            UPSTREAM="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
-            if [ -z "$UPSTREAM" ]; then
-                UPSTREAM="origin/main"
-            fi
-            BASE="$(git merge-base "$local_oid" "$UPSTREAM" 2>/dev/null || true)"
-        fi
-        if [ -z "$BASE" ]; then
-            UNKNOWN=true
-            break
-        fi
-
-        # Unguarded this is a `set -e` exit: a git failure here would abort
-        # the push with nothing printed. A range we cannot diff is a range we
-        # cannot judge, which is the same answer as a base we could not find.
-        if ! REF_PATHS="$(git diff --name-only "$BASE" "$local_oid" --)"; then
-            UNKNOWN=true
-            break
-        fi
-        CHANGED="$CHANGED
-$REF_PATHS"
-    done <<REFS
-$REF_UPDATES
-REFS
-
-    if [ "$UNKNOWN" = false ]; then
-        SKIP_SUITE=true
-        while IFS= read -r changed_path; do
-            if [ -z "$changed_path" ]; then
-                continue
-            fi
-            if inert_path "$changed_path"; then
-                continue
-            fi
-            SKIP_SUITE=false
-            echo "Pre-push: $changed_path can reach the suite, running it."
-            break
-        done <<PATHS
-$CHANGED
-PATHS
+    if [ ! -x "$PRE_PUSH_HOOK" ]; then
+        echo "Error: no executable pre-push hook at $PRE_PUSH_HOOK." >&2
+        echo "It is tracked in this repo; check the checkout is complete and" >&2
+        echo "that the executable bit survived." >&2
+        exit 1
     fi
+
+    # Unquoted marker: the installed path is baked in here, once, at install
+    # time. Nothing else in this chunk expands.
+    cat > "$pre_push" << HOOK
+#!/usr/bin/env bash
+# Pre-push shim. Installed by libviprs-tests/tools/install-hooks.sh
+# To skip (emergency only): git push --no-verify
+#
+# No behaviour lives here on purpose. The hook is checked in at
+# libviprs-tests/tools/hooks/pre-push (libviprs/libviprs#695); this only points
+# at it, so a pull updates every repo at once and no clone can quietly run a
+# vintage nobody can name.
+HOOK_PATH="$PRE_PUSH_HOOK"
+HOOK
+
+    cat >> "$pre_push" << 'HOOK'
+
+# A harness push runs the hook it is pushing, the same way it gates on the
+# suite it is pushing (libviprs/libviprs#684). Only libviprs-tests carries this
+# file, so for every other repo the test below is simply false.
+TREE="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -n "$TREE" ] && [ -x "$TREE/tools/hooks/pre-push" ]; then
+    HOOK_PATH="$TREE/tools/hooks/pre-push"
 fi
 
-if [ "$SKIP_SUITE" = true ]; then
-    echo "Pre-push: nothing in this push reaches the test suite, skipping it."
-    printf '%s\n' "$CHANGED" | sed '/^$/d; s/^/  /'
-    echo "  (LIBVIPRS_PREPUSH_ALL=1 runs it anyway)"
-    exit 0
-fi
-
-# git hands every hook a GIT_DIR (and, in a worktree, one pointing at the
-# per-worktree admin directory), and it wins over -C and over the working
-# directory for every git command anything below runs. Leaving it set made the
-# suite report this push's HEAD as the revision of trees it had never looked
-# at. The paths above are already resolved, so drop it here.
-unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_QUARANTINE_PATH
-
-echo "Running pre-push test suite on $TREE..."
-if ! "$RUN_TESTS"; then
-    echo ""
-    echo "Pre-push tests failed. Push aborted."
-    echo "Fix the failures or use: git push --no-verify"
+# Installing by reference has one failure mode copying does not: the file can
+# go away, and git skips a hook it cannot execute without printing anything. A
+# gate that disappears in silence is the failure #683 and #684 were both about,
+# so refuse the push and say where to look.
+if [ ! -x "$HOOK_PATH" ]; then
+    echo "pre-push: no executable hook at $HOOK_PATH" >&2
+    echo "Re-run libviprs-tests/tools/install-hooks.sh, or restore that checkout." >&2
+    echo "To push without a gate: git push --no-verify" >&2
     exit 1
 fi
+
+exec "$HOOK_PATH" "$@"
 HOOK
     chmod +x "$pre_push"
 }
@@ -533,7 +401,7 @@ for REPO_DIR in "${REPOS[@]}"; do
             # for the cli it gates the cli.
             write_pre_commit "$HOOKS_DIR" "$REPO_NAME"
             if has_suite_slot "$REPO_NAME"; then
-                write_pre_push "$HOOKS_DIR"
+                install_pre_push "$HOOKS_DIR"
                 echo "  done: $REPO_NAME (pre-commit + pre-push)"
             else
                 echo "  done: $REPO_NAME (pre-commit only; the suite has no slot for it)"


### PR DESCRIPTION
Stacked on #172 (libviprs/libviprs#691). Review that first, or read this against `fix/691-cli-prepush-slot`.

The pre-push hook is now `tools/hooks/pre-push`, a tracked file. What `install-hooks.sh` puts in `.git/hooks/pre-push` is a shim that runs it. Three problems came from the heredoc shape rather than from anything the hook does, and being a file fixes all three.

**It gets linted.** `shellcheck tools/*.sh tools/hooks/pre-push` runs in the lint job. Every one of the seven scripts is clean, and it caught something on its very first run over the extracted file: a comment line I had started with the word "shellcheck", which it read as a malformed directive (SC1072/SC1073) and would have stopped checking at. That is ~200 lines of shell that had no static checking at all until now.

**It gets executed by the guards.** They install into a throwaway workspace with the real installer and drive the installed hook with a ref-update on stdin, from a linked worktree as well as a main checkout. The stub standing in for `run-tests.sh` reports the environment it was handed, so which trees the gate picked, which `run-tests.sh` it ran, and whether it dropped the inherited git environment are all readable off one push.

**It stops needing a redeploy per fix.** A pull into this checkout updates the hook in every repo pointing at it. That was not hypothetical. `libviprs-cli` on this machine was still running the pre-#684, pre-#683 body, two fixes behind, and nothing anywhere could have told you.

## The evidence that mattered most

The issue says two substring guards passed while the behaviour they named had been removed. Here is that, measured on `87e8103`, which is `main`. Each mutation breaks the behaviour and leaves the substring behind in a comment, which is the only thing a `contains()` was ever looking at.

| mutation on `main` | the four substring guards | the whole `prepush_gate_tests_the_pushed_tree` suite | `prepush_gate_cost_controls` |
|---|---|---|---|
| **OM1** resolve the tree from `$0` again, which is #684 fully reverted and the gate building the main checkout on every lane push | all 4 **green** | **7/7 green** | 2 failed |
| **OM2** delete the `unset GIT_DIR ...` line, so the whole git environment leaks into the suite | all 4 **green** | **7/7 green** | **7/7 green** |
| **OM3** delete both `export` lines from the harness arm, so neither tree is pinned and `run-tests.sh` goes back to inferring them | all 4 **green** | **7/7 green** | **7/7 green** |

Fourteen guards on this hook. Under OM2 and OM3, not one of them moves. OM1 is caught only by the two cost-control guards that already ran the hook, and only incidentally.

The four assertions are gone: `contains("git rev-parse --show-toplevel")`, `contains("git rev-parse --git-common-dir")`, `contains("unset GIT_DIR")`, the two literal `export` lines, and `contains("${LIBVIPRS_PREPUSH_ALL")`. What replaces them runs the hook.

## Mutation table

Every one applied to the tree, measured, reverted. `git status` is clean afterwards.

| # | mutation | guard | result |
|---|---|---|---|
| N1 | resolve the tree from `$0` instead of asking git (OM1, against the new guards) | `the_gate_is_handed_the_tree_being_pushed_and_its_sibling` | **RED** |
| N2 | stop pinning the sibling tree on a harness push | `the_gate_is_handed_the_tree_being_pushed_and_its_sibling` | **RED** |
| N3 | gate a harness push on the main checkout's `run-tests.sh` | `a_harness_push_runs_the_suite_script_it_is_pushing` | **RED** |
| N4 | delete the `unset` line, keep the comment above it (OM2) | `the_gate_drops_the_git_environment_it_inherited` | **RED** |
| N5 | delete the one line that expands `LIBVIPRS_PREPUSH_ALL`, keep all three mentions | `the_skip_can_be_overridden` | **RED** |
| N6 | flip `inert_path`'s fallthrough to `true`, disabling the gate for every push in every repo | `the_skip_list_exempts_exactly_the_pinned_paths` | **RED** |
| N7 | install by copying the hook instead of pointing at it | `a_push_runs_the_checked_in_hook_without_a_reinstall` | **RED** |
| N8 | drop the shim's preference for the tree being pushed | `a_harness_push_runs_the_hook_it_is_pushing` | **RED** |
| N9 | let the shim wave the push through when the hook is not there | `the_installed_shim_refuses_the_push_when_the_hook_is_gone` | **RED** |
| N10 | commit the hook without the executable bit | `the_hook_is_tracked_executable` | **RED** |
| N11 | delete both `export` lines from the harness arm (OM3) | `the_gate_is_handed_the_tree_being_pushed_and_its_sibling` | **RED** |

## Two decisions worth arguing with

**No `core.hooksPath`.** The issue proposes it, and I did not take it. The pre-commit hook is generated per repo (the cargo step lists differ), so `hooksPath` needs a per-repo directory holding both hooks, which is `.git/hooks` with extra indirection and one more setting that silently disables every hook if somebody changes it. The three things the issue wanted from it, linting, execution and self-updating, all come from the file being checked in, not from how git finds it. The #684 bonus it mentions is already paid for: the hook asks `git rev-parse --show-toplevel`.

**The shim carries one branch, on purpose.** A harness push runs the hook out of the tree it is pushing, so a change to the hook is gated by the changed hook, exactly the way #684 made a harness push gate on the suite it is pushing. N8 is the mutation for it. Everything else in the shim is a path and a refusal.

That refusal is the failure mode installing by reference has and copying does not: the file can go away, and git skips a hook it cannot execute without printing anything. So the shim exits non-zero and names the path. `the_hook_is_tracked_executable` covers the neighbouring one, since a copied hook was executable because the installer chmodded it, and a referenced hook is executable because git tracked the bit.

## Gate

```
cargo fmt -- --check                                              clean
RUSTFLAGS="-Dwarnings" cargo clippy --all-targets -- -D warnings   silent
cargo test                                                        769 passed, 0 failed, 11 ignored
shellcheck tools/*.sh tools/hooks/pre-push                        clean (7 files)
```

769 against 766 on #172: four new in `prepush_hook_is_a_file`, and one fewer in `prepush_gate_tests_the_pushed_tree` (four text guards out, three behavioural ones in).

## Found on the way

`install-hooks.sh` keeps per-repo cargo step lists with a comment promising they mirror each repo's CI lint job exactly, and nothing checks it. They have drifted: the core's list runs 2 of the 5 clippy passes CI runs (`object-store-sink`, `svg` and `jxl` are missing), and this repo's runs 4 of 5 (`jxl` missing, and `s3` is a deprecated alias for a cell the matrix already covers). #695 names this in its "Related" section. It is too big to fold in here, so it is libviprs/libviprs#715 and it is fixed in the PR stacked on this one.

Closes libviprs/libviprs#695
