### PR TITLE
test(cli, resample): tighten the tolerances #668 was hiding behind, and stop calling it a design decision

### DIFF
--- a/tests/cli_resample_diff.rs
+++ b/tests/cli_resample_diff.rs
@@ -9,14 +9,43 @@
 //! exactly — including the skip-guard / `VIPRS_REQUIRE_CLI` discipline.
 //!
 //! **Every resample op is oracle class BOUNDED-TOL** (the premultiply / rounding
-//! campaign #406-418): the core computes the reduce / interpolate masks in `f64`
-//! per output position while vips quantises the sub-pixel offset into fixed-point
-//! tables, so the two agree to ≤1 LSB. The MEASURED per-case max-abs-diff (see
-//! PROVENANCE.md) is 0 or 1 for every case **except** `affine … --interpolate
-//! bicubic`, which measures **2 LSB**: the core evaluates exact f64 Catmull-Rom
-//! coefficients while vips's `VipsInterpolateBicubic` uses a coarser fixed-point
-//! table, a genuine core-vs-vips rounding difference (not a CLI bug) compared at
-//! tol 2 with a documented open question.
+//! campaign #406-418), and since libviprs#668 the reason is a narrower one than
+//! this header used to give. The core no longer evaluates the reduce and
+//! bicubic kernels at the true sub-pixel offset. `table_offset` rounds the
+//! offset onto the same 65-entry grid `vips_reduceh` and
+//! `vips_interpolate_bicubic_interpolate` round onto, so the offset is not a
+//! source of divergence on either side any more.
+//!
+//! Two smaller things are left, and both have an issue of their own. On the
+//! integer carriers vips quantises the coefficients themselves, `matrixs` in
+//! reduce and `matrixi` in bicubic, where the core stays in f64
+//! (libviprs#704). And `bicubic_float` sums four rows and then the columns
+//! while the core runs one 16-term sum, which reassociates the same products
+//! and moves the last bit (libviprs#705). Together they are worth ≤1 LSB on a
+//! uchar carrier, and they are what the nine cells measuring 1 are made of.
+//!
+//! **What this header said before, and why it mattered.** It said the core
+//! computed the masks in `f64` per output position "so the two agree to ≤1
+//! LSB", and `AFFINE_BICUBIC_TOL = 2.0` said the same thing again about the
+//! interpolator. That is the divergence libviprs#668 turned out to be, written
+//! down as a design decision in two places across two repos, and it is a fair
+//! part of why the bug lasted. Both are gone.
+//!
+//! **What is pinned, and what deliberately is not** (measured in
+//! libviprs#723). After libviprs#702 thirteen of the 22 comparison cells
+//! measure 0 and nine measure 1. Six mutations of the resampling offset, from
+//! reverting it outright to coarsening the grid four times over, move exactly
+//! two cells: `resize --vscale 0.75` and `affine … --interpolate bicubic`.
+//! Those two are pinned at what they measure, 0 and 1. The other twelve zeroes
+//! stay at ≤1, because no mutation of the offset separates 0 from 1 on them, so
+//! pinning them would buy no falsifiability and cost a vips-version tripwire.
+//!
+//! **The reduce half of libviprs#668 has no guard here at all**, and no
+//! tolerance can give it one. `resize --vscale 0.75` is the right op at the
+//! right factor and it reads 0 before the fix, after it, and with the fix
+//! reverted: on a float `.v` the two cores differ, on the committed PNG they
+//! are byte-identical, so the difference rounds away below an LSB. That wants a
+//! float-carrier cell and a new committed reference, which is libviprs#724.
 //!
 //! Inputs are DISCRIMINATING (an identity / no-op op would FAIL): `grad.png` is a
 //! 2-D gradient varying in BOTH axes (so `shrinkv`/`reducev`/`rot` are

