### PR TITLE
fix(hooks): make the pre-commit hook lint what CI lints, and check that it does

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,11 @@ jobs:
       # hard panic, so this job can never go green without actually running viprs.
       - env:
           VIPRS_REQUIRE_CLI: 1
-        run: cargo test --test cli_morphology_diff --test cli_bands_diff --test cli_extract_diff --test cli_conversion_diff --test cli_core_diff --test cli_convolution_diff --test cli_matrix_diff --test cli_colour_diff --test cli_resample_diff --test cli_histogram_diff --test cli_composite_diff --test cli_freqfilt_diff --test cli_mosaicing_diff --test cli_create_diff --test cli_draw_diff --test cli_aritha_diff --test cli_arithb_diff --test cli_iocleanup_diff
+        # install_hooks_mirror_ci's cli arm is the only place the cli's
+        # pre-commit hook is compared against the cli's own CI, and it can only
+        # run where the sibling is laid down, which is here
+        # (libviprs/libviprs#715).
+        run: cargo test --test install_hooks_mirror_ci --test cli_morphology_diff --test cli_bands_diff --test cli_extract_diff --test cli_conversion_diff --test cli_core_diff --test cli_convolution_diff --test cli_matrix_diff --test cli_colour_diff --test cli_resample_diff --test cli_histogram_diff --test cli_composite_diff --test cli_freqfilt_diff --test cli_mosaicing_diff --test cli_create_diff --test cli_draw_diff --test cli_aritha_diff --test cli_arithb_diff --test cli_iocleanup_diff
 
   lint:
     name: Lint

--- a/README.md
+++ b/README.md
@@ -151,7 +151,14 @@ into the two the suite can see:
 
 **Pre-commit** (runs on every `git commit`):
 - `cargo fmt -- --check` — rejects unformatted code
-- `cargo clippy --all-targets -- -D warnings` — rejects lint warnings
+- Every `cargo clippy` pass that repo's `ci.yml` runs, feature matrix
+  expanded, so a feature-gated regression cannot pass locally and fail
+  remotely. For this repo that is the default cell plus `object-store-sink`,
+  `packfile`, `tracing` and `jxl`, then `./tools/run_ported_cells.sh --clippy`.
+- The lockstep is enforced rather than asked for:
+  `tests/install_hooks_mirror_ci.rs` runs the generated hook with a recording
+  stand-in for `cargo` and compares what it invokes against the workflow
+  (libviprs/libviprs#715).
 
 **Pre-push** (libviprs and libviprs-tests only; runs on `git push`, when the
 push can reach the suite):

--- a/tests/common/hooks.rs
+++ b/tests/common/hooks.rs
@@ -97,7 +97,10 @@ impl Workspace {
         let dir = tempfile::tempdir().expect("temp dir for a stand-in workspace");
         let root = dir.path().canonicalize().expect("canonical temp path");
 
-        for repo in ["libviprs", "libviprs-tests"] {
+        // libviprs-cli gets no pre-push hook (libviprs/libviprs#691) but it
+        // does get a pre-commit one, and #715's guard runs that, so it is here
+        // too. Nothing pushes from it.
+        for repo in ["libviprs", "libviprs-cli", "libviprs-tests"] {
             let repo_root = root.join(repo);
             std::fs::create_dir_all(&repo_root).expect("create the stand-in repo");
             git(&repo_root, &["init", "-q", "-b", "main"]);

--- a/tests/install_hooks_mirror_ci.rs
+++ b/tests/install_hooks_mirror_ci.rs
@@ -1,0 +1,245 @@
+//! Guards that the pre-commit hook runs what each repo's CI lint job runs
+//! (libviprs/libviprs#715).
+//!
+//! `tools/install-hooks.sh` says its pre-commit hook "Mirrors each repo's
+//! `.github/workflows/ci.yml` Check & Lint job *exactly*, so a clean local
+//! commit means a clean remote Check & Lint", and then asks a human to keep
+//! the per-repo cargo step lists in lockstep by hand. That did not happen. The
+//! core's list ran two of the five clippy passes CI runs, missing
+//! `object-store-sink`, `svg` and `jxl`, and this repo's missed `jxl` while
+//! spending a compile on `s3`, a deprecated alias for a cell the matrix
+//! already covers under its real name.
+//!
+//! Every one of those per-feature passes exists because the default pass
+//! compiles none of that code (#382, #500, #502, and libviprs-tests#55). So a
+//! commit that breaks `src/svg.rs` passed the local hook and failed CI, which
+//! is the exact failure the hook was written to prevent.
+//!
+//! The guard runs the generated hook with a recording stand-in for `cargo`
+//! first on `PATH` and compares the invocations it actually makes against the
+//! lint lines in that repo's `ci.yml`. Grepping either file would be worth
+//! nothing, which is the standing lesson of libviprs/libviprs#695.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::process::Command;
+
+mod common;
+use common::cli::{cli_dir, require_cli};
+use common::hooks::{Workspace, make_executable, repo_root};
+
+/// A `cargo` that records its arguments and succeeds, so the hook runs every
+/// step instead of stopping at the first one.
+const RECORDING_CARGO: &str = r#"#!/bin/sh
+printf 'cargo %s\n' "$*" >> "$LOCKSTEP_RECORD"
+exit 0
+"#;
+
+/// The same for the one non-cargo lint step, which the hook invokes by
+/// relative path rather than through `PATH`.
+const RECORDING_PORTED_CELLS: &str = r#"#!/bin/sh
+printf './tools/run_ported_cells.sh %s\n' "$*" >> "$LOCKSTEP_RECORD"
+exit 0
+"#;
+
+/// Every lint command `ci.yml` runs, with the feature matrix expanded.
+///
+/// `cargo check` and `cargo build` lines are deliberately out. The comment
+/// above the step lists already says clippy does `cargo check`'s work, and the
+/// core's `cargo build --features s3` is there to prove a deprecated alias
+/// still resolves, which the manifest settles and a whole extra build on every
+/// commit does not earn.
+fn ci_lint_commands(workflow: &str) -> BTreeSet<String> {
+    let features: Vec<String> = workflow
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            let list = line.strip_prefix("feature: [")?.strip_suffix(']')?;
+            Some(
+                list.split(',')
+                    .map(|f| f.trim().to_string())
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .flatten()
+        .collect();
+
+    let mut found = BTreeSet::new();
+    for line in workflow.lines() {
+        let line = line.trim();
+        let Some(cmd) = line
+            .strip_prefix("- run: ")
+            .or_else(|| line.strip_prefix("run: "))
+        else {
+            continue;
+        };
+        let cmd = cmd.trim();
+        let is_lint = cmd.starts_with("cargo clippy")
+            || cmd.starts_with("cargo fmt")
+            || (cmd.starts_with("./tools/run_ported_cells.sh") && cmd.contains("--clippy"));
+        if !is_lint {
+            continue;
+        }
+        if cmd.contains("${{ matrix.feature }}") {
+            assert!(
+                !features.is_empty(),
+                "a workflow line uses ${{{{ matrix.feature }}}} but no job \
+                 declares a `feature: [...]` list, so this guard cannot expand \
+                 it: {cmd}"
+            );
+            for feature in &features {
+                found.insert(cmd.replace("${{ matrix.feature }}", feature));
+            }
+        } else {
+            found.insert(cmd.to_string());
+        }
+    }
+    found
+}
+
+/// What the pre-commit hook `install-hooks.sh` writes for `repo` actually
+/// runs, observed by putting a recorder in front of it.
+fn hook_runs(ws: &Workspace, repo: &str) -> BTreeSet<String> {
+    let repo_dir = ws.repo(repo);
+    let hook = repo_dir.join(".git/hooks/pre-commit");
+    assert!(
+        hook.is_file(),
+        "no pre-commit hook was installed into {repo}, so this guard would \
+         pass on an empty recording"
+    );
+
+    let bin = ws.root.join("recorders").join(repo);
+    std::fs::create_dir_all(&bin).expect("create the recorder directory");
+    let cargo = bin.join("cargo");
+    std::fs::write(&cargo, RECORDING_CARGO).expect("write the recording cargo");
+    make_executable(&cargo);
+
+    // The hook reaches this one by relative path, so it has to sit in the
+    // stand-in repo rather than on PATH.
+    let ported = repo_dir.join("tools/run_ported_cells.sh");
+    std::fs::create_dir_all(ported.parent().expect("tools dir")).expect("create tools dir");
+    std::fs::write(&ported, RECORDING_PORTED_CELLS).expect("write the recording ported cells");
+    make_executable(&ported);
+
+    let record = ws.root.join(format!("{repo}.record"));
+    let _ = std::fs::remove_file(&record);
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    let out = Command::new("bash")
+        .arg(&hook)
+        .current_dir(&repo_dir)
+        .env("PATH", path)
+        .env("LOCKSTEP_RECORD", &record)
+        .output()
+        .expect("run the generated pre-commit hook");
+    assert!(
+        out.status.success(),
+        "the pre-commit hook failed with every command stubbed to succeed:\n{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    std::fs::read_to_string(&record)
+        .unwrap_or_default()
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect()
+}
+
+/// The workflow for a repo, read out of that repo's checkout.
+fn workflow_of(root: &Path) -> String {
+    let path = root.join(".github/workflows/ci.yml");
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+fn compare(repo: &str, ci: BTreeSet<String>, hook: BTreeSet<String>) {
+    assert!(
+        !ci.is_empty(),
+        "found no lint commands in {repo}'s ci.yml, so this guard would pass \
+         on a workflow that lints nothing"
+    );
+
+    let missing: Vec<&String> = ci.difference(&hook).collect();
+    let extra: Vec<&String> = hook.difference(&ci).collect();
+
+    assert!(
+        missing.is_empty(),
+        "{repo}'s CI lints these and the pre-commit hook does not:\n  {}\n\
+         Each one is a commit that passes locally and fails remotely, which is \
+         the whole reason the hook exists. Add them to the step list for \
+         {repo} in tools/install-hooks.sh (#715).",
+        missing
+            .iter()
+            .map(|c| c.as_str())
+            .collect::<Vec<_>>()
+            .join("\n  ")
+    );
+    assert!(
+        extra.is_empty(),
+        "the pre-commit hook for {repo} runs these and CI does not:\n  {}\n\
+         Either CI lost a check the hook still remembers, or the hook is \
+         spending a compile on something nothing asks for. Reconcile them in \
+         tools/install-hooks.sh (#715).",
+        extra
+            .iter()
+            .map(|c| c.as_str())
+            .collect::<Vec<_>>()
+            .join("\n  ")
+    );
+}
+
+/// This repo. Its own workflow is always here, so there is nothing to skip.
+#[test]
+fn the_hook_lints_this_repo_the_way_its_ci_does() {
+    let ws = Workspace::new();
+    compare(
+        "libviprs-tests",
+        ci_lint_commands(&workflow_of(&repo_root())),
+        hook_runs(&ws, "libviprs-tests"),
+    );
+}
+
+/// The core checkout. `libviprs = { path = "../libviprs" }` in this crate's
+/// manifest means it is there whenever this suite can run at all, and the
+/// Docker build context stages it with its `.github/` intact.
+#[test]
+fn the_hook_lints_the_core_the_way_its_ci_does() {
+    let ws = Workspace::new();
+    compare(
+        "libviprs",
+        ci_lint_commands(&workflow_of(&repo_root().join("../libviprs"))),
+        hook_runs(&ws, "libviprs"),
+    );
+}
+
+/// The cli is not laid down by the default `test` job or by the Docker gate,
+/// so this one has to skip where it is absent. Skipping reads to `cargo test`
+/// as a pass, so it follows the same false-green guard as the differential
+/// cells: `VIPRS_REQUIRE_CLI=1`, set on the job that does lay the cli down,
+/// turns the skip into a panic (`tests/common/cli.rs`).
+#[test]
+fn the_hook_lints_the_cli_the_way_its_ci_does() {
+    let dir = cli_dir();
+    let workflow = dir.join(".github/workflows/ci.yml");
+    if !workflow.is_file() {
+        assert!(
+            !require_cli(),
+            "VIPRS_REQUIRE_CLI=1 but there is no libviprs-cli workflow at {}, \
+             so this guard would compare nothing and report a false green",
+            workflow.display()
+        );
+        return;
+    }
+
+    let ws = Workspace::new();
+    compare(
+        "libviprs-cli",
+        ci_lint_commands(&workflow_of(&dir)),
+        hook_runs(&ws, "libviprs-cli"),
+    );
+}

--- a/tools/install-hooks.sh
+++ b/tools/install-hooks.sh
@@ -38,19 +38,34 @@ REPOS=(
 )
 
 # ---------------------------------------------------------------------------
-# Per-repo cargo lint/check commands. Keep these in lockstep with the
-# `cargo` lines under the Check & Lint / lint-and-build jobs in each repo's
-# `.github/workflows/ci.yml`. They run in order; the first failure aborts.
+# Per-repo cargo lint commands, in lockstep with the `cargo clippy` and
+# `cargo fmt` lines in each repo's `.github/workflows/ci.yml`, feature matrix
+# expanded. They run in order; the first failure aborts.
+#
+# `tests/install_hooks_mirror_ci.rs` enforces the lockstep by running the
+# generated hook with a recording stand-in for `cargo` and comparing what it
+# invokes against those workflow lines, so a list that drifts fails there
+# naming the passes it lost. It used to be a comment asking a human to keep
+# them in step, and the core's list sat at two of five passes for as long as
+# that was true (libviprs/libviprs#715).
 #
 # `cargo clippy` already runs `cargo check`'s work, so we don't repeat the
 # explicit `cargo check --all-targets` lines that CI also has — clippy
-# covers them.
+# covers them. The core's `cargo build --features s3` is also out: it is there
+# to prove a deprecated alias still resolves, which the manifest settles
+# without a whole extra build on every commit.
 # ---------------------------------------------------------------------------
 
-# libviprs has both default-features and `--features pdfium` clippy passes.
+# libviprs lints the default cell and four feature-gated ones. Each of the
+# latter is in CI because the default pass compiles none of that code:
+# object-store-sink (#382), svg (#502) and jxl (#500) are all non-default and
+# all have `#[cfg(test)] mod tests` the default job never sees.
 LIBVIPRS_CARGO_STEPS=(
     "cargo clippy --all-targets -- -D warnings -W clippy::incompatible_msrv -W deprecated"
     "cargo clippy --all-targets --features pdfium -- -D warnings -W clippy::incompatible_msrv -W deprecated"
+    "cargo clippy --all-targets --features object-store-sink -- -D warnings -W clippy::incompatible_msrv -W deprecated"
+    "cargo clippy --all-targets --features svg -- -D warnings -W clippy::incompatible_msrv -W deprecated"
+    "cargo clippy --all-targets --features jxl -- -D warnings -W clippy::incompatible_msrv -W deprecated"
 )
 
 # libviprs-cli has no `pdfium` feature; one clippy pass.
@@ -59,18 +74,22 @@ LIBVIPRS_CLI_CARGO_STEPS=(
 )
 
 # libviprs-tests CI is plainer — no incompatible_msrv / deprecated lints.
-# These mirror the ci.yml jobs one-for-one so the enforced local mirror
-# compiles and lints every feature cell, not just the default one. Without
-# the per-feature passes a regression in the s3 / packfile / tracing gated
-# modules ships green locally because the default harness never compiles that
-# code (the failure #55 targets). The ported step is scoped through
+# These mirror the ci.yml `feature-cells` matrix one-for-one so the enforced
+# local mirror compiles and lints every feature cell, not just the default
+# one. Without the per-feature passes a regression in the object-store-sink /
+# packfile / tracing / jxl gated modules ships green locally because the
+# default harness never compiles that code (the failure #55 targets). `s3`
+# stood here in place of `object-store-sink` for a while, which is the same
+# feature under a deprecated alias, so the `jxl` cell was the one going
+# unlinted (libviprs/libviprs#715). The ported step is scoped through
 # tools/run_ported_cells.sh because the three deferred codec cells do not
 # compile yet (issue #77), so `--all-targets` cannot carry that feature.
 LIBVIPRS_TESTS_CARGO_STEPS=(
     "cargo clippy --all-targets -- -D warnings"
-    "cargo clippy --all-targets --features s3 -- -D warnings"
+    "cargo clippy --all-targets --features object-store-sink -- -D warnings"
     "cargo clippy --all-targets --features packfile -- -D warnings"
     "cargo clippy --all-targets --features tracing -- -D warnings"
+    "cargo clippy --all-targets --features jxl -- -D warnings"
     "./tools/run_ported_cells.sh --clippy"
 )
 


### PR DESCRIPTION
Stacked on #173, and it came out of it. libviprs/libviprs#695 names this in its "Related" section, and I hit the measurement while reading the step lists.

`tools/install-hooks.sh` said its pre-commit hook "Mirrors each repo's `.github/workflows/ci.yml` Check & Lint job *exactly*, so a clean local commit means a clean remote Check & Lint", then asked a human to keep the per-repo cargo step lists in lockstep by hand. Nothing checked it and it had drifted.

## What was missing, measured

| repo | CI lints | the hook ran | missing |
|---|---|---|---|
| libviprs | default, `pdfium`, `object-store-sink`, `svg`, `jxl` | default, `pdfium` | **3 of 5** |
| libviprs-tests | default, `object-store-sink`, `packfile`, `tracing`, `jxl`, ported cells | default, `s3`, `packfile`, `tracing`, ported cells | **`jxl`**, and `s3` is a deprecated alias for the `object-store-sink` cell |
| libviprs-cli | default | default | none |

Every one of those per-feature passes is in CI because the default one compiles none of that code, each with an issue number on it: `object-store-sink` #382, `svg` #502, `jxl` #500, and libviprs-tests#55 for the class. So a commit that broke `src/svg.rs` or `src/jxl.rs` in the core passed the local hook and failed CI, which is the failure the hook was written to prevent.

## The guard runs the hook, it does not read it

`tests/install_hooks_mirror_ci.rs` installs into a throwaway workspace with the real installer, puts a recording stand-in for `cargo` first on `PATH` and one for `run_ported_cells.sh` in the repo, runs the generated pre-commit hook, and collects the invocations it actually makes. Then it compares that set to the `cargo clippy` / `cargo fmt` / `run_ported_cells.sh --clippy` lines in that repo's `ci.yml`, feature matrix expanded. Set equality, so it catches a hook that lost a pass *and* a hook that keeps one CI dropped.

`cargo check` and `cargo build` lines stay out of the comparison. The step list's own comment says clippy does `cargo check`'s work, and the core's `cargo build --features s3` is there to prove a deprecated alias still resolves, which the manifest settles without a whole extra build on every commit.

## A hole I found in my own guard

The cli arm was silently skipping. `cli_dir()` resolves to `../libviprs-cli`, which is not laid down by the default `test` job, by the Docker gate, or in a lane worktree, so `the_hook_lints_the_cli_the_way_its_ci_does` was reporting green having compared nothing. Emptying `LIBVIPRS_CLI_CARGO_STEPS` entirely did not move it (P7 below, first run).

So the `cli-differential` job now runs `--test install_hooks_mirror_ci` alongside the 18 differential binaries. That job lays the cli down at `CLI_COUNTERPART_REV` and sets `VIPRS_REQUIRE_CLI=1`, which is the repo's existing false-green guard: `require_cli()` turns the skip into a panic there and leaves it a clean skip everywhere else. With the cli laid down, P7 goes red.

## Mutation table

Applied, measured, reverted. `git status` clean afterwards. The cli rows run with `VIPRS_CLI_DIR` pointed at the real cli checkout and `VIPRS_REQUIRE_CLI=1`, which is what the `cli-differential` job does.

| # | mutation | guard | result |
|---|---|---|---|
| P1 | drop the `jxl` cell from this repo's list (half of what the issue measured) | `the_hook_lints_this_repo_the_way_its_ci_does` | **RED** |
| P2 | drop the `svg` cell from the core's list (the #502 pass) | `the_hook_lints_the_core_the_way_its_ci_does` | **RED** |
| P3 | put `s3` back in place of `object-store-sink`, exactly as it was | `the_hook_lints_this_repo_the_way_its_ci_does` | **RED** |
| P4 | add a pass CI does not run | `the_hook_lints_this_repo_the_way_its_ci_does` | **RED** |
| P5 | stop running `cargo fmt` in the hook | `the_hook_lints_this_repo_the_way_its_ci_does` | **RED** |
| P6 | CI loses a matrix cell the hook still runs (mutate `ci.yml`, not the hook) | `the_hook_lints_this_repo_the_way_its_ci_does` | **RED** |
| P7 | drop the cli's only clippy pass, cli laid down | `the_hook_lints_the_cli_the_way_its_ci_does` | **RED** |
| P7 | the same, cli **not** laid down, before the `cli-differential` wiring | `the_hook_lints_the_cli_the_way_its_ci_does` | GREEN, which is why the wiring is in this PR |
| P8 | hide the cli and demand it (`VIPRS_CLI_DIR=/nonexistent VIPRS_REQUIRE_CLI=1`) | `the_hook_lints_the_cli_the_way_its_ci_does` | **RED** |
| P8b | the same skip without `VIPRS_REQUIRE_CLI`, which is the Docker gate and every dev machine | `the_hook_lints_the_cli_the_way_its_ci_does` | GREEN, as it has to be |

## Gate

```
cargo fmt -- --check                                              clean
shellcheck tools/*.sh tools/hooks/pre-push                        clean
RUSTFLAGS="-Dwarnings" cargo clippy --all-targets -- -D warnings   silent
cargo test                                                        772 passed, 0 failed, 11 ignored
```

772 against 769 on #173, the three new guards. The workflow pinning guards (`counterpart_pinning`, `cli_counterpart_pinning`, `pdfium_ci_policy`, `pdfium_provenance`) all still pass over the edited `ci.yml`.

One thing to know before merging: this makes the local pre-commit hook slower, by three extra clippy passes in the core and one here. That is the cost of the hook telling the truth, and it is paid on commit rather than on push, where #683 just finished cutting the expensive one.

Closes libviprs/libviprs#715