--- a/tests/cli_resample_diff.rs
+++ b/tests/cli_resample_diff.rs
@@ -49,14 +49,17 @@ use common::cli::{cli_available, cli_fixture, decode_compare, run_viprs, run_vip
 
 use tempfile::TempDir;
 
-/// BOUNDED-TOL ≤1 LSB (CLI_CONTRACT.md §5): the core's f64 masks vs vips's
-/// fixed-point quantisation agree to within one least-significant bit.
+/// BOUNDED-TOL ≤1 LSB (CLI_CONTRACT.md §5): what is left of the core-vs-vips
+/// difference once both sides round the sub-pixel offset onto the same grid.
+/// The residual is the coefficient tables on the integer carriers
+/// (libviprs#704) plus the bicubic accumulation order (libviprs#705).
 const BT1: f64 = 1.0;
 
-/// The one measured exception: `affine … --interpolate bicubic` lands 2 LSB from
-/// vips because the core uses exact f64 Catmull-Rom coefficients while vips uses a
-/// coarser fixed-point table (see the module header + PROVENANCE open question).
-const AFFINE_BICUBIC_TOL: f64 = 2.0;
+/// Bit-exact. Only `resize --vscale 0.75` is held here, and only because it is
+/// the one cell besides `affine … bicubic` that a wrong resampling offset moves
+/// (libviprs#723). Twelve more cells measure 0, and they stay at [`BT1`]
+/// because no mutation of the offset separates 0 from 1 on them.
+const EXACT: f64 = 0.0;
 
 /// Skip-guard: `true` (with a printed reason) when the CLI sibling is absent.
 /// Under `$VIPRS_REQUIRE_CLI=1` an absent sibling PANICS inside [`cli_available`]
@@ -221,17 +224,22 @@ fn resize_half_matches_vips_bounded_tol() {
 }
 
 #[test]
-fn resize_vscale_matches_vips_bounded_tol() {
+fn resize_vscale_matches_vips_exactly() {
     if skip_if_no_cli("resize_vscale") {
         return;
     }
     let out = op("resize_vscale.png");
-    // --vscale gives the two axes DIFFERENT scales (a non-square resize).
+    // --vscale gives the two axes DIFFERENT scales (a non-square resize), and
+    // 0.75 is the only NON-DYADIC factor in this file: 32x32 to 16x24, vertical
+    // residual shrink 4/3, an offset that lands off the 1/64 grid at every
+    // output row. MEASURED 0. It is pinned at 0 rather than at BT1 because a
+    // resampling offset rounded onto the wrong grid moves it to 1
+    // (libviprs#723), so ≤1 here absorbs the one regression it exists to catch.
     run_viprs_ok(&["resize", &fx(RGB), &out, "0.5", "--vscale", "0.75"]);
     decode_compare(
         &PathBuf::from(&out),
         &cli_fixture("resample/resize_vscale_expected.png"),
-        BT1,
+        EXACT,
     );
 }
 
@@ -267,8 +275,8 @@ fn resize_nearest_matches_vips_bounded_tol() {
 }
 
 // ---------------------------------------------------------------------------
-// affine — S1 matrix transform. Bilinear (default) is ≤1 LSB; bicubic measures
-// 2 LSB (an HONEST core-vs-vips divergence, compared at tol 2 — see header).
+// affine — S1 matrix transform. Both interpolators measure 1 LSB. Bicubic used
+// to measure 2, and that 2 was libviprs#668 (see header).
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -287,14 +295,17 @@ fn affine_bilinear_matches_vips_bounded_tol() {
 }
 
 #[test]
-fn affine_bicubic_matches_vips_at_two_lsb() {
+fn affine_bicubic_matches_vips_bounded_tol() {
     if skip_if_no_cli("affine_bicubic") {
         return;
     }
     let out = op("affine_bicubic.png");
-    // --interpolate bicubic is the ONE resample case that exceeds 1 LSB (measured
-    // 2): exact f64 Catmull-Rom (core) vs vips's fixed-point coefficient table.
-    // Honest, non-rigged — compared at the measured tol 2, NOT hidden.
+    // This used to be the ONE resample case that exceeded 1 LSB, at a measured
+    // 2, and the reason given for it was the divergence libviprs#668 turned out
+    // to be. It MEASURES 1 once the core rounds the bicubic offset onto vips's
+    // grid, and 2 again if that is reverted, so BT1 is what makes this cell able
+    // to tell the two apart. It NEEDS core libviprs#702: against a core without
+    // it this is red, which is the point.
     run_viprs_ok(&[
         "affine",
         &fx(RGB),
@@ -306,7 +317,7 @@ fn affine_bicubic_matches_vips_at_two_lsb() {
     decode_compare(
         &PathBuf::from(&out),
         &cli_fixture("resample/affine_bicubic_expected.png"),
-        AFFINE_BICUBIC_TOL,
+        BT1,
     );
 }
 

--- a/tests/fixtures/cli/PROVENANCE.md
+++ b/tests/fixtures/cli/PROVENANCE.md
@@ -1158,11 +1158,11 @@ References (paths relative to `tests/fixtures/cli/`):
 | `resample/reduceh_expected.png` | ≤1 LSB (1) | `vips reduceh grad.png reduceh_expected.png 2` |
 | `resample/reducev_expected.png` | ≤1 LSB (1) | `vips reducev grad.png reducev_expected.png 2` |
 | `resample/resize_half_expected.png` | ≤1 LSB (0) | `vips resize rgb.png resize_half_expected.png 0.5` |
-| `resample/resize_vscale_expected.png` | ≤1 LSB (0) | `vips resize rgb.png resize_vscale_expected.png 0.5 --vscale 0.75` |
+| `resample/resize_vscale_expected.png` | **EXACT (0)** | `vips resize rgb.png resize_vscale_expected.png 0.5 --vscale 0.75` |
 | `resample/resize_up_expected.png` | ≤1 LSB (1) | `vips resize grad.png resize_up_expected.png 2.0` (upscale → affine path) |
 | `resample/resize_nearest_expected.png` | ≤1 LSB (0) | `vips resize rgb.png resize_nearest_expected.png 0.5 --kernel nearest` |
 | `resample/affine_bilinear_expected.png` | ≤1 LSB (1) | `vips affine rgb.png affine_bilinear_expected.png "1.5 0 0 1.5"` (default bilinear) |
-| `resample/affine_bicubic_expected.png` | **2 LSB (2)** | `vips affine rgb.png affine_bicubic_expected.png "1.5 0 0 1.5" --interpolate bicubic` (bicubic quantises to 2 LSB — noted divergence) |
+| `resample/affine_bicubic_expected.png` | ≤1 LSB (1) | `vips affine rgb.png affine_bicubic_expected.png "1.5 0 0 1.5" --interpolate bicubic` (was 2 before libviprs#702 rounded the bicubic offset onto vips's grid) |
 | `resample/similarity_angle_expected.png` | ≤1 LSB (1) | `vips similarity rgb.png similarity_angle_expected.png --angle 30` |
 | `resample/similarity_scale_expected.png` | ≤1 LSB (1) | `vips similarity rgb.png similarity_scale_expected.png --scale 1.5` |
 | `resample/rotate_expected.png` | ≤1 LSB (1) | `vips rotate rgb.png rotate_expected.png 30` |
@@ -1170,7 +1170,7 @@ References (paths relative to `tests/fixtures/cli/`):
 | `resample/mapim_bicubic_expected.png` | ≤1 LSB (1) | `vips mapim rgb.png mapim_bicubic_expected.png index.v --interpolate bicubic` |
 | `resample/thumbnail_expected.png` | ≤1 LSB (0) | `vips thumbnail rgb.png thumbnail_expected.png 16` (FILENAME input) |
 | `resample/thumbnail_crop_expected.png` | ≤1 LSB (0) | `vips thumbnail rgb.png thumbnail_crop_expected.png 16 --height 8 --crop centre` (NON-square target — centre-crop removes pixels, 16×8, distinct from the no-crop fixtures) |
-| `resample/thumbnail_linear_expected.png` | ≤1 LSB (1) | `vips thumbnail rgb.png thumbnail_linear_expected.png 16 --linear` (linear-light reduce path) |
+| `resample/thumbnail_linear_expected.png` | ≤1 LSB (0) | `vips thumbnail rgb.png thumbnail_linear_expected.png 16 --linear` (linear-light reduce path) |
 | `resample/thumbnail_image_expected.png` | ≤1 LSB (0) | `vips thumbnail_image rgb.png thumbnail_image_expected.png 16` |
 
 **Open question**: `affine … --interpolate bicubic` measures **2 LSB** (not the

--- a/tools/gen_cli_expected.sh
+++ b/tools/gen_cli_expected.sh
@@ -3447,11 +3447,11 @@ References (paths relative to \`tests/fixtures/cli/\`):
 | \`resample/reduceh_expected.png\` | ≤1 LSB (1) | \`vips reduceh grad.png reduceh_expected.png 2\` |
 | \`resample/reducev_expected.png\` | ≤1 LSB (1) | \`vips reducev grad.png reducev_expected.png 2\` |
 | \`resample/resize_half_expected.png\` | ≤1 LSB (0) | \`vips resize rgb.png resize_half_expected.png 0.5\` |
-| \`resample/resize_vscale_expected.png\` | ≤1 LSB (0) | \`vips resize rgb.png resize_vscale_expected.png 0.5 --vscale 0.75\` |
+| \`resample/resize_vscale_expected.png\` | **EXACT (0)** | \`vips resize rgb.png resize_vscale_expected.png 0.5 --vscale 0.75\` |
 | \`resample/resize_up_expected.png\` | ≤1 LSB (1) | \`vips resize grad.png resize_up_expected.png 2.0\` (upscale → affine path) |
 | \`resample/resize_nearest_expected.png\` | ≤1 LSB (0) | \`vips resize rgb.png resize_nearest_expected.png 0.5 --kernel nearest\` |
 | \`resample/affine_bilinear_expected.png\` | ≤1 LSB (1) | \`vips affine rgb.png affine_bilinear_expected.png "1.5 0 0 1.5"\` (default bilinear) |
-| \`resample/affine_bicubic_expected.png\` | **2 LSB (2)** | \`vips affine rgb.png affine_bicubic_expected.png "1.5 0 0 1.5" --interpolate bicubic\` (bicubic quantises to 2 LSB — noted divergence) |
+| \`resample/affine_bicubic_expected.png\` | ≤1 LSB (1) | \`vips affine rgb.png affine_bicubic_expected.png "1.5 0 0 1.5" --interpolate bicubic\` (was 2 before libviprs#702 rounded the bicubic offset onto vips's grid) |
 | \`resample/similarity_angle_expected.png\` | ≤1 LSB (1) | \`vips similarity rgb.png similarity_angle_expected.png --angle 30\` |
 | \`resample/similarity_scale_expected.png\` | ≤1 LSB (1) | \`vips similarity rgb.png similarity_scale_expected.png --scale 1.5\` |
 | \`resample/rotate_expected.png\` | ≤1 LSB (1) | \`vips rotate rgb.png rotate_expected.png 30\` |
@@ -3459,7 +3459,7 @@ References (paths relative to \`tests/fixtures/cli/\`):
 | \`resample/mapim_bicubic_expected.png\` | ≤1 LSB (1) | \`vips mapim rgb.png mapim_bicubic_expected.png index.v --interpolate bicubic\` |
 | \`resample/thumbnail_expected.png\` | ≤1 LSB (0) | \`vips thumbnail rgb.png thumbnail_expected.png 16\` (FILENAME input) |
 | \`resample/thumbnail_crop_expected.png\` | ≤1 LSB (0) | \`vips thumbnail rgb.png thumbnail_crop_expected.png 16 --height 8 --crop centre\` (NON-square target — centre-crop removes pixels, 16×8, distinct from the no-crop fixtures) |
-| \`resample/thumbnail_linear_expected.png\` | ≤1 LSB (1) | \`vips thumbnail rgb.png thumbnail_linear_expected.png 16 --linear\` (linear-light reduce path) |
+| \`resample/thumbnail_linear_expected.png\` | ≤1 LSB (0) | \`vips thumbnail rgb.png thumbnail_linear_expected.png 16 --linear\` (linear-light reduce path) |
 | \`resample/thumbnail_image_expected.png\` | ≤1 LSB (0) | \`vips thumbnail_image rgb.png thumbnail_image_expected.png 16\` |
 
 **Open question**: \`affine … --interpolate bicubic\` measures **2 LSB** (not the


### PR DESCRIPTION
> ## Do not merge before core libviprs/libviprs#702
>
> Against core `main` the bicubic cell measures 2 and this branch asserts 1, so the harness is red until #702 lands. That is the evidence, not an accident: it is the same assertion that says the fix is needed. Merge order is #702 first, then this.

Stacked on #174.

`tests/cli_resample_diff.rs` wrote the sub-pixel resampling divergence down as a design decision, in the module header and again in `AFFINE_BICUBIC_TOL = 2.0`. #702 (issue #668) makes it false in the other direction: `resize`, `reduce` and bicubic `affine` now round the offset onto libvips' 65-entry grid through `table_offset`. #702 flagged the prose and deliberately left it alone, saying the numbers wanted a fresh measurement rather than a guess. So I measured.

## How

Two copies of `libviprs-cli`, one built against core `main` at `120acb6` and one against `fix/668-resize-nondyadic` at `f15ff00`, each reaching its core through a sibling symlink so neither checkout was written to. Every `decode_compare` cell in the file run through a throwaway harness that reports `max_abs_diff` instead of asserting on it. Then six more cores, each a scratch copy of #702's branch with one thing changed:

| | mutation |
|---|---|
| r1 | both call sites back to the exact offset, which is #668 fully reverted |
| r2 | the `reduce_axis` call site only |
| r3 | the `Interpolator::Bicubic` call sites only |
| r4 | grid coarsened from 1/64 to 1/32 |
| r5 | `table_offset` truncating where it floors (#702's M3) |
| r6 | grid coarsened to 1/16 |

r1 uses the verbatim `3801cd1` lines, `kernel.mask(&mut c, shrink, x - x.floor())` and `catmull_coefficients(&mut cx, x - x0 as f64)`. My first attempt at r1 passed the whole coordinate instead of its fractional part and produced max-abs-diffs around 250, which is how I know it was wrong rather than a revert.

## What every cell measures

Max-abs-diff against the committed vips 8.18.4 reference. `bef` is core `main`, `aft` is #702.

| cell | old tol | bef | aft | r1 | r2 | r3 | r4 | r5 | r6 |
|---|---|---|---|---|---|---|---|---|---|
| `shrink 2 2` | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| `shrinkh 2` | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| `shrinkv 2` | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| `reduce lanczos3 2 2` | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| `reduce cubic 2 2` | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| `reduceh 2` | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 |
| `reducev 2` | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 |
| `resize 0.5` | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| **`resize 0.5 --vscale 0.75`** | 1 | 0 | 0 | 0 | 0 | 0 | **1** | 0 | **1** |
| `resize 2.0` | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 |
| `resize 0.5 --kernel nearest` | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| `affine 1.5 bilinear` | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 |
| **`affine 1.5 bicubic`** | **2** | **2** | **1** | **2** | 1 | **2** | **7** | 1 | **7** |
| `similarity --angle 30` | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 |
| `similarity --scale 1.5` | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 |
| `rotate 30` | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 |
| `mapim bilinear` | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| `mapim bicubic` | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1 |
| `thumbnail 16` | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| `thumbnail 16 --height 8 --crop centre` | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| `thumbnail 16 --linear` | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
| `thumbnail_image 16` | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |

Two cells move under anything. Everything else in the file is blind to the resampling offset, including a grid coarsened four times over.

## The old tolerances were absorbing a real difference

This is the row that matters. Same harness, tolerances as committed on `main` versus tolerances as on this branch, run against five cores. `RED` names the cells that fail.

| tolerances | core `main` | core #702 | r1 (#668 reverted) | r3 (bicubic reverted) | r4 (grid 1/32) |
|---|---|---|---|---|---|
| **old** (`vscale` ≤1, bicubic ≤2) | PASS | PASS | **PASS** | **PASS** | RED bicubic |
| **new** (`vscale` 0, bicubic ≤1) | RED bicubic | PASS | RED bicubic | RED bicubic | RED bicubic, RED vscale |

At the committed tolerances the whole 22-cell file passes against a core with #668 completely reverted. It could not tell #702 from the bug it fixes.

## Mutation table, one tightening at a time

Each tightening on its own, to show neither is carried by the other.

| # | mutation | effect |
|---|---|---|
| T1 | loosen `affine_bicubic` back to 2.0, keep `vscale` at 0 | r1 and r3 go **green again**, so the bicubic tightening is the whole of that guard |
| T2 | loosen `resize_vscale` back to `BT1`, keep bicubic at 1 | r4 stops reporting `resize_vscale`, so the vscale tightening is the whole of that guard |
| T3 | both loosened (the state on `main`) | every core passes except r4 |

Reverted after each; `git status` clean.

## What I did not tighten, and why

Thirteen cells measure 0 and I pinned one. No mutation of the resampling offset, up to r6, separates 0 from 1 on the other twelve, so pinning them would carry no information and would add a vips-version tripwire across a third of the file. That is in the header too, so the next person does not read the twelve `BT1`s as an oversight.

## The finding I would rather not have had

The review expected `resize --vscale 0.75` to be absorbing the divergence. It is not. It is the right op at the right factor, 32x32 to 16x24, vertical residual 4/3, exactly what #702 measures at 6144/9216 samples differing, and it reads **0 before the fix, 0 after it, and 0 with the fix fully reverted**. The carrier is why:

```
float .v carrier    the two binaries DIFFER
uchar PNG carrier   the two binaries are byte-identical
```

Below an LSB once it is rounded into a byte. So **the reduce half of #668 has no guard in this file and no tolerance can give it one**. Pinning that cell at 0 is still worth doing, because a wrong grid does move it, but it does not catch a straight revert and the header says so rather than implying otherwise. The float-carrier cell that would catch it needs a new committed reference, which runs into the 8.18.4 oracle pin, so it is libviprs/libviprs#724 rather than folded in here.

## Folded in

`PROVENANCE.md` recorded `thumbnail_linear_expected.png` at `≤1 LSB (1)`. It measures **0** on all seven cores I built. One row, corrected, in both `PROVENANCE.md` and the `gen_cli_expected.sh` line that emits it, so a regeneration does not put it back.

## Gate

```
cargo fmt -- --check                                              clean
shellcheck tools/*.sh tools/hooks/pre-push                        clean
RUSTFLAGS="-Dwarnings" cargo clippy --all-targets -- -D warnings   silent
cargo test                                                        772 passed, 0 failed, 11 ignored
```

Unchanged from #174, because the 24 resample cells skip locally without a `../libviprs-cli` sibling. The numbers that matter come from running them explicitly:

```
VIPRS_BIN=<built against core main>  VIPRS_REQUIRE_CLI=1  cargo test --test cli_resample_diff
  -> 23 passed, 1 failed: affine_bicubic, max-abs-diff 2 > tol 1

VIPRS_BIN=<built against #702>       VIPRS_REQUIRE_CLI=1  cargo test --test cli_resample_diff
  -> 24 passed, 0 failed
```

Neither core checkout was written to at any point: every build went through a scratch copy or a symlinked sibling, and `git status` in both is clean.

Closes libviprs/libviprs#723
