### PR TITLE
hooks, resample: land the checked-in pre-push hook, the honest pre-commit mirror, and the tightened resample tolerances

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,3 +131,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt -- --check
       - run: cargo clippy --all-targets -- -D warnings
+      # The pre-push hook is a real file rather than a heredoc inside
+      # install-hooks.sh (libviprs/libviprs#695), so it gets linted like the
+      # rest of the shell. shellcheck ships on the ubuntu-latest image.
+      - run: shellcheck tools/*.sh tools/hooks/pre-push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,11 @@ jobs:
       # hard panic, so this job can never go green without actually running viprs.
       - env:
           VIPRS_REQUIRE_CLI: 1
-        run: cargo test --test cli_morphology_diff --test cli_bands_diff --test cli_extract_diff --test cli_conversion_diff --test cli_core_diff --test cli_convolution_diff --test cli_matrix_diff --test cli_colour_diff --test cli_resample_diff --test cli_histogram_diff --test cli_composite_diff --test cli_freqfilt_diff --test cli_mosaicing_diff --test cli_create_diff --test cli_draw_diff --test cli_aritha_diff --test cli_arithb_diff --test cli_iocleanup_diff
+        # install_hooks_mirror_ci's cli arm is the only place the cli's
+        # pre-commit hook is compared against the cli's own CI, and it can only
+        # run where the sibling is laid down, which is here
+        # (libviprs/libviprs#715).
+        run: cargo test --test install_hooks_mirror_ci --test cli_morphology_diff --test cli_bands_diff --test cli_extract_diff --test cli_conversion_diff --test cli_core_diff --test cli_convolution_diff --test cli_matrix_diff --test cli_colour_diff --test cli_resample_diff --test cli_histogram_diff --test cli_composite_diff --test cli_freqfilt_diff --test cli_mosaicing_diff --test cli_create_diff --test cli_draw_diff --test cli_aritha_diff --test cli_arithb_diff --test cli_iocleanup_diff
 
   lint:
     name: Lint

--- a/README.md
+++ b/README.md
@@ -151,7 +151,14 @@ into the two the suite can see:
 
 **Pre-commit** (runs on every `git commit`):
 - `cargo fmt -- --check` — rejects unformatted code
-- `cargo clippy --all-targets -- -D warnings` — rejects lint warnings
+- Every `cargo clippy` pass that repo's `ci.yml` runs, feature matrix
+  expanded, so a feature-gated regression cannot pass locally and fail
+  remotely. For this repo that is the default cell plus `object-store-sink`,
+  `packfile`, `tracing` and `jxl`, then `./tools/run_ported_cells.sh --clippy`.
+- The lockstep is enforced rather than asked for:
+  `tests/install_hooks_mirror_ci.rs` runs the generated hook with a recording
+  stand-in for `cargo` and compares what it invokes against the workflow
+  (libviprs/libviprs#715).
 
 **Pre-push** (libviprs and libviprs-tests only; runs on `git push`, when the
 push can reach the suite):

--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ into the two the suite can see:
 
 **Pre-push** (libviprs and libviprs-tests only; runs on `git push`, when the
 push can reach the suite):
+- The hook is `tools/hooks/pre-push`, a tracked file. What lands in
+  `.git/hooks/pre-push` is a shim that runs it, so a `git pull` here updates
+  the hook in every repo at once and no clone is left running a vintage nobody
+  can name (libviprs/libviprs#695). Re-run `install-hooks.sh` only when the
+  workspace layout moves. A harness push runs the hook out of the tree it is
+  pushing, so a change to the hook is gated by the changed hook.
 - Runs the Docker test suite via `run-tests.sh`, against the working tree being
   pushed. A linked worktree gates on its own branch, not on the main checkout
   (libviprs/libviprs#684).
@@ -302,6 +308,7 @@ libviprs-tests/
 ├── Dockerfile
 ├── README.md
 ├── tools/
+│   ├── hooks/pre-push
 │   ├── install-hooks.sh
 │   └── run-tests.sh
 ├── .github/

--- a/tests/cli_resample_diff.rs
+++ b/tests/cli_resample_diff.rs
@@ -9,14 +9,43 @@
 //! exactly — including the skip-guard / `VIPRS_REQUIRE_CLI` discipline.
 //!
 //! **Every resample op is oracle class BOUNDED-TOL** (the premultiply / rounding
-//! campaign #406-418): the core computes the reduce / interpolate masks in `f64`
-//! per output position while vips quantises the sub-pixel offset into fixed-point
-//! tables, so the two agree to ≤1 LSB. The MEASURED per-case max-abs-diff (see
-//! PROVENANCE.md) is 0 or 1 for every case **except** `affine … --interpolate
-//! bicubic`, which measures **2 LSB**: the core evaluates exact f64 Catmull-Rom
-//! coefficients while vips's `VipsInterpolateBicubic` uses a coarser fixed-point
-//! table, a genuine core-vs-vips rounding difference (not a CLI bug) compared at
-//! tol 2 with a documented open question.
+//! campaign #406-418), and since libviprs#668 the reason is a narrower one than
+//! this header used to give. The core no longer evaluates the reduce and
+//! bicubic kernels at the true sub-pixel offset. `table_offset` rounds the
+//! offset onto the same 65-entry grid `vips_reduceh` and
+//! `vips_interpolate_bicubic_interpolate` round onto, so the offset is not a
+//! source of divergence on either side any more.
+//!
+//! Two smaller things are left, and both have an issue of their own. On the
+//! integer carriers vips quantises the coefficients themselves, `matrixs` in
+//! reduce and `matrixi` in bicubic, where the core stays in f64
+//! (libviprs#704). And `bicubic_float` sums four rows and then the columns
+//! while the core runs one 16-term sum, which reassociates the same products
+//! and moves the last bit (libviprs#705). Together they are worth ≤1 LSB on a
+//! uchar carrier, and they are what the nine cells measuring 1 are made of.
+//!
+//! **What this header said before, and why it mattered.** It said the core
+//! computed the masks in `f64` per output position "so the two agree to ≤1
+//! LSB", and `AFFINE_BICUBIC_TOL = 2.0` said the same thing again about the
+//! interpolator. That is the divergence libviprs#668 turned out to be, written
+//! down as a design decision in two places across two repos, and it is a fair
+//! part of why the bug lasted. Both are gone.
+//!
+//! **What is pinned, and what deliberately is not** (measured in
+//! libviprs#723). After libviprs#702 thirteen of the 22 comparison cells
+//! measure 0 and nine measure 1. Six mutations of the resampling offset, from
+//! reverting it outright to coarsening the grid four times over, move exactly
+//! two cells: `resize --vscale 0.75` and `affine … --interpolate bicubic`.
+//! Those two are pinned at what they measure, 0 and 1. The other twelve zeroes
+//! stay at ≤1, because no mutation of the offset separates 0 from 1 on them, so
+//! pinning them would buy no falsifiability and cost a vips-version tripwire.
+//!
+//! **The reduce half of libviprs#668 has no guard here at all**, and no
+//! tolerance can give it one. `resize --vscale 0.75` is the right op at the
+//! right factor and it reads 0 before the fix, after it, and with the fix
+//! reverted: on a float `.v` the two cores differ, on the committed PNG they
+//! are byte-identical, so the difference rounds away below an LSB. That wants a
+//! float-carrier cell and a new committed reference, which is libviprs#724.
 //!
 //! Inputs are DISCRIMINATING (an identity / no-op op would FAIL): `grad.png` is a
 //! 2-D gradient varying in BOTH axes (so `shrinkv`/`reducev`/`rot` are

--- a/tests/cli_resample_diff.rs
+++ b/tests/cli_resample_diff.rs
@@ -49,14 +49,17 @@ use common::cli::{cli_available, cli_fixture, decode_compare, run_viprs, run_vip
 
 use tempfile::TempDir;
 
-/// BOUNDED-TOL ≤1 LSB (CLI_CONTRACT.md §5): the core's f64 masks vs vips's
-/// fixed-point quantisation agree to within one least-significant bit.
+/// BOUNDED-TOL ≤1 LSB (CLI_CONTRACT.md §5): what is left of the core-vs-vips
+/// difference once both sides round the sub-pixel offset onto the same grid.
+/// The residual is the coefficient tables on the integer carriers
+/// (libviprs#704) plus the bicubic accumulation order (libviprs#705).
 const BT1: f64 = 1.0;
 
-/// The one measured exception: `affine … --interpolate bicubic` lands 2 LSB from
-/// vips because the core uses exact f64 Catmull-Rom coefficients while vips uses a
-/// coarser fixed-point table (see the module header + PROVENANCE open question).
-const AFFINE_BICUBIC_TOL: f64 = 2.0;
+/// Bit-exact. Only `resize --vscale 0.75` is held here, and only because it is
+/// the one cell besides `affine … bicubic` that a wrong resampling offset moves
+/// (libviprs#723). Twelve more cells measure 0, and they stay at [`BT1`]
+/// because no mutation of the offset separates 0 from 1 on them.
+const EXACT: f64 = 0.0;
 
 /// Skip-guard: `true` (with a printed reason) when the CLI sibling is absent.
 /// Under `$VIPRS_REQUIRE_CLI=1` an absent sibling PANICS inside [`cli_available`]
@@ -221,17 +224,22 @@ fn resize_half_matches_vips_bounded_tol() {
 }
 
 #[test]
-fn resize_vscale_matches_vips_bounded_tol() {
+fn resize_vscale_matches_vips_exactly() {
     if skip_if_no_cli("resize_vscale") {
         return;
     }
     let out = op("resize_vscale.png");
-    // --vscale gives the two axes DIFFERENT scales (a non-square resize).
+    // --vscale gives the two axes DIFFERENT scales (a non-square resize), and
+    // 0.75 is the only NON-DYADIC factor in this file: 32x32 to 16x24, vertical
+    // residual shrink 4/3, an offset that lands off the 1/64 grid at every
+    // output row. MEASURED 0. It is pinned at 0 rather than at BT1 because a
+    // resampling offset rounded onto the wrong grid moves it to 1
+    // (libviprs#723), so ≤1 here absorbs the one regression it exists to catch.
     run_viprs_ok(&["resize", &fx(RGB), &out, "0.5", "--vscale", "0.75"]);
     decode_compare(
         &PathBuf::from(&out),
         &cli_fixture("resample/resize_vscale_expected.png"),
-        BT1,
+        EXACT,
     );
 }
 
@@ -267,8 +275,8 @@ fn resize_nearest_matches_vips_bounded_tol() {
 }
 
 // ---------------------------------------------------------------------------
-// affine — S1 matrix transform. Bilinear (default) is ≤1 LSB; bicubic measures
-// 2 LSB (an HONEST core-vs-vips divergence, compared at tol 2 — see header).
+// affine — S1 matrix transform. Both interpolators measure 1 LSB. Bicubic used
+// to measure 2, and that 2 was libviprs#668 (see header).
 // ---------------------------------------------------------------------------
 
 #[test]
@@ -287,14 +295,17 @@ fn affine_bilinear_matches_vips_bounded_tol() {
 }
 
 #[test]
-fn affine_bicubic_matches_vips_at_two_lsb() {
+fn affine_bicubic_matches_vips_bounded_tol() {
     if skip_if_no_cli("affine_bicubic") {
         return;
     }
     let out = op("affine_bicubic.png");
-    // --interpolate bicubic is the ONE resample case that exceeds 1 LSB (measured
-    // 2): exact f64 Catmull-Rom (core) vs vips's fixed-point coefficient table.
-    // Honest, non-rigged — compared at the measured tol 2, NOT hidden.
+    // This used to be the ONE resample case that exceeded 1 LSB, at a measured
+    // 2, and the reason given for it was the divergence libviprs#668 turned out
+    // to be. It MEASURES 1 once the core rounds the bicubic offset onto vips's
+    // grid, and 2 again if that is reverted, so BT1 is what makes this cell able
+    // to tell the two apart. It NEEDS core libviprs#702: against a core without
+    // it this is red, which is the point.
     run_viprs_ok(&[
         "affine",
         &fx(RGB),
@@ -306,7 +317,7 @@ fn affine_bicubic_matches_vips_at_two_lsb() {
     decode_compare(
         &PathBuf::from(&out),
         &cli_fixture("resample/affine_bicubic_expected.png"),
-        AFFINE_BICUBIC_TOL,
+        BT1,
     );
 }
 

--- a/tests/common/hooks.rs
+++ b/tests/common/hooks.rs
@@ -1,15 +1,20 @@
-//! Reads the git hooks `tools/install-hooks.sh` writes, so the guards on them
-//! can assert against the text that actually lands in `.git/hooks/`.
+//! The pre-push hook, and a stand-in workspace for driving it.
 //!
-//! Two suites need this (`prepush_gate_tests_the_pushed_tree` for #684 and
-//! `prepush_gate_cost_controls` for #683) and both used to carry their own
-//! copy, including the heredoc marker string byte for byte. That marker is the
-//! fragile part: change the quoting in `install-hooks.sh` and every copy has to
-//! follow, and the one that does not follow fails with "no longer writes the
-//! pre-push hook from a heredoc" rather than with anything about the change
-//! that broke it. One copy, here.
+//! The hook is a real tracked file, `tools/hooks/pre-push`
+//! (libviprs/libviprs#695). It used to be a heredoc inside
+//! `tools/install-hooks.sh`, which meant the only thing a guard could do with
+//! it was grep it, and two guards that did exactly that passed while the
+//! behaviour they named had been deleted. So nothing here asserts on the
+//! hook's text. [`Workspace`] builds a throwaway workspace of stand-in repos,
+//! runs `tools/install-hooks.sh` in it for real, and drives the installed hook
+//! with a synthetic ref-update on stdin, the way git does.
+//!
+//! Two suites use it: `prepush_gate_tests_the_pushed_tree` for #684 and
+//! `prepush_gate_cost_controls` for #683.
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 /// This crate's root, which is also the repo root for the harness checkout.
 pub fn repo_root() -> PathBuf {
@@ -22,28 +27,354 @@ pub fn read(rel: &str) -> String {
     std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
 }
 
-/// The marker `install-hooks.sh` opens the pre-push heredoc with. Kept as one
-/// constant so the two guards cannot drift apart on it.
-const PRE_PUSH_HEREDOC: &str = "cat > \"$pre_push\" << 'HOOK'\n";
+/// The hook, relative to the repo root.
+pub const PRE_PUSH_HOOK: &str = "tools/hooks/pre-push";
 
-/// The pre-push hook body exactly as `install-hooks.sh` writes it: the heredoc
-/// between `<< 'HOOK'` and the closing `HOOK`. Reading the generated text
-/// rather than the generator keeps the assertions pointed at what actually
-/// lands in `.git/hooks/pre-push`.
-pub fn generated_pre_push() -> String {
-    let script = read("tools/install-hooks.sh");
-    let start = script
-        .find(PRE_PUSH_HEREDOC)
-        .map(|i| i + PRE_PUSH_HEREDOC.len())
-        .expect(
-            "tools/install-hooks.sh no longer writes the pre-push hook from a \
-             `cat > \"$pre_push\" << 'HOOK'` heredoc; update PRE_PUSH_HEREDOC in \
-             tests/common/hooks.rs to follow it rather than deleting the guards \
-             that read it",
+/// The pre-push hook body, read from the file that *is* the hook rather than
+/// from a generator that writes one.
+pub fn pre_push_hook() -> String {
+    let path = repo_root().join(PRE_PUSH_HOOK);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "cannot read {}: {e}\nThe pre-push hook is a tracked file and \
+             tools/install-hooks.sh installs a shim that runs it, rather than \
+             generating a copy of it (libviprs/libviprs#695).",
+            path.display()
+        )
+    })
+}
+
+/// What the stub `run-tests.sh` prints when the hook decides to run the suite.
+pub const RAN_MARKER: &str = "STUB-RAN-THE-SUITE";
+
+/// A stand-in for `run-tests.sh` that reports the environment the hook handed
+/// it, so both halves of a decision (did it run, and what did it run against)
+/// are readable off one push without Docker.
+pub const STUB_RUN_TESTS: &str = r#"#!/bin/sh
+echo "STUB-RAN-THE-SUITE"
+echo "STUB-SCRIPT=$0"
+echo "STUB-LIBVIPRS_DIR=${LIBVIPRS_DIR-unset}"
+echo "STUB-LIBVIPRS_TESTS_DIR=${LIBVIPRS_TESTS_DIR-unset}"
+echo "STUB-GIT_DIR=${GIT_DIR-unset}"
+echo "STUB-GIT_WORK_TREE=${GIT_WORK_TREE-unset}"
+echo "STUB-GIT_INDEX_FILE=${GIT_INDEX_FILE-unset}"
+echo "STUB-GIT_PREFIX=${GIT_PREFIX-unset}"
+echo "STUB-GIT_QUARANTINE_PATH=${GIT_QUARANTINE_PATH-unset}"
+"#;
+
+/// One `STUB-<name>=` line out of what a push printed.
+pub fn reported(out: &str, name: &str) -> String {
+    let prefix = format!("STUB-{name}=");
+    out.lines()
+        .find_map(|line| line.trim().strip_prefix(&prefix))
+        .unwrap_or_else(|| {
+            panic!("the stub suite never reported {name}, so it did not run:\n{out}")
+        })
+        .to_string()
+}
+
+/// A throwaway workspace holding the two repos the hook expects as siblings,
+/// with the hooks installed by the real `tools/install-hooks.sh` and a stub in
+/// place of `run-tests.sh`.
+///
+/// The evidence that #683 and #684 work was rows of skip/run decisions
+/// produced by hand. For changes whose failure mode is the gate silently
+/// ceasing to run, or silently gating the wrong tree, by hand and uncommitted
+/// is the wrong place for it.
+pub struct Workspace {
+    _dir: tempfile::TempDir,
+    pub root: PathBuf,
+}
+
+impl Default for Workspace {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Workspace {
+    pub fn new() -> Workspace {
+        let dir = tempfile::tempdir().expect("temp dir for a stand-in workspace");
+        let root = dir.path().canonicalize().expect("canonical temp path");
+
+        for repo in ["libviprs", "libviprs-tests"] {
+            let repo_root = root.join(repo);
+            std::fs::create_dir_all(&repo_root).expect("create the stand-in repo");
+            git(&repo_root, &["init", "-q", "-b", "main"]);
+        }
+
+        // The harness carries both the installer and the hook it installs, so
+        // both have to be here before the installer runs and committed before
+        // a linked worktree can see them.
+        let tests_root = root.join("libviprs-tests");
+        std::fs::create_dir_all(tests_root.join("tools/hooks"))
+            .expect("create the stand-in tools directory");
+        for rel in ["tools/install-hooks.sh", PRE_PUSH_HOOK] {
+            let to = tests_root.join(rel);
+            let from = repo_root().join(rel);
+            std::fs::copy(&from, &to).unwrap_or_else(|e| {
+                panic!("copy {} into the stand-in workspace: {e}", from.display())
+            });
+            make_executable(&to);
+        }
+        let stub = tests_root.join("tools/run-tests.sh");
+        std::fs::write(&stub, STUB_RUN_TESTS).expect("write the stub run-tests.sh");
+        make_executable(&stub);
+
+        let ws = Workspace { _dir: dir, root };
+        ws.commit("libviprs-tests", "harness tooling", &[]);
+        ws.commit(
+            "libviprs",
+            "stand-in core crate",
+            &[("src/lib.rs", "// stand-in\n")],
         );
-    let rest = &script[start..];
-    let end = rest
-        .find("\nHOOK\n")
-        .expect("unterminated pre-push heredoc in tools/install-hooks.sh");
-    rest[..end].to_string()
+        ws.install_hooks();
+        ws
+    }
+
+    /// Run `tools/install-hooks.sh` from inside the stand-in harness, the way
+    /// a developer does, and hand back everything it printed.
+    pub fn install_hooks(&self) -> String {
+        let out = Command::new("bash")
+            .arg(self.repo("libviprs-tests").join("tools/install-hooks.sh"))
+            .current_dir(self.repo("libviprs-tests"))
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
+            .output()
+            .expect("run tools/install-hooks.sh");
+        let text = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            out.status.success(),
+            "tools/install-hooks.sh exited {}:\n{text}",
+            out.status
+        );
+        text
+    }
+
+    pub fn repo(&self, name: &str) -> PathBuf {
+        self.root.join(name)
+    }
+
+    /// The checked-in hook inside the stand-in harness, which is what the
+    /// installed shim points at.
+    pub fn checked_in_hook(&self) -> PathBuf {
+        self.repo("libviprs-tests").join(PRE_PUSH_HOOK)
+    }
+
+    /// A linked worktree of `repo`, on a new branch, somewhere that is not a
+    /// sibling of the checkouts. Epic #520 runs every lane in one of these,
+    /// and it is the case the shared hooks directory gets wrong.
+    pub fn worktree(&self, repo: &str, branch: &str) -> PathBuf {
+        let path = self.root.join("lanes").join(branch);
+        std::fs::create_dir_all(path.parent().expect("lanes dir")).expect("create the lanes dir");
+        git(
+            &self.repo(repo),
+            &[
+                "worktree",
+                "add",
+                "-q",
+                "-b",
+                branch,
+                path.to_str().expect("utf-8 worktree path"),
+            ],
+        );
+        path.canonicalize().expect("canonical worktree path")
+    }
+
+    /// Commit `files` in `tree` and return the commit's oid. `tree` can be a
+    /// main checkout or a linked worktree.
+    pub fn commit_in(&self, tree: &Path, message: &str, files: &[(&str, &str)]) -> String {
+        for (rel, contents) in files {
+            let path = tree.join(rel);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("create a directory for a stand-in file");
+            }
+            std::fs::write(&path, contents).expect("write a stand-in file");
+        }
+        git(tree, &["add", "-A"]);
+        git(
+            tree,
+            &[
+                "-c",
+                "user.name=prepush guard",
+                "-c",
+                "user.email=guard@example.invalid",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-q",
+                "--allow-empty",
+                "-m",
+                message,
+            ],
+        );
+        git(tree, &["rev-parse", "HEAD"]).trim().to_string()
+    }
+
+    /// The same, on a repo's main checkout.
+    pub fn commit(&self, repo: &str, message: &str, files: &[(&str, &str)]) -> String {
+        self.commit_in(&self.repo(repo), message, files)
+    }
+
+    /// Start describing a push. Nothing happens until [`Push::run`].
+    pub fn push<'a>(&'a self, repo: &'a str) -> Push<'a> {
+        Push {
+            ws: self,
+            repo,
+            from: None,
+            before: String::new(),
+            after: String::new(),
+            force_all: false,
+            git_env: false,
+        }
+    }
+}
+
+/// One push at the installed hook.
+pub struct Push<'a> {
+    ws: &'a Workspace,
+    repo: &'a str,
+    from: Option<PathBuf>,
+    before: String,
+    after: String,
+    force_all: bool,
+    git_env: bool,
+}
+
+impl<'a> Push<'a> {
+    /// Push from a linked worktree rather than from the main checkout. git
+    /// still runs the hook out of the main checkout's shared hooks directory,
+    /// which is the whole of #684.
+    pub fn from(mut self, tree: &Path) -> Push<'a> {
+        self.from = Some(tree.to_path_buf());
+        self
+    }
+
+    pub fn range(mut self, before: &str, after: &str) -> Push<'a> {
+        self.before = before.to_string();
+        self.after = after.to_string();
+        self
+    }
+
+    pub fn force_all(mut self) -> Push<'a> {
+        self.force_all = true;
+        self
+    }
+
+    /// Hand the hook the git environment git itself exports into it. It beats
+    /// `git -C` and the working directory for every git command anything
+    /// downstream runs, so a hook that does not drop it makes the suite answer
+    /// for the pushing repository whatever tree it was aimed at.
+    pub fn with_git_env(mut self) -> Push<'a> {
+        self.git_env = true;
+        self
+    }
+
+    /// Run the hook and require it to allow the push.
+    pub fn run(self) -> String {
+        let (ok, text) = self.try_run();
+        assert!(ok, "the pre-push hook rejected the push:\n{text}");
+        text
+    }
+
+    /// Run the hook and hand back whether it allowed the push, and everything
+    /// it printed.
+    pub fn try_run(self) -> (bool, String) {
+        let main = self.ws.repo(self.repo);
+        let tree = self.from.clone().unwrap_or_else(|| main.clone());
+
+        let mut cmd = Command::new("bash");
+        cmd.arg(main.join(".git/hooks/pre-push"))
+            .arg("origin")
+            .arg("git@example.invalid:libviprs/x.git")
+            .current_dir(&tree)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        for leaked in [
+            "GIT_DIR",
+            "GIT_WORK_TREE",
+            "GIT_INDEX_FILE",
+            "GIT_PREFIX",
+            "GIT_QUARANTINE_PATH",
+            "LIBVIPRS_PREPUSH_ALL",
+        ] {
+            cmd.env_remove(leaked);
+        }
+        if self.force_all {
+            cmd.env("LIBVIPRS_PREPUSH_ALL", "1");
+        }
+        if self.git_env {
+            let dir = git(&tree, &["rev-parse", "--absolute-git-dir"])
+                .trim()
+                .to_string();
+            cmd.env("GIT_DIR", &dir)
+                .env("GIT_INDEX_FILE", format!("{dir}/index"))
+                .env("GIT_PREFIX", "")
+                .env("GIT_QUARANTINE_PATH", format!("{dir}/incoming"));
+        }
+
+        let mut child = cmd.spawn().expect("run the installed pre-push hook");
+        {
+            let stdin = child.stdin.as_mut().expect("hook stdin");
+            writeln!(
+                stdin,
+                "refs/heads/main {} refs/heads/main {}",
+                self.after, self.before
+            )
+            .expect("feed the ref update to the hook");
+        }
+        let out = child
+            .wait_with_output()
+            .expect("collect the hook's decision");
+        let text = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        (out.status.success(), text)
+    }
+}
+
+pub fn git(dir: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .output()
+        .unwrap_or_else(|e| {
+            panic!(
+                "these guards drive the real hook, which needs git on PATH: \
+                 `git {}` in {}: {e}",
+                args.join(" "),
+                dir.display()
+            )
+        });
+    assert!(
+        out.status.success(),
+        "git {} failed in {}: {}",
+        args.join(" "),
+        dir.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+pub fn make_executable(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+            .expect("make the stand-in script executable");
+    }
+    #[cfg(not(unix))]
+    let _ = path;
 }

--- a/tests/common/hooks.rs
+++ b/tests/common/hooks.rs
@@ -97,7 +97,10 @@ impl Workspace {
         let dir = tempfile::tempdir().expect("temp dir for a stand-in workspace");
         let root = dir.path().canonicalize().expect("canonical temp path");
 
-        for repo in ["libviprs", "libviprs-tests"] {
+        // libviprs-cli gets no pre-push hook (libviprs/libviprs#691) but it
+        // does get a pre-commit one, and #715's guard runs that, so it is here
+        // too. Nothing pushes from it.
+        for repo in ["libviprs", "libviprs-cli", "libviprs-tests"] {
             let repo_root = root.join(repo);
             std::fs::create_dir_all(&repo_root).expect("create the stand-in repo");
             git(&repo_root, &["init", "-q", "-b", "main"]);

--- a/tests/common/hooks.rs
+++ b/tests/common/hooks.rs
@@ -208,6 +208,10 @@ impl Workspace {
                 "commit.gpgsign=false",
                 "commit",
                 "-q",
+                // These guards are about the pre-push hook. The pre-commit
+                // hook the installer also writes runs `cargo fmt` in the repo
+                // it is installed in, and a stand-in repo is not a crate.
+                "--no-verify",
                 "--allow-empty",
                 "-m",
                 message,

--- a/tests/fixtures/cli/PROVENANCE.md
+++ b/tests/fixtures/cli/PROVENANCE.md
@@ -1158,11 +1158,11 @@ References (paths relative to `tests/fixtures/cli/`):
 | `resample/reduceh_expected.png` | ≤1 LSB (1) | `vips reduceh grad.png reduceh_expected.png 2` |
 | `resample/reducev_expected.png` | ≤1 LSB (1) | `vips reducev grad.png reducev_expected.png 2` |
 | `resample/resize_half_expected.png` | ≤1 LSB (0) | `vips resize rgb.png resize_half_expected.png 0.5` |
-| `resample/resize_vscale_expected.png` | ≤1 LSB (0) | `vips resize rgb.png resize_vscale_expected.png 0.5 --vscale 0.75` |
+| `resample/resize_vscale_expected.png` | **EXACT (0)** | `vips resize rgb.png resize_vscale_expected.png 0.5 --vscale 0.75` |
 | `resample/resize_up_expected.png` | ≤1 LSB (1) | `vips resize grad.png resize_up_expected.png 2.0` (upscale → affine path) |
 | `resample/resize_nearest_expected.png` | ≤1 LSB (0) | `vips resize rgb.png resize_nearest_expected.png 0.5 --kernel nearest` |
 | `resample/affine_bilinear_expected.png` | ≤1 LSB (1) | `vips affine rgb.png affine_bilinear_expected.png "1.5 0 0 1.5"` (default bilinear) |
-| `resample/affine_bicubic_expected.png` | **2 LSB (2)** | `vips affine rgb.png affine_bicubic_expected.png "1.5 0 0 1.5" --interpolate bicubic` (bicubic quantises to 2 LSB — noted divergence) |
+| `resample/affine_bicubic_expected.png` | ≤1 LSB (1) | `vips affine rgb.png affine_bicubic_expected.png "1.5 0 0 1.5" --interpolate bicubic` (was 2 before libviprs#702 rounded the bicubic offset onto vips's grid) |
 | `resample/similarity_angle_expected.png` | ≤1 LSB (1) | `vips similarity rgb.png similarity_angle_expected.png --angle 30` |
 | `resample/similarity_scale_expected.png` | ≤1 LSB (1) | `vips similarity rgb.png similarity_scale_expected.png --scale 1.5` |
 | `resample/rotate_expected.png` | ≤1 LSB (1) | `vips rotate rgb.png rotate_expected.png 30` |
@@ -1170,7 +1170,7 @@ References (paths relative to `tests/fixtures/cli/`):
 | `resample/mapim_bicubic_expected.png` | ≤1 LSB (1) | `vips mapim rgb.png mapim_bicubic_expected.png index.v --interpolate bicubic` |
 | `resample/thumbnail_expected.png` | ≤1 LSB (0) | `vips thumbnail rgb.png thumbnail_expected.png 16` (FILENAME input) |
 | `resample/thumbnail_crop_expected.png` | ≤1 LSB (0) | `vips thumbnail rgb.png thumbnail_crop_expected.png 16 --height 8 --crop centre` (NON-square target — centre-crop removes pixels, 16×8, distinct from the no-crop fixtures) |
-| `resample/thumbnail_linear_expected.png` | ≤1 LSB (1) | `vips thumbnail rgb.png thumbnail_linear_expected.png 16 --linear` (linear-light reduce path) |
+| `resample/thumbnail_linear_expected.png` | ≤1 LSB (0) | `vips thumbnail rgb.png thumbnail_linear_expected.png 16 --linear` (linear-light reduce path) |
 | `resample/thumbnail_image_expected.png` | ≤1 LSB (0) | `vips thumbnail_image rgb.png thumbnail_image_expected.png 16` |
 
 **Open question**: `affine … --interpolate bicubic` measures **2 LSB** (not the

--- a/tests/install_hooks_mirror_ci.rs
+++ b/tests/install_hooks_mirror_ci.rs
@@ -1,0 +1,245 @@
+//! Guards that the pre-commit hook runs what each repo's CI lint job runs
+//! (libviprs/libviprs#715).
+//!
+//! `tools/install-hooks.sh` says its pre-commit hook "Mirrors each repo's
+//! `.github/workflows/ci.yml` Check & Lint job *exactly*, so a clean local
+//! commit means a clean remote Check & Lint", and then asks a human to keep
+//! the per-repo cargo step lists in lockstep by hand. That did not happen. The
+//! core's list ran two of the five clippy passes CI runs, missing
+//! `object-store-sink`, `svg` and `jxl`, and this repo's missed `jxl` while
+//! spending a compile on `s3`, a deprecated alias for a cell the matrix
+//! already covers under its real name.
+//!
+//! Every one of those per-feature passes exists because the default pass
+//! compiles none of that code (#382, #500, #502, and libviprs-tests#55). So a
+//! commit that breaks `src/svg.rs` passed the local hook and failed CI, which
+//! is the exact failure the hook was written to prevent.
+//!
+//! The guard runs the generated hook with a recording stand-in for `cargo`
+//! first on `PATH` and compares the invocations it actually makes against the
+//! lint lines in that repo's `ci.yml`. Grepping either file would be worth
+//! nothing, which is the standing lesson of libviprs/libviprs#695.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::process::Command;
+
+mod common;
+use common::cli::{cli_dir, require_cli};
+use common::hooks::{Workspace, make_executable, repo_root};
+
+/// A `cargo` that records its arguments and succeeds, so the hook runs every
+/// step instead of stopping at the first one.
+const RECORDING_CARGO: &str = r#"#!/bin/sh
+printf 'cargo %s\n' "$*" >> "$LOCKSTEP_RECORD"
+exit 0
+"#;
+
+/// The same for the one non-cargo lint step, which the hook invokes by
+/// relative path rather than through `PATH`.
+const RECORDING_PORTED_CELLS: &str = r#"#!/bin/sh
+printf './tools/run_ported_cells.sh %s\n' "$*" >> "$LOCKSTEP_RECORD"
+exit 0
+"#;
+
+/// Every lint command `ci.yml` runs, with the feature matrix expanded.
+///
+/// `cargo check` and `cargo build` lines are deliberately out. The comment
+/// above the step lists already says clippy does `cargo check`'s work, and the
+/// core's `cargo build --features s3` is there to prove a deprecated alias
+/// still resolves, which the manifest settles and a whole extra build on every
+/// commit does not earn.
+fn ci_lint_commands(workflow: &str) -> BTreeSet<String> {
+    let features: Vec<String> = workflow
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            let list = line.strip_prefix("feature: [")?.strip_suffix(']')?;
+            Some(
+                list.split(',')
+                    .map(|f| f.trim().to_string())
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .flatten()
+        .collect();
+
+    let mut found = BTreeSet::new();
+    for line in workflow.lines() {
+        let line = line.trim();
+        let Some(cmd) = line
+            .strip_prefix("- run: ")
+            .or_else(|| line.strip_prefix("run: "))
+        else {
+            continue;
+        };
+        let cmd = cmd.trim();
+        let is_lint = cmd.starts_with("cargo clippy")
+            || cmd.starts_with("cargo fmt")
+            || (cmd.starts_with("./tools/run_ported_cells.sh") && cmd.contains("--clippy"));
+        if !is_lint {
+            continue;
+        }
+        if cmd.contains("${{ matrix.feature }}") {
+            assert!(
+                !features.is_empty(),
+                "a workflow line uses ${{{{ matrix.feature }}}} but no job \
+                 declares a `feature: [...]` list, so this guard cannot expand \
+                 it: {cmd}"
+            );
+            for feature in &features {
+                found.insert(cmd.replace("${{ matrix.feature }}", feature));
+            }
+        } else {
+            found.insert(cmd.to_string());
+        }
+    }
+    found
+}
+
+/// What the pre-commit hook `install-hooks.sh` writes for `repo` actually
+/// runs, observed by putting a recorder in front of it.
+fn hook_runs(ws: &Workspace, repo: &str) -> BTreeSet<String> {
+    let repo_dir = ws.repo(repo);
+    let hook = repo_dir.join(".git/hooks/pre-commit");
+    assert!(
+        hook.is_file(),
+        "no pre-commit hook was installed into {repo}, so this guard would \
+         pass on an empty recording"
+    );
+
+    let bin = ws.root.join("recorders").join(repo);
+    std::fs::create_dir_all(&bin).expect("create the recorder directory");
+    let cargo = bin.join("cargo");
+    std::fs::write(&cargo, RECORDING_CARGO).expect("write the recording cargo");
+    make_executable(&cargo);
+
+    // The hook reaches this one by relative path, so it has to sit in the
+    // stand-in repo rather than on PATH.
+    let ported = repo_dir.join("tools/run_ported_cells.sh");
+    std::fs::create_dir_all(ported.parent().expect("tools dir")).expect("create tools dir");
+    std::fs::write(&ported, RECORDING_PORTED_CELLS).expect("write the recording ported cells");
+    make_executable(&ported);
+
+    let record = ws.root.join(format!("{repo}.record"));
+    let _ = std::fs::remove_file(&record);
+    let path = format!(
+        "{}:{}",
+        bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    let out = Command::new("bash")
+        .arg(&hook)
+        .current_dir(&repo_dir)
+        .env("PATH", path)
+        .env("LOCKSTEP_RECORD", &record)
+        .output()
+        .expect("run the generated pre-commit hook");
+    assert!(
+        out.status.success(),
+        "the pre-commit hook failed with every command stubbed to succeed:\n{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    std::fs::read_to_string(&record)
+        .unwrap_or_default()
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect()
+}
+
+/// The workflow for a repo, read out of that repo's checkout.
+fn workflow_of(root: &Path) -> String {
+    let path = root.join(".github/workflows/ci.yml");
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
+
+fn compare(repo: &str, ci: BTreeSet<String>, hook: BTreeSet<String>) {
+    assert!(
+        !ci.is_empty(),
+        "found no lint commands in {repo}'s ci.yml, so this guard would pass \
+         on a workflow that lints nothing"
+    );
+
+    let missing: Vec<&String> = ci.difference(&hook).collect();
+    let extra: Vec<&String> = hook.difference(&ci).collect();
+
+    assert!(
+        missing.is_empty(),
+        "{repo}'s CI lints these and the pre-commit hook does not:\n  {}\n\
+         Each one is a commit that passes locally and fails remotely, which is \
+         the whole reason the hook exists. Add them to the step list for \
+         {repo} in tools/install-hooks.sh (#715).",
+        missing
+            .iter()
+            .map(|c| c.as_str())
+            .collect::<Vec<_>>()
+            .join("\n  ")
+    );
+    assert!(
+        extra.is_empty(),
+        "the pre-commit hook for {repo} runs these and CI does not:\n  {}\n\
+         Either CI lost a check the hook still remembers, or the hook is \
+         spending a compile on something nothing asks for. Reconcile them in \
+         tools/install-hooks.sh (#715).",
+        extra
+            .iter()
+            .map(|c| c.as_str())
+            .collect::<Vec<_>>()
+            .join("\n  ")
+    );
+}
+
+/// This repo. Its own workflow is always here, so there is nothing to skip.
+#[test]
+fn the_hook_lints_this_repo_the_way_its_ci_does() {
+    let ws = Workspace::new();
+    compare(
+        "libviprs-tests",
+        ci_lint_commands(&workflow_of(&repo_root())),
+        hook_runs(&ws, "libviprs-tests"),
+    );
+}
+
+/// The core checkout. `libviprs = { path = "../libviprs" }` in this crate's
+/// manifest means it is there whenever this suite can run at all, and the
+/// Docker build context stages it with its `.github/` intact.
+#[test]
+fn the_hook_lints_the_core_the_way_its_ci_does() {
+    let ws = Workspace::new();
+    compare(
+        "libviprs",
+        ci_lint_commands(&workflow_of(&repo_root().join("../libviprs"))),
+        hook_runs(&ws, "libviprs"),
+    );
+}
+
+/// The cli is not laid down by the default `test` job or by the Docker gate,
+/// so this one has to skip where it is absent. Skipping reads to `cargo test`
+/// as a pass, so it follows the same false-green guard as the differential
+/// cells: `VIPRS_REQUIRE_CLI=1`, set on the job that does lay the cli down,
+/// turns the skip into a panic (`tests/common/cli.rs`).
+#[test]
+fn the_hook_lints_the_cli_the_way_its_ci_does() {
+    let dir = cli_dir();
+    let workflow = dir.join(".github/workflows/ci.yml");
+    if !workflow.is_file() {
+        assert!(
+            !require_cli(),
+            "VIPRS_REQUIRE_CLI=1 but there is no libviprs-cli workflow at {}, \
+             so this guard would compare nothing and report a false green",
+            workflow.display()
+        );
+        return;
+    }
+
+    let ws = Workspace::new();
+    compare(
+        "libviprs-cli",
+        ci_lint_commands(&workflow_of(&dir)),
+        hook_runs(&ws, "libviprs-cli"),
+    );
+}

--- a/tests/install_hooks_pre_push_slots.rs
+++ b/tests/install_hooks_pre_push_slots.rs
@@ -65,7 +65,16 @@ impl Workspace {
         // real one.
         let tools = root.join("libviprs-tests/tools");
         std::fs::create_dir_all(&tools).expect("create the stand-in tools directory");
-        for script in ["install-hooks.sh", "run-tests.sh", "run_ported_cells.sh"] {
+        std::fs::create_dir_all(tools.join("hooks")).expect("create the stand-in hooks directory");
+        // The installer points the shim it writes at tools/hooks/pre-push and
+        // refuses to install without it, so the stand-in harness carries the
+        // real one (libviprs/libviprs#695).
+        for script in [
+            "install-hooks.sh",
+            "run-tests.sh",
+            "run_ported_cells.sh",
+            "hooks/pre-push",
+        ] {
             let to = tools.join(script);
             std::fs::copy(repo_root().join("tools").join(script), &to)
                 .unwrap_or_else(|e| panic!("copy tools/{script} into the stand-in workspace: {e}"));

--- a/tests/prepush_gate_cost_controls.rs
+++ b/tests/prepush_gate_cost_controls.rs
@@ -11,11 +11,11 @@
 //!
 //! The failure mode of the whole change is the gate quietly ceasing to run, so
 //! these guards are built to fail when that happens rather than to describe it.
-//! Two of them lift `inert_path()` out of the generated hook and *execute* it:
-//! one runs every tracked path in both repos through it and pins the set that
-//! comes back inert, the other installs the whole hook in a throwaway workspace
-//! and drives real pushes past it. An earlier pair of text guards here could
-//! not fail for the reason they claimed: a reviewer flipped `inert_path`'s
+//! Two of them lift `inert_path()` out of the hook and *execute* it: one runs
+//! every tracked path in both repos through it and pins the set that comes
+//! back inert, the other installs the whole hook in a throwaway workspace and
+//! drives real pushes past it. An earlier pair of text guards here could not
+//! fail for the reason they claimed: a reviewer flipped `inert_path`'s
 //! fallthrough to `true`, disabling the gate for every push in every repo, and
 //! both stayed green.
 
@@ -25,22 +25,22 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 mod common;
-use common::hooks::{generated_pre_push, read, repo_root};
+use common::hooks::{RAN_MARKER, STUB_RUN_TESTS, Workspace, pre_push_hook, read, repo_root};
 
 // ---------------------------------------------------------------------------
 // Running the hook's own `inert_path()`
 // ---------------------------------------------------------------------------
 
-/// The `inert_path()` shell function, lifted verbatim out of the generated
-/// hook and wrapped in a driver that prints the inert ones from a list of
-/// paths on stdin.
+/// The `inert_path()` shell function, lifted verbatim out of the hook and
+/// wrapped in a driver that prints the inert ones from a list of paths on
+/// stdin.
 ///
 /// Lifting the real text is the point. A guard that re-implements the case
 /// statement in Rust tests the re-implementation, and a guard that greps the
 /// text tests the grep; both were tried here and both waved through six
 /// poisoned entries and a flipped fallthrough.
 fn inert_path_driver() -> String {
-    let hook = generated_pre_push();
+    let hook = pre_push_hook();
     let start = hook.find("inert_path() {").expect(
         "the pre-push hook must decide what it may skip in one place, a shell \
          function called inert_path()",
@@ -286,170 +286,6 @@ fn the_skip_list_never_exempts_what_the_suite_reads() {
 // Driving the whole hook
 // ---------------------------------------------------------------------------
 
-/// What the stub `run-tests.sh` prints when the hook decides to run the suite.
-const RAN_MARKER: &str = "STUB-RAN-THE-SUITE";
-
-/// A throwaway workspace holding the two repos the hook expects as siblings,
-/// with the generated pre-push hook installed in both and a stub in place of
-/// `run-tests.sh`, so a decision can be observed without Docker.
-///
-/// The evidence that this change works was six rows of skip/run decisions
-/// produced by hand. For a change whose failure mode is the gate silently
-/// ceasing to run, by hand and uncommitted is the wrong place for it.
-struct Workspace {
-    _dir: tempfile::TempDir,
-    root: PathBuf,
-}
-
-impl Workspace {
-    fn new() -> Workspace {
-        let dir = tempfile::tempdir().expect("temp dir for a stand-in workspace");
-        let root = dir.path().canonicalize().expect("canonical temp path");
-        let hook_body = generated_pre_push();
-
-        for repo in ["libviprs", "libviprs-tests"] {
-            let repo_root = root.join(repo);
-            std::fs::create_dir_all(repo_root.join("tools")).expect("create the stand-in repo");
-            git(&repo_root, &["init", "-q"]);
-
-            let hook = repo_root.join(".git/hooks/pre-push");
-            std::fs::create_dir_all(hook.parent().expect("hooks dir")).expect("create hooks dir");
-            std::fs::write(&hook, &hook_body).expect("install the generated pre-push hook");
-            make_executable(&hook);
-        }
-
-        // The hook points a libviprs push at the sibling harness's script and a
-        // libviprs-tests push at the pushed tree's own copy; in this workspace
-        // those are the same file, and it must exist or the hook bails out
-        // before it ever reaches the skip decision.
-        let stub = root.join("libviprs-tests/tools/run-tests.sh");
-        std::fs::write(&stub, format!("#!/bin/sh\necho \"{RAN_MARKER}\"\n"))
-            .expect("write the stub run-tests.sh");
-        make_executable(&stub);
-
-        Workspace { _dir: dir, root }
-    }
-
-    fn repo(&self, name: &str) -> PathBuf {
-        self.root.join(name)
-    }
-
-    /// Commit `files` in `repo` and return the commit's oid.
-    fn commit(&self, repo: &str, message: &str, files: &[(&str, &str)]) -> String {
-        let root = self.repo(repo);
-        for (rel, contents) in files {
-            let path = root.join(rel);
-            if let Some(parent) = path.parent() {
-                std::fs::create_dir_all(parent).expect("create a directory for a stand-in file");
-            }
-            std::fs::write(&path, contents).expect("write a stand-in file");
-        }
-        git(&root, &["add", "-A"]);
-        git(
-            &root,
-            &[
-                "-c",
-                "user.name=prepush guard",
-                "-c",
-                "user.email=guard@example.invalid",
-                "-c",
-                "commit.gpgsign=false",
-                "commit",
-                "-q",
-                "--allow-empty",
-                "-m",
-                message,
-            ],
-        );
-        git(&root, &["rev-parse", "HEAD"]).trim().to_string()
-    }
-
-    /// Run the installed hook the way git does: from the top of the working
-    /// tree, with the ref updates on stdin.
-    fn push(&self, repo: &str, before: &str, after: &str, force_all: bool) -> String {
-        let root = self.repo(repo);
-        let mut cmd = Command::new("bash");
-        cmd.arg(root.join(".git/hooks/pre-push"))
-            .arg("origin")
-            .arg("git@example.invalid:libviprs/x.git")
-            .current_dir(&root)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-        for leaked in [
-            "GIT_DIR",
-            "GIT_WORK_TREE",
-            "GIT_INDEX_FILE",
-            "GIT_PREFIX",
-            "LIBVIPRS_PREPUSH_ALL",
-        ] {
-            cmd.env_remove(leaked);
-        }
-        if force_all {
-            cmd.env("LIBVIPRS_PREPUSH_ALL", "1");
-        }
-
-        let mut child = cmd.spawn().expect("run the generated pre-push hook");
-        {
-            let stdin = child.stdin.as_mut().expect("hook stdin");
-            writeln!(stdin, "refs/heads/main {after} refs/heads/main {before}")
-                .expect("feed the ref update to the hook");
-        }
-        let out = child
-            .wait_with_output()
-            .expect("collect the hook's decision");
-        let text = format!(
-            "{}{}",
-            String::from_utf8_lossy(&out.stdout),
-            String::from_utf8_lossy(&out.stderr)
-        );
-        assert!(
-            out.status.success(),
-            "the pre-push hook exited {} on a {repo} push:\n{text}",
-            out.status
-        );
-        text
-    }
-}
-
-fn git(dir: &Path, args: &[&str]) -> String {
-    let out = Command::new("git")
-        .arg("-C")
-        .arg(dir)
-        .args(args)
-        .env_remove("GIT_DIR")
-        .env_remove("GIT_WORK_TREE")
-        .env_remove("GIT_INDEX_FILE")
-        .output()
-        .unwrap_or_else(|e| {
-            panic!(
-                "these guards drive the real hook, which needs git on PATH: \
-                 `git {}` in {}: {e}",
-                args.join(" "),
-                dir.display()
-            )
-        });
-    assert!(
-        out.status.success(),
-        "git {} failed in {}: {}",
-        args.join(" "),
-        dir.display(),
-        String::from_utf8_lossy(&out.stderr)
-    );
-    String::from_utf8_lossy(&out.stdout).into_owned()
-}
-
-fn make_executable(path: &Path) {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
-            .expect("make the stand-in script executable");
-    }
-    #[cfg(not(unix))]
-    let _ = path;
-}
-
 /// The skip list decides nothing on its own; the hook does. So install the
 /// hook, push at it, and read the answer off the run.
 ///
@@ -466,10 +302,7 @@ fn the_hook_skips_and_runs_the_way_the_list_says() {
         ("LICENSE", "stand-in licence\n"),
         ("docs/note.md", "stand-in note\n"),
         ("src/lib.rs", "// stand-in\n"),
-        (
-            "tools/run-tests.sh",
-            "#!/bin/sh\necho \"STUB-RAN-THE-SUITE\"\n",
-        ),
+        ("tools/run-tests.sh", STUB_RUN_TESTS),
     ];
 
     let cases: &[(&str, &str, &str, bool, &str)] = &[
@@ -499,7 +332,7 @@ fn the_hook_skips_and_runs_the_way_the_list_says() {
         (
             "libviprs-tests",
             "tools/run-tests.sh",
-            "#!/bin/sh\necho \"STUB-RAN-THE-SUITE\"\n# changed\n",
+            "#!/bin/sh\n# changed\necho \"STUB-RAN-THE-SUITE\"\n",
             true,
             "it is the suite",
         ),
@@ -529,7 +362,7 @@ fn the_hook_skips_and_runs_the_way_the_list_says() {
     for (repo, path, contents, should_run, why) in cases {
         let before = ws.commit(repo, "base", &base);
         let after = ws.commit(repo, "change", &[(path, contents)]);
-        let out = ws.push(repo, &before, &after, false);
+        let out = ws.push(repo).range(&before, &after).run();
 
         let ran = out.contains(RAN_MARKER);
         let skipped = out.contains("skipping it");
@@ -552,33 +385,19 @@ fn the_hook_skips_and_runs_the_way_the_list_says() {
 /// the next person who does not trust the filter goes back to `--no-verify`
 /// and takes the whole gate with them.
 ///
-/// Asserted twice over, because the bare name `LIBVIPRS_PREPUSH_ALL` appears
-/// three times in the hook and is expanded once: delete the one line that
-/// reads it, keep the comment, and a `contains("LIBVIPRS_PREPUSH_ALL")` guard
-/// stays green with the escape hatch gone.
+/// This used to assert `hook.contains("${LIBVIPRS_PREPUSH_ALL")` as well. The
+/// bare name appears three times in the hook and is expanded once, so that
+/// half was there to catch "delete the line that reads it, keep the comment",
+/// and it is worth exactly nothing next to running the push twice.
 #[test]
 fn the_skip_can_be_overridden() {
-    let hook = generated_pre_push();
-    assert!(
-        hook.contains("${LIBVIPRS_PREPUSH_ALL"),
-        "the pre-push hook mentions LIBVIPRS_PREPUSH_ALL but never expands it, \
-         so the escape hatch is documentation only. Without a real one the only \
-         way past a wrong skip decision is --no-verify, which is what #683 is \
-         about"
-    );
-
-    // And the same thing again through the hook itself, on a push it would
-    // otherwise skip.
     let ws = Workspace::new();
     let before = ws.commit(
         "libviprs-tests",
         "base",
         &[
             ("LICENSE", "stand-in licence\n"),
-            (
-                "tools/run-tests.sh",
-                "#!/bin/sh\necho \"STUB-RAN-THE-SUITE\"\n",
-            ),
+            ("tools/run-tests.sh", STUB_RUN_TESTS),
         ],
     );
     let after = ws.commit(
@@ -587,14 +406,18 @@ fn the_skip_can_be_overridden() {
         &[("LICENSE", "stand-in licence, revised\n")],
     );
 
-    let skipped = ws.push("libviprs-tests", &before, &after, false);
+    let skipped = ws.push("libviprs-tests").range(&before, &after).run();
     assert!(
         !skipped.contains(RAN_MARKER),
         "a LICENSE-only push should have been skipped, so the override below \
          proves nothing. The hook said:\n{skipped}"
     );
 
-    let forced = ws.push("libviprs-tests", &before, &after, true);
+    let forced = ws
+        .push("libviprs-tests")
+        .range(&before, &after)
+        .force_all()
+        .run();
     assert!(
         forced.contains(RAN_MARKER),
         "LIBVIPRS_PREPUSH_ALL=1 must run the suite on a push the list would \

--- a/tests/prepush_gate_tests_the_pushed_tree.rs
+++ b/tests/prepush_gate_tests_the_pushed_tree.rs
@@ -10,83 +10,189 @@
 //! as "my branch passes" and meant nothing of the kind.
 //!
 //! Two properties have to hold together, and neither is visible from the
-//! other side, which is why both are pinned here:
+//! other side, which is why both are driven here:
 //!
 //!   * the hook has to *find* the pushed tree, and it cannot do that from
 //!     `$0` (shared hooks directory) or by walking up from `.git` (in a
 //!     worktree that is a file holding a `gitdir:` pointer, not a directory).
-//!     Only `git rev-parse` knows.
 //!   * `run-tests.sh` has to *accept* it. It did not have a parameter for it
 //!     at all, so passing one from the hook was not enough on its own.
 //!
-//! These are text and behaviour guards on the harness rather than on library
-//! output, in the same shape as `counterpart_pinning` and
-//! `feature_rename_docs_present`: there is no libvips analogue for "the local
-//! gate is honest", and the failure mode is silent by construction.
+//! Everything about the hook here is measured by running it. The guards that
+//! stood here before asserted `hook.contains("git rev-parse --show-toplevel")`
+//! and `hook.contains("unset GIT_DIR")`, and both of those stay green when the
+//! line they name is deleted and the comment above it is left behind, which is
+//! libviprs/libviprs#695. So instead: install the hooks with the real
+//! installer, push at them from a linked worktree with a ref-update on stdin,
+//! and read the trees off what the suite was handed.
 
 use std::process::Command;
 
 mod common;
-use common::hooks::{generated_pre_push, read, repo_root};
+use common::hooks::{Workspace, repo_root, reported};
 
-/// #684: the hook must ask git which tree is being pushed. `$0` points into
-/// the hooks directory, which a main checkout shares with every worktree
-/// hanging off it, so anything resolved from it names the main checkout.
+/// #684, end to end and per push shape. `run-tests.sh` falls back to the
+/// siblings of wherever the script itself sits, and for a worktree push that
+/// script is inside the worktree, whose neighbours are other lanes rather than
+/// the workspace, so both slots have to be named on every push and not just
+/// the one being pushed.
 #[test]
-fn pre_push_hook_resolves_the_pushed_tree_from_git() {
-    let hook = generated_pre_push();
+fn the_gate_is_handed_the_tree_being_pushed_and_its_sibling() {
+    let ws = Workspace::new();
 
-    assert!(
-        hook.contains("git rev-parse --show-toplevel"),
-        "the pre-push hook must take the tree under test from \
-         `git rev-parse --show-toplevel`, which is the working tree whose \
-         commits are going out (#684)"
+    let core_lane = ws.worktree("libviprs", "core-lane");
+    let harness_lane = ws.worktree("libviprs-tests", "harness-lane");
+
+    let cases: &[(&str, Option<&std::path::Path>, &str, &str)] = &[
+        (
+            "libviprs",
+            None,
+            "libviprs",
+            "a core push from the main checkout gates on the main checkout",
+        ),
+        (
+            "libviprs",
+            Some(&core_lane),
+            "lanes/core-lane",
+            "a core push from a lane worktree must gate on the lane, not on \
+             the main checkout whose hooks directory ran the hook",
+        ),
+        (
+            "libviprs-tests",
+            None,
+            "libviprs-tests",
+            "a harness push from the main checkout gates on the main checkout",
+        ),
+        (
+            "libviprs-tests",
+            Some(&harness_lane),
+            "lanes/harness-lane",
+            "a harness push from a lane worktree must gate on the lane",
+        ),
+    ];
+
+    for (repo, from, expected_rel, why) in cases {
+        let tree = from
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| ws.repo(repo));
+
+        let before = common::hooks::git(&tree, &["rev-parse", "HEAD"])
+            .trim()
+            .to_string();
+        // Something no skip list can call inert, so the gate reaches the suite.
+        let after = ws.commit_in(
+            &tree,
+            "a change the suite can see",
+            &[("src/lib.rs", "// changed\n")],
+        );
+
+        let out = ws
+            .push(repo)
+            .from(&tree)
+            .range(&before, &after)
+            .with_git_env()
+            .run();
+
+        let expected = ws.root.join(expected_rel);
+        let (pushed_slot, sibling_slot, sibling_rel) = match *repo {
+            "libviprs" => ("LIBVIPRS_DIR", "LIBVIPRS_TESTS_DIR", "libviprs-tests"),
+            _ => ("LIBVIPRS_TESTS_DIR", "LIBVIPRS_DIR", "libviprs"),
+        };
+
+        assert_eq!(
+            reported(&out, pushed_slot),
+            expected.display().to_string(),
+            "{pushed_slot} named the wrong tree, because {why}. The hook said:\n{out}"
+        );
+        assert_eq!(
+            reported(&out, sibling_slot),
+            ws.root.join(sibling_rel).display().to_string(),
+            "{sibling_slot} was not pinned to the workspace sibling on a {repo} \
+             push, so run-tests.sh is left to infer it from wherever the script \
+             it picked happens to sit (#684). The hook said:\n{out}"
+        );
+    }
+}
+
+/// A push that changes the harness has to gate through the harness it is
+/// changing, not through the copy in the main checkout. Finding the tree is
+/// only half of #684; running the pushed tree's script is the other half.
+#[test]
+fn a_harness_push_runs_the_suite_script_it_is_pushing() {
+    let ws = Workspace::new();
+    let lane = ws.worktree("libviprs-tests", "harness-lane");
+
+    let before = common::hooks::git(&lane, &["rev-parse", "HEAD"])
+        .trim()
+        .to_string();
+    let after = ws.commit_in(
+        &lane,
+        "a harness change",
+        &[("tests/something.rs", "// changed\n")],
     );
-    assert!(
-        hook.contains("git rev-parse --git-common-dir"),
-        "the pre-push hook must find the repo's main checkout through \
-         `git rev-parse --git-common-dir`; a linked worktree's `.git` is a \
-         file holding a `gitdir:` pointer, so walking up from it does not \
-         give a repository root (#684)"
-    );
-    assert!(
-        !hook.contains(r#"$(dirname "$0")/../.."#),
-        "the pre-push hook still derives a repository from its own path. \
-         Every worktree of a repo runs the same hook file out of the main \
-         checkout's hooks directory, so that always names the main checkout \
-         and never the branch being pushed (#684)"
+
+    let out = ws
+        .push("libviprs-tests")
+        .from(&lane)
+        .range(&before, &after)
+        .with_git_env()
+        .run();
+
+    assert_eq!(
+        reported(&out, "SCRIPT"),
+        lane.join("tools/run-tests.sh").display().to_string(),
+        "the gate ran a run-tests.sh from outside the tree being pushed, so a \
+         change to the suite is gated by the suite it is replacing (#684). \
+         The hook said:\n{out}"
     );
 }
 
-/// #684: finding the tree is only half of it. The hook has to hand it over,
-/// and `run-tests.sh` has to have somewhere to put it.
+/// git hands every hook a `GIT_DIR`, and in a worktree it points at that
+/// worktree's admin directory. It beats both `git -C` and the working
+/// directory, so a `git` call made downstream answers for the repository doing
+/// the pushing whatever directory it was aimed at. The first run of the fixed
+/// hook reported the pushing branch's HEAD as the revision of an unrelated
+/// tree, which is #684 wearing a different hat: a banner that names the wrong
+/// commit is no better than a gate that builds the wrong one.
 #[test]
-fn pre_push_hook_hands_the_tree_to_run_tests() {
-    let hook = generated_pre_push();
+fn the_gate_drops_the_git_environment_it_inherited() {
+    let ws = Workspace::new();
+    let lane = ws.worktree("libviprs-tests", "harness-lane");
 
-    for slot in ["LIBVIPRS_DIR", "LIBVIPRS_TESTS_DIR"] {
-        assert!(
-            hook.contains(&format!("export {slot}=")),
-            "the pre-push hook must export {slot} so run-tests.sh builds the \
-             pushed tree; without it the script falls back to the sibling \
-             checkout, which is the whole of #684"
-        );
-    }
+    let before = common::hooks::git(&lane, &["rev-parse", "HEAD"])
+        .trim()
+        .to_string();
+    let after = ws.commit_in(&lane, "a harness change", &[("tests/x.rs", "// c\n")]);
 
-    let script = read("tools/run-tests.sh");
-    for slot in ["LIBVIPRS_DIR", "LIBVIPRS_TESTS_DIR"] {
-        assert!(
-            script.contains(slot),
-            "tools/run-tests.sh must read {slot}, or the hook exporting it \
-             has no effect (#684)"
+    let out = ws
+        .push("libviprs-tests")
+        .from(&lane)
+        .range(&before, &after)
+        .with_git_env()
+        .run();
+
+    for leaked in [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_PREFIX",
+        "GIT_QUARANTINE_PATH",
+    ] {
+        assert_eq!(
+            reported(&out, leaked),
+            "unset",
+            "the gate handed {leaked} through to the suite. git exports it into \
+             hooks and it wins over `git -C`, so everything the suite asks git \
+             answers for the pushing repository rather than for the tree it was \
+             handed (#684). The hook said:\n{out}"
         );
     }
 }
 
-/// The behavioural half: hand `run-tests.sh` a tree and it must say, before
-/// it builds anything, that it is going to build that tree. `--plan` exists
-/// so this is answerable without Docker, and so a human can ask the same
-/// question from a worktree in under a second.
+/// The behavioural half on the `run-tests.sh` side: hand it a tree and it must
+/// say, before it builds anything, that it is going to build that tree.
+/// `--plan` exists so this is answerable without Docker, and so a human can
+/// ask the same question from a worktree in under a second.
 #[test]
 fn run_tests_plan_reports_the_tree_it_was_handed() {
     let core = tempfile::tempdir().expect("temp dir for a stand-in core crate");
@@ -176,13 +282,9 @@ fn run_tests_still_defaults_to_the_sibling_layout() {
     );
 }
 
-/// git hands every hook a `GIT_DIR`, and in a worktree it points at that
-/// worktree's admin directory. It beats both `git -C` and the working
-/// directory, so a `git` call made from inside the gate answers for the
-/// repository doing the pushing whatever directory it was aimed at. The first
-/// run of the fixed hook reported the pushing branch's HEAD as the revision of
-/// an unrelated tree, which is #684 wearing a different hat: a banner that
-/// names the wrong commit is no better than a gate that builds the wrong one.
+/// The same leak as `the_gate_drops_the_git_environment_it_inherited`, from
+/// the other side: even with a `GIT_DIR` set, `run-tests.sh` must describe the
+/// tree it was handed rather than the repository that exported it.
 #[test]
 fn run_tests_does_not_report_the_pushing_repo_as_another_tree() {
     let core = tempfile::tempdir().expect("temp dir for a stand-in core crate");
@@ -235,40 +337,5 @@ fn run_tests_does_not_report_the_pushing_repo_as_another_tree() {
         "run-tests.sh described a directory that is not a git checkout as though \
          it were one, which means it answered from the inherited GIT_DIR rather \
          than from the tree it was handed. Line was: {line}"
-    );
-}
-
-/// The same leak, from the hook's side: it has to drop the git environment
-/// before handing over, or every `git` call the suite makes inherits it.
-#[test]
-fn pre_push_hook_clears_the_inherited_git_environment() {
-    let hook = generated_pre_push();
-    assert!(
-        hook.contains("unset GIT_DIR"),
-        "the pre-push hook must unset GIT_DIR before running the suite; git \
-         exports it into hooks and it wins over `git -C`, so anything the \
-         suite asks git answers for the pushing repository (#684)"
-    );
-}
-
-/// Both slots get named, not just the one being pushed. run-tests.sh falls
-/// back to the siblings of wherever the script sits, and for a libviprs-tests
-/// push that script is inside the worktree, whose neighbours are other lanes.
-#[test]
-fn pre_push_hook_pins_both_trees_not_just_the_pushed_one() {
-    let hook = generated_pre_push();
-    let libviprs_arm = hook
-        .split("libviprs-tests)")
-        .next()
-        .expect("the case statement has a libviprs arm");
-    assert!(
-        libviprs_arm.contains("LIBVIPRS_TESTS_DIR=\"$WORKSPACE_ROOT/libviprs-tests\""),
-        "a libviprs push must also pin the test tree to the workspace sibling, \
-         rather than leaving run-tests.sh to infer it (#684)"
-    );
-    assert!(
-        hook.contains("LIBVIPRS_DIR=\"$WORKSPACE_ROOT/libviprs\""),
-        "a libviprs-tests push must also pin the core tree to the workspace \
-         sibling, rather than leaving run-tests.sh to infer it (#684)"
     );
 }

--- a/tests/prepush_hook_is_a_file.rs
+++ b/tests/prepush_hook_is_a_file.rs
@@ -1,0 +1,162 @@
+//! Guards on how the pre-push hook is delivered (libviprs/libviprs#695).
+//!
+//! It used to be a heredoc inside `tools/install-hooks.sh`, and three problems
+//! followed from that shape rather than from anything the hook does. A linter
+//! saw a string literal, so ~120 lines of shell got no static checking. A
+//! guard could only assert on it by substring, and two that did stayed green
+//! while the behaviour they named had been removed. And it reached a repo only
+//! when somebody re-ran the installer, with no version stamp in the generated
+//! file, so a stale install was undetectable: at any moment an unknown subset
+//! of checkouts was running an unknown vintage.
+//!
+//! That third one has bite. libviprs/libviprs#684 existed because a hook
+//! silently gated the wrong tree and read green, and the delivery mechanism
+//! guaranteed the next such fix would ship the same way.
+//!
+//! So the hook is a tracked file and the installer writes a shim that runs it.
+//! These guards are about that arrangement holding: they install into a
+//! throwaway workspace with the real installer, change the checked-in file
+//! without reinstalling, and check the change reaches the push.
+
+use std::path::Path;
+
+mod common;
+use common::hooks::{PRE_PUSH_HOOK, Workspace, git, repo_root};
+
+/// A line the hook prints so a push can say which copy of it ran.
+fn marked(hook: &Path, marker: &str) {
+    let body = std::fs::read_to_string(hook).expect("read the checked-in hook");
+    let (shebang, rest) = body.split_once('\n').expect("the hook has a shebang");
+    std::fs::write(hook, format!("{shebang}\necho \"{marker}\"\n{rest}"))
+        .expect("mark the checked-in hook");
+}
+
+/// Commit something the skip list cannot call inert, and hand back the range.
+fn a_change(ws: &Workspace, tree: &Path) -> (String, String) {
+    let before = git(tree, &["rev-parse", "HEAD"]).trim().to_string();
+    let after = ws.commit_in(
+        tree,
+        "a change the suite can see",
+        &[("src/lib.rs", "// c\n")],
+    );
+    (before, after)
+}
+
+/// The point of the whole change. Edit the checked-in hook, do not reinstall
+/// anything, and the next push runs the edited hook.
+///
+/// While it was a heredoc this could not hold: a fix reached a repo only when
+/// somebody re-ran `install-hooks.sh` there, and nothing anywhere could tell
+/// you which vintage a given clone was on.
+#[test]
+fn a_push_runs_the_checked_in_hook_without_a_reinstall() {
+    let ws = Workspace::new();
+    marked(&ws.checked_in_hook(), "HOOK-EDITED-AFTER-INSTALL");
+
+    let tree = ws.repo("libviprs");
+    let (before, after) = a_change(&ws, &tree);
+    let out = ws
+        .push("libviprs")
+        .range(&before, &after)
+        .with_git_env()
+        .run();
+
+    assert!(
+        out.contains("HOOK-EDITED-AFTER-INSTALL"),
+        "a push ran a copy of the hook rather than the checked-in file, so a \
+         fix to the hook reaches a repo only when somebody re-runs \
+         install-hooks.sh there and no clone can say which vintage it is on \
+         (#695). The hook said:\n{out}"
+    );
+}
+
+/// The same property under the case that produced #684: a harness push runs
+/// the hook it is pushing, out of the worktree, not the copy in the main
+/// checkout. Otherwise a change to the hook is gated by the hook it replaces.
+#[test]
+fn a_harness_push_runs_the_hook_it_is_pushing() {
+    let ws = Workspace::new();
+    marked(&ws.checked_in_hook(), "HOOK-FROM-THE-MAIN-CHECKOUT");
+    ws.commit("libviprs-tests", "mark the main checkout's hook", &[]);
+
+    let lane = ws.worktree("libviprs-tests", "harness-lane");
+    marked(&lane.join(PRE_PUSH_HOOK), "HOOK-FROM-THE-LANE");
+    let before = git(&lane, &["rev-parse", "HEAD"]).trim().to_string();
+    let after = ws.commit_in(&lane, "change the hook", &[]);
+
+    let out = ws
+        .push("libviprs-tests")
+        .from(&lane)
+        .range(&before, &after)
+        .with_git_env()
+        .run();
+
+    assert!(
+        out.contains("HOOK-FROM-THE-LANE"),
+        "a harness push ran a hook from outside the tree being pushed, so a \
+         change to the hook is gated by the hook it replaces (#684, #695). \
+         The hook said:\n{out}"
+    );
+    assert!(
+        !out.contains("HOOK-FROM-THE-MAIN-CHECKOUT"),
+        "the push ran the main checkout's hook as well as the lane's. \
+         The hook said:\n{out}"
+    );
+}
+
+/// Installing by reference has one failure mode a copy does not: the thing
+/// pointed at can go away. It must say so rather than let the push through,
+/// because a gate that disappears quietly is the failure #684 and #683 were
+/// both about.
+#[test]
+fn the_installed_shim_refuses_the_push_when_the_hook_is_gone() {
+    let ws = Workspace::new();
+    let hooks_dir = ws.repo("libviprs-tests").join("tools/hooks");
+    std::fs::rename(&hooks_dir, hooks_dir.with_extension("moved"))
+        .expect("move the checked-in hook out of the way");
+
+    let tree = ws.repo("libviprs");
+    let (before, after) = a_change(&ws, &tree);
+    let (allowed, out) = ws
+        .push("libviprs")
+        .range(&before, &after)
+        .with_git_env()
+        .try_run();
+
+    assert!(
+        !allowed,
+        "the push went through with no hook to run. A gate installed by \
+         reference has to fail loudly when the reference breaks, or moving a \
+         checkout turns the gate off in silence (#695). It said:\n{out}"
+    );
+    assert!(
+        out.contains(&hooks_dir.join("pre-push").display().to_string()),
+        "the refusal did not name the path it could not find, so nobody can \
+         act on it. It said:\n{out}"
+    );
+    assert!(
+        out.contains("install-hooks.sh"),
+        "the refusal did not say how to fix it. It said:\n{out}"
+    );
+}
+
+/// A copied-and-chmodded hook was executable because the installer made it so.
+/// A hook reached by reference is executable because git tracked the bit, and
+/// git will happily track it without one. A non-executable hook is not a
+/// broken hook, it is no hook: git skips it and says nothing.
+#[test]
+fn the_hook_is_tracked_executable() {
+    let entry = git(&repo_root(), &["ls-files", "-s", "--", PRE_PUSH_HOOK]);
+    let entry = entry.trim();
+    assert!(
+        !entry.is_empty(),
+        "git does not track {PRE_PUSH_HOOK}, so nothing ships it to a clone \
+         and every install points at a file that is not there (#695)"
+    );
+    assert!(
+        entry.starts_with("100755 "),
+        "{PRE_PUSH_HOOK} is tracked without the executable bit ({entry}). git \
+         skips a hook it cannot execute and prints nothing, so the gate would \
+         be off in every fresh clone with no sign of it"
+    );
+}

--- a/tests/prepush_hook_is_a_file.rs
+++ b/tests/prepush_hook_is_a_file.rs
@@ -21,14 +21,18 @@
 use std::path::Path;
 
 mod common;
-use common::hooks::{PRE_PUSH_HOOK, Workspace, git, repo_root};
+use common::hooks::{PRE_PUSH_HOOK, Workspace, git, make_executable, repo_root};
 
-/// A line the hook prints so a push can say which copy of it ran.
-fn marked(hook: &Path, marker: &str) {
-    let body = std::fs::read_to_string(hook).expect("read the checked-in hook");
+/// Write the real hook to `dest` with one extra line saying which copy of it
+/// ran. Always built from this repo's pristine copy, so marking a file never
+/// inherits a marker from whatever it is overwriting.
+fn marked(dest: &Path, marker: &str) {
+    let body = std::fs::read_to_string(repo_root().join(PRE_PUSH_HOOK))
+        .expect("read this repo's checked-in hook");
     let (shebang, rest) = body.split_once('\n').expect("the hook has a shebang");
-    std::fs::write(hook, format!("{shebang}\necho \"{marker}\"\n{rest}"))
-        .expect("mark the checked-in hook");
+    std::fs::write(dest, format!("{shebang}\necho \"{marker}\"\n{rest}"))
+        .expect("write a marked hook");
+    make_executable(dest);
 }
 
 /// Commit something the skip list cannot call inert, and hand back the range.

--- a/tools/gen_cli_expected.sh
+++ b/tools/gen_cli_expected.sh
@@ -3447,11 +3447,11 @@ References (paths relative to \`tests/fixtures/cli/\`):
 | \`resample/reduceh_expected.png\` | ≤1 LSB (1) | \`vips reduceh grad.png reduceh_expected.png 2\` |
 | \`resample/reducev_expected.png\` | ≤1 LSB (1) | \`vips reducev grad.png reducev_expected.png 2\` |
 | \`resample/resize_half_expected.png\` | ≤1 LSB (0) | \`vips resize rgb.png resize_half_expected.png 0.5\` |
-| \`resample/resize_vscale_expected.png\` | ≤1 LSB (0) | \`vips resize rgb.png resize_vscale_expected.png 0.5 --vscale 0.75\` |
+| \`resample/resize_vscale_expected.png\` | **EXACT (0)** | \`vips resize rgb.png resize_vscale_expected.png 0.5 --vscale 0.75\` |
 | \`resample/resize_up_expected.png\` | ≤1 LSB (1) | \`vips resize grad.png resize_up_expected.png 2.0\` (upscale → affine path) |
 | \`resample/resize_nearest_expected.png\` | ≤1 LSB (0) | \`vips resize rgb.png resize_nearest_expected.png 0.5 --kernel nearest\` |
 | \`resample/affine_bilinear_expected.png\` | ≤1 LSB (1) | \`vips affine rgb.png affine_bilinear_expected.png "1.5 0 0 1.5"\` (default bilinear) |
-| \`resample/affine_bicubic_expected.png\` | **2 LSB (2)** | \`vips affine rgb.png affine_bicubic_expected.png "1.5 0 0 1.5" --interpolate bicubic\` (bicubic quantises to 2 LSB — noted divergence) |
+| \`resample/affine_bicubic_expected.png\` | ≤1 LSB (1) | \`vips affine rgb.png affine_bicubic_expected.png "1.5 0 0 1.5" --interpolate bicubic\` (was 2 before libviprs#702 rounded the bicubic offset onto vips's grid) |
 | \`resample/similarity_angle_expected.png\` | ≤1 LSB (1) | \`vips similarity rgb.png similarity_angle_expected.png --angle 30\` |
 | \`resample/similarity_scale_expected.png\` | ≤1 LSB (1) | \`vips similarity rgb.png similarity_scale_expected.png --scale 1.5\` |
 | \`resample/rotate_expected.png\` | ≤1 LSB (1) | \`vips rotate rgb.png rotate_expected.png 30\` |
@@ -3459,7 +3459,7 @@ References (paths relative to \`tests/fixtures/cli/\`):
 | \`resample/mapim_bicubic_expected.png\` | ≤1 LSB (1) | \`vips mapim rgb.png mapim_bicubic_expected.png index.v --interpolate bicubic\` |
 | \`resample/thumbnail_expected.png\` | ≤1 LSB (0) | \`vips thumbnail rgb.png thumbnail_expected.png 16\` (FILENAME input) |
 | \`resample/thumbnail_crop_expected.png\` | ≤1 LSB (0) | \`vips thumbnail rgb.png thumbnail_crop_expected.png 16 --height 8 --crop centre\` (NON-square target — centre-crop removes pixels, 16×8, distinct from the no-crop fixtures) |
-| \`resample/thumbnail_linear_expected.png\` | ≤1 LSB (1) | \`vips thumbnail rgb.png thumbnail_linear_expected.png 16 --linear\` (linear-light reduce path) |
+| \`resample/thumbnail_linear_expected.png\` | ≤1 LSB (0) | \`vips thumbnail rgb.png thumbnail_linear_expected.png 16 --linear\` (linear-light reduce path) |
 | \`resample/thumbnail_image_expected.png\` | ≤1 LSB (0) | \`vips thumbnail_image rgb.png thumbnail_image_expected.png 16\` |
 
 **Open question**: \`affine … --interpolate bicubic\` measures **2 LSB** (not the

--- a/tools/hooks/pre-push
+++ b/tools/hooks/pre-push
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# pre-push: run the Docker test suite before pushing.
+#
+# This is a real file, tracked in libviprs-tests, and it is the hook: what
+# `tools/install-hooks.sh` puts in `.git/hooks/pre-push` is a shim that runs
+# this. It used to be a heredoc inside that script, and three things followed
+# from the shape rather than from anything it does (libviprs/libviprs#695):
+# a linter saw a string literal so ~120 lines of shell got no static checking,
+# a guard could only assert on it by substring (two of them passed
+# while the behaviour they named had been deleted), and it reached a repo only
+# when somebody re-ran the installer, so at any moment an unknown set of
+# checkouts was running an unknown vintage.
+#
+# Being a file fixes all three. It is linted in CI, the guards in
+# `tests/prepush_gate_tests_the_pushed_tree.rs` and
+# `tests/prepush_gate_cost_controls.rs` execute it with a synthetic ref-update
+# on stdin, and a pull updates every repo pointing at it.
+#
+# To skip (emergency only): git push --no-verify. For a skip decision you do
+# not trust, LIBVIPRS_PREPUSH_ALL=1 first.
+# ---------------------------------------------------------------------------
+
+# A repo's main checkout and all of its linked worktrees share one hooks
+# directory, and git invokes the hook with $0 inside that shared directory.
+# Anything resolved from $0 is therefore the main checkout, whichever tree is
+# actually being pushed, which is how every lane worktree on epic #520 gated
+# against `main` instead of against its own branch (libviprs/libviprs#684).
+# A worktree's .git is a file holding a gitdir: pointer rather than a
+# directory, so walking up from it does not work either. Ask git, which runs
+# hooks from the top of the working tree whose commits are going out.
+TREE="$(git rev-parse --show-toplevel)"
+
+# --git-common-dir is the *main* checkout's .git for a linked worktree, and a
+# path relative to here for the main checkout itself, so resolve it from the
+# tree rather than assuming it is absolute. Its parent tells us which repo
+# this is, and where the sibling libviprs-tests checkout lives.
+MAIN_CHECKOUT="$(cd "$TREE" && cd "$(dirname "$(git rev-parse --git-common-dir)")" && pwd)"
+REPO_NAME="$(basename "$MAIN_CHECKOUT")"
+WORKSPACE_ROOT="$(cd "$MAIN_CHECKOUT/.." && pwd)"
+RUN_TESTS="$WORKSPACE_ROOT/libviprs-tests/tools/run-tests.sh"
+
+# Hand the pushed tree to the suite in whichever slot it belongs. Without
+# this run-tests.sh falls back to the sibling checkouts, which is the whole
+# defect. There are two slots and this hook is only installed into the two
+# repos that have one (libviprs/libviprs#691).
+# Both slots get pinned, not just the one being pushed. run-tests.sh falls
+# back to the siblings of wherever the script itself sits, and the script the
+# line below may pick sits inside the worktree, whose neighbours are other
+# lanes rather than the workspace. Naming both leaves nothing to infer.
+case "$REPO_NAME" in
+    libviprs)
+        export LIBVIPRS_DIR="$TREE"
+        export LIBVIPRS_TESTS_DIR="$WORKSPACE_ROOT/libviprs-tests"
+        ;;
+    libviprs-tests)
+        export LIBVIPRS_TESTS_DIR="$TREE"
+        export LIBVIPRS_DIR="$WORKSPACE_ROOT/libviprs"
+        # A push that changes the harness gates on the harness it changes,
+        # not on the copy sitting in the main checkout.
+        if [ -x "$TREE/tools/run-tests.sh" ]; then
+            RUN_TESTS="$TREE/tools/run-tests.sh"
+        fi
+        ;;
+esac
+
+if [ ! -f "$RUN_TESTS" ]; then
+    echo "Warning: run-tests.sh not found at $RUN_TESTS"
+    echo "Skipping pre-push tests. Install libviprs-tests as a sibling directory."
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Is there anything in this push the suite could see?
+# ---------------------------------------------------------------------------
+# A full image build and suite run for a two-file workflow edit is what taught
+# everyone to reach for --no-verify, and a hook nobody runs protects nothing
+# (libviprs/libviprs#683). So skip, but only where the answer is knowable:
+# paths that no test in either repo reads. That list is deliberately short.
+#
+# README.md and CHANGELOG.md are NOT on it. This suite's documentation guards
+# read both, and they read them out of the *core* checkout as well as its own
+# (tests/feature_rename_docs_present.rs), so a docs-only push to either repo
+# can genuinely fail. Two entries are per-repo for the same reason: .github/
+# and .gitignore are inert for a libviprs push and read by a libviprs-tests
+# one, whose pinning guards read .github/workflows/*.yml (tests/common/
+# workflows.rs, tests/counterpart_pinning.rs) and whose provenance guard reads
+# .gitignore for the native-binary patterns (tests/pdfium_provenance.rs, issue
+# #56). A .gitignore-only push is exactly the push that can drop those
+# patterns, so it is the last one that should skip the guard on them.
+#
+# tests/prepush_gate_cost_controls.rs runs every tracked path in both repos
+# through this function for real and pins the set that comes back inert, so
+# adding an entry here fails there with the files it would newly exempt.
+#
+# Set LIBVIPRS_PREPUSH_ALL=1 to run the suite whatever the paths say.
+
+inert_path() {
+    case "$1" in
+        .github/*|.gitignore)
+            [ "$REPO_NAME" != "libviprs-tests" ]
+            ;;
+        docs/*|.gitattributes|.editorconfig|LICENSE|LICENSE-*)
+            true
+            ;;
+        *)
+            false
+            ;;
+    esac
+}
+
+REF_UPDATES="$(cat)"
+CHANGED=""
+SKIP_SUITE=false
+
+if [ "${LIBVIPRS_PREPUSH_ALL:-0}" != "1" ] && [ -n "$REF_UPDATES" ]; then
+    UNKNOWN=false
+    while read -r _local_ref local_oid _remote_ref remote_oid; do
+        if [ -z "${local_oid:-}" ]; then
+            continue
+        fi
+        # An all-zero local oid is a ref deletion: no content goes out.
+        case "$local_oid" in
+            *[!0]*) : ;;
+            *)      continue ;;
+        esac
+
+        BASE=""
+        case "${remote_oid:-}" in
+            *[!0]*)
+                if git cat-file -e "${remote_oid}^{commit}" 2>/dev/null; then
+                    BASE="$remote_oid"
+                fi
+                ;;
+        esac
+        if [ -z "$BASE" ]; then
+            # New branch. Compare against whatever the remote's default branch
+            # already has, and give up rather than guess if that is not here.
+            UPSTREAM="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+            if [ -z "$UPSTREAM" ]; then
+                UPSTREAM="origin/main"
+            fi
+            BASE="$(git merge-base "$local_oid" "$UPSTREAM" 2>/dev/null || true)"
+        fi
+        if [ -z "$BASE" ]; then
+            UNKNOWN=true
+            break
+        fi
+
+        # Unguarded this is a `set -e` exit: a git failure here would abort
+        # the push with nothing printed. A range we cannot diff is a range we
+        # cannot judge, which is the same answer as a base we could not find.
+        if ! REF_PATHS="$(git diff --name-only "$BASE" "$local_oid" --)"; then
+            UNKNOWN=true
+            break
+        fi
+        CHANGED="$CHANGED
+$REF_PATHS"
+    done <<REFS
+$REF_UPDATES
+REFS
+
+    if [ "$UNKNOWN" = false ]; then
+        SKIP_SUITE=true
+        while IFS= read -r changed_path; do
+            if [ -z "$changed_path" ]; then
+                continue
+            fi
+            if inert_path "$changed_path"; then
+                continue
+            fi
+            SKIP_SUITE=false
+            echo "Pre-push: $changed_path can reach the suite, running it."
+            break
+        done <<PATHS
+$CHANGED
+PATHS
+    fi
+fi
+
+if [ "$SKIP_SUITE" = true ]; then
+    echo "Pre-push: nothing in this push reaches the test suite, skipping it."
+    printf '%s\n' "$CHANGED" | sed '/^$/d; s/^/  /'
+    echo "  (LIBVIPRS_PREPUSH_ALL=1 runs it anyway)"
+    exit 0
+fi
+
+# git hands every hook a GIT_DIR (and, in a worktree, one pointing at the
+# per-worktree admin directory), and it wins over -C and over the working
+# directory for every git command anything below runs. Leaving it set made the
+# suite report this push's HEAD as the revision of trees it had never looked
+# at. The paths above are already resolved, so drop it here.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_QUARANTINE_PATH
+
+echo "Running pre-push test suite on $TREE..."
+if ! "$RUN_TESTS"; then
+    echo ""
+    echo "Pre-push tests failed. Push aborted."
+    echo "Fix the failures or use: git push --no-verify"
+    exit 1
+fi

--- a/tools/install-hooks.sh
+++ b/tools/install-hooks.sh
@@ -11,6 +11,9 @@ set -euo pipefail
 #                 Check & Lint. Update the per-repo cargo command lists below
 #                 when a repo's CI matrix changes, and re-run this script.
 #   pre-push    — Docker test suite via run-tests.sh (slow, on every push)
+#                 The hook itself is a tracked file, tools/hooks/pre-push;
+#                 what lands in .git/hooks is a shim that runs it
+#                 (libviprs/libviprs#695).
 #                 Runs against the working tree being pushed, which for a
 #                 linked worktree is not the main checkout the hooks
 #                 directory lives in (libviprs/libviprs#684). Only where the
@@ -175,195 +178,60 @@ HOOK
     chmod +x "$pre_commit"
 }
 
-write_pre_push() {
+# The pre-push hook is not generated. It is a real file at tools/hooks/pre-push
+# and this writes a shim that runs it, so a linter can see it, the guards can
+# execute it, and a pull into this checkout updates the hook in every repo
+# pointing at it instead of needing a redeploy per fix
+# (libviprs/libviprs#695).
+PRE_PUSH_HOOK="$SCRIPT_DIR/hooks/pre-push"
+
+install_pre_push() {
     local hooks_dir="$1"
     local pre_push="$hooks_dir/pre-push"
-    cat > "$pre_push" << 'HOOK'
-#!/usr/bin/env bash
-set -euo pipefail
 
-# Pre-push hook: run Docker test suite before pushing.
-# Installed by libviprs-tests/tools/install-hooks.sh
-# To skip (emergency only): git push --no-verify
-
-# A repo's main checkout and all of its linked worktrees share one hooks
-# directory, and git invokes the hook with $0 inside that shared directory.
-# Anything resolved from $0 is therefore the main checkout, whichever tree is
-# actually being pushed, which is how every lane worktree on epic #520 gated
-# against `main` instead of against its own branch (libviprs/libviprs#684).
-# A worktree's .git is a file holding a gitdir: pointer rather than a
-# directory, so walking up from it does not work either. Ask git, which runs
-# hooks from the top of the working tree whose commits are going out.
-TREE="$(git rev-parse --show-toplevel)"
-
-# --git-common-dir is the *main* checkout's .git for a linked worktree, and a
-# path relative to here for the main checkout itself, so resolve it from the
-# tree rather than assuming it is absolute. Its parent tells us which repo
-# this is, and where the sibling libviprs-tests checkout lives.
-MAIN_CHECKOUT="$(cd "$TREE" && cd "$(dirname "$(git rev-parse --git-common-dir)")" && pwd)"
-REPO_NAME="$(basename "$MAIN_CHECKOUT")"
-WORKSPACE_ROOT="$(cd "$MAIN_CHECKOUT/.." && pwd)"
-RUN_TESTS="$WORKSPACE_ROOT/libviprs-tests/tools/run-tests.sh"
-
-# Hand the pushed tree to the suite in whichever slot it belongs. Without
-# this run-tests.sh falls back to the sibling checkouts, which is the whole
-# defect. There are two slots and this hook is only installed into the two
-# repos that have one (libviprs/libviprs#691).
-# Both slots get pinned, not just the one being pushed. run-tests.sh falls
-# back to the siblings of wherever the script itself sits, and the script the
-# line below may pick sits inside the worktree, whose neighbours are other
-# lanes rather than the workspace. Naming both leaves nothing to infer.
-case "$REPO_NAME" in
-    libviprs)
-        export LIBVIPRS_DIR="$TREE"
-        export LIBVIPRS_TESTS_DIR="$WORKSPACE_ROOT/libviprs-tests"
-        ;;
-    libviprs-tests)
-        export LIBVIPRS_TESTS_DIR="$TREE"
-        export LIBVIPRS_DIR="$WORKSPACE_ROOT/libviprs"
-        # A push that changes the harness gates on the harness it changes,
-        # not on the copy sitting in the main checkout.
-        if [ -x "$TREE/tools/run-tests.sh" ]; then
-            RUN_TESTS="$TREE/tools/run-tests.sh"
-        fi
-        ;;
-esac
-
-if [ ! -f "$RUN_TESTS" ]; then
-    echo "Warning: run-tests.sh not found at $RUN_TESTS"
-    echo "Skipping pre-push tests. Install libviprs-tests as a sibling directory."
-    exit 0
-fi
-
-# ---------------------------------------------------------------------------
-# Is there anything in this push the suite could see?
-# ---------------------------------------------------------------------------
-# A full image build and suite run for a two-file workflow edit is what taught
-# everyone to reach for --no-verify, and a hook nobody runs protects nothing
-# (libviprs/libviprs#683). So skip, but only where the answer is knowable:
-# paths that no test in either repo reads. That list is deliberately short.
-#
-# README.md and CHANGELOG.md are NOT on it. This suite's documentation guards
-# read both, and they read them out of the *core* checkout as well as its own
-# (tests/feature_rename_docs_present.rs), so a docs-only push to either repo
-# can genuinely fail. Two entries are per-repo for the same reason: .github/
-# and .gitignore are inert for a libviprs push and read by a libviprs-tests
-# one, whose pinning guards read .github/workflows/*.yml (tests/common/
-# workflows.rs, tests/counterpart_pinning.rs) and whose provenance guard reads
-# .gitignore for the native-binary patterns (tests/pdfium_provenance.rs, issue
-# #56). A .gitignore-only push is exactly the push that can drop those
-# patterns, so it is the last one that should skip the guard on them.
-#
-# tests/prepush_gate_cost_controls.rs runs every tracked path in both repos
-# through this function for real and pins the set that comes back inert, so
-# adding an entry here fails there with the files it would newly exempt.
-#
-# Set LIBVIPRS_PREPUSH_ALL=1 to run the suite whatever the paths say.
-
-inert_path() {
-    case "$1" in
-        .github/*|.gitignore)
-            [ "$REPO_NAME" != "libviprs-tests" ]
-            ;;
-        docs/*|.gitattributes|.editorconfig|LICENSE|LICENSE-*)
-            true
-            ;;
-        *)
-            false
-            ;;
-    esac
-}
-
-REF_UPDATES="$(cat)"
-CHANGED=""
-SKIP_SUITE=false
-
-if [ "${LIBVIPRS_PREPUSH_ALL:-0}" != "1" ] && [ -n "$REF_UPDATES" ]; then
-    UNKNOWN=false
-    while read -r _local_ref local_oid _remote_ref remote_oid; do
-        if [ -z "${local_oid:-}" ]; then
-            continue
-        fi
-        # An all-zero local oid is a ref deletion: no content goes out.
-        case "$local_oid" in
-            *[!0]*) : ;;
-            *)      continue ;;
-        esac
-
-        BASE=""
-        case "${remote_oid:-}" in
-            *[!0]*)
-                if git cat-file -e "${remote_oid}^{commit}" 2>/dev/null; then
-                    BASE="$remote_oid"
-                fi
-                ;;
-        esac
-        if [ -z "$BASE" ]; then
-            # New branch. Compare against whatever the remote's default branch
-            # already has, and give up rather than guess if that is not here.
-            UPSTREAM="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
-            if [ -z "$UPSTREAM" ]; then
-                UPSTREAM="origin/main"
-            fi
-            BASE="$(git merge-base "$local_oid" "$UPSTREAM" 2>/dev/null || true)"
-        fi
-        if [ -z "$BASE" ]; then
-            UNKNOWN=true
-            break
-        fi
-
-        # Unguarded this is a `set -e` exit: a git failure here would abort
-        # the push with nothing printed. A range we cannot diff is a range we
-        # cannot judge, which is the same answer as a base we could not find.
-        if ! REF_PATHS="$(git diff --name-only "$BASE" "$local_oid" --)"; then
-            UNKNOWN=true
-            break
-        fi
-        CHANGED="$CHANGED
-$REF_PATHS"
-    done <<REFS
-$REF_UPDATES
-REFS
-
-    if [ "$UNKNOWN" = false ]; then
-        SKIP_SUITE=true
-        while IFS= read -r changed_path; do
-            if [ -z "$changed_path" ]; then
-                continue
-            fi
-            if inert_path "$changed_path"; then
-                continue
-            fi
-            SKIP_SUITE=false
-            echo "Pre-push: $changed_path can reach the suite, running it."
-            break
-        done <<PATHS
-$CHANGED
-PATHS
+    if [ ! -x "$PRE_PUSH_HOOK" ]; then
+        echo "Error: no executable pre-push hook at $PRE_PUSH_HOOK." >&2
+        echo "It is tracked in this repo; check the checkout is complete and" >&2
+        echo "that the executable bit survived." >&2
+        exit 1
     fi
+
+    # Unquoted marker: the installed path is baked in here, once, at install
+    # time. Nothing else in this chunk expands.
+    cat > "$pre_push" << HOOK
+#!/usr/bin/env bash
+# Pre-push shim. Installed by libviprs-tests/tools/install-hooks.sh
+# To skip (emergency only): git push --no-verify
+#
+# No behaviour lives here on purpose. The hook is checked in at
+# libviprs-tests/tools/hooks/pre-push (libviprs/libviprs#695); this only points
+# at it, so a pull updates every repo at once and no clone can quietly run a
+# vintage nobody can name.
+HOOK_PATH="$PRE_PUSH_HOOK"
+HOOK
+
+    cat >> "$pre_push" << 'HOOK'
+
+# A harness push runs the hook it is pushing, the same way it gates on the
+# suite it is pushing (libviprs/libviprs#684). Only libviprs-tests carries this
+# file, so for every other repo the test below is simply false.
+TREE="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -n "$TREE" ] && [ -x "$TREE/tools/hooks/pre-push" ]; then
+    HOOK_PATH="$TREE/tools/hooks/pre-push"
 fi
 
-if [ "$SKIP_SUITE" = true ]; then
-    echo "Pre-push: nothing in this push reaches the test suite, skipping it."
-    printf '%s\n' "$CHANGED" | sed '/^$/d; s/^/  /'
-    echo "  (LIBVIPRS_PREPUSH_ALL=1 runs it anyway)"
-    exit 0
-fi
-
-# git hands every hook a GIT_DIR (and, in a worktree, one pointing at the
-# per-worktree admin directory), and it wins over -C and over the working
-# directory for every git command anything below runs. Leaving it set made the
-# suite report this push's HEAD as the revision of trees it had never looked
-# at. The paths above are already resolved, so drop it here.
-unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_PREFIX GIT_QUARANTINE_PATH
-
-echo "Running pre-push test suite on $TREE..."
-if ! "$RUN_TESTS"; then
-    echo ""
-    echo "Pre-push tests failed. Push aborted."
-    echo "Fix the failures or use: git push --no-verify"
+# Installing by reference has one failure mode copying does not: the file can
+# go away, and git skips a hook it cannot execute without printing anything. A
+# gate that disappears in silence is the failure #683 and #684 were both about,
+# so refuse the push and say where to look.
+if [ ! -x "$HOOK_PATH" ]; then
+    echo "pre-push: no executable hook at $HOOK_PATH" >&2
+    echo "Re-run libviprs-tests/tools/install-hooks.sh, or restore that checkout." >&2
+    echo "To push without a gate: git push --no-verify" >&2
     exit 1
 fi
+
+exec "$HOOK_PATH" "$@"
 HOOK
     chmod +x "$pre_push"
 }
@@ -533,7 +401,7 @@ for REPO_DIR in "${REPOS[@]}"; do
             # for the cli it gates the cli.
             write_pre_commit "$HOOKS_DIR" "$REPO_NAME"
             if has_suite_slot "$REPO_NAME"; then
-                write_pre_push "$HOOKS_DIR"
+                install_pre_push "$HOOKS_DIR"
                 echo "  done: $REPO_NAME (pre-commit + pre-push)"
             else
                 echo "  done: $REPO_NAME (pre-commit only; the suite has no slot for it)"

--- a/tools/install-hooks.sh
+++ b/tools/install-hooks.sh
@@ -38,19 +38,34 @@ REPOS=(
 )
 
 # ---------------------------------------------------------------------------
-# Per-repo cargo lint/check commands. Keep these in lockstep with the
-# `cargo` lines under the Check & Lint / lint-and-build jobs in each repo's
-# `.github/workflows/ci.yml`. They run in order; the first failure aborts.
+# Per-repo cargo lint commands, in lockstep with the `cargo clippy` and
+# `cargo fmt` lines in each repo's `.github/workflows/ci.yml`, feature matrix
+# expanded. They run in order; the first failure aborts.
+#
+# `tests/install_hooks_mirror_ci.rs` enforces the lockstep by running the
+# generated hook with a recording stand-in for `cargo` and comparing what it
+# invokes against those workflow lines, so a list that drifts fails there
+# naming the passes it lost. It used to be a comment asking a human to keep
+# them in step, and the core's list sat at two of five passes for as long as
+# that was true (libviprs/libviprs#715).
 #
 # `cargo clippy` already runs `cargo check`'s work, so we don't repeat the
 # explicit `cargo check --all-targets` lines that CI also has — clippy
-# covers them.
+# covers them. The core's `cargo build --features s3` is also out: it is there
+# to prove a deprecated alias still resolves, which the manifest settles
+# without a whole extra build on every commit.
 # ---------------------------------------------------------------------------
 
-# libviprs has both default-features and `--features pdfium` clippy passes.
+# libviprs lints the default cell and four feature-gated ones. Each of the
+# latter is in CI because the default pass compiles none of that code:
+# object-store-sink (#382), svg (#502) and jxl (#500) are all non-default and
+# all have `#[cfg(test)] mod tests` the default job never sees.
 LIBVIPRS_CARGO_STEPS=(
     "cargo clippy --all-targets -- -D warnings -W clippy::incompatible_msrv -W deprecated"
     "cargo clippy --all-targets --features pdfium -- -D warnings -W clippy::incompatible_msrv -W deprecated"
+    "cargo clippy --all-targets --features object-store-sink -- -D warnings -W clippy::incompatible_msrv -W deprecated"
+    "cargo clippy --all-targets --features svg -- -D warnings -W clippy::incompatible_msrv -W deprecated"
+    "cargo clippy --all-targets --features jxl -- -D warnings -W clippy::incompatible_msrv -W deprecated"
 )
 
 # libviprs-cli has no `pdfium` feature; one clippy pass.
@@ -59,18 +74,22 @@ LIBVIPRS_CLI_CARGO_STEPS=(
 )
 
 # libviprs-tests CI is plainer — no incompatible_msrv / deprecated lints.
-# These mirror the ci.yml jobs one-for-one so the enforced local mirror
-# compiles and lints every feature cell, not just the default one. Without
-# the per-feature passes a regression in the s3 / packfile / tracing gated
-# modules ships green locally because the default harness never compiles that
-# code (the failure #55 targets). The ported step is scoped through
+# These mirror the ci.yml `feature-cells` matrix one-for-one so the enforced
+# local mirror compiles and lints every feature cell, not just the default
+# one. Without the per-feature passes a regression in the object-store-sink /
+# packfile / tracing / jxl gated modules ships green locally because the
+# default harness never compiles that code (the failure #55 targets). `s3`
+# stood here in place of `object-store-sink` for a while, which is the same
+# feature under a deprecated alias, so the `jxl` cell was the one going
+# unlinted (libviprs/libviprs#715). The ported step is scoped through
 # tools/run_ported_cells.sh because the three deferred codec cells do not
 # compile yet (issue #77), so `--all-targets` cannot carry that feature.
 LIBVIPRS_TESTS_CARGO_STEPS=(
     "cargo clippy --all-targets -- -D warnings"
-    "cargo clippy --all-targets --features s3 -- -D warnings"
+    "cargo clippy --all-targets --features object-store-sink -- -D warnings"
     "cargo clippy --all-targets --features packfile -- -D warnings"
     "cargo clippy --all-targets --features tracing -- -D warnings"
+    "cargo clippy --all-targets --features jxl -- -D warnings"
     "./tools/run_ported_cells.sh --clippy"
 )
 


### PR DESCRIPTION
Closes libviprs/libviprs#695.
Closes libviprs/libviprs#715.
Closes libviprs/libviprs#723.

Housekeeping PR. #173, #174 and #175 were a stack on top of #172, and when #172
squash-merged the three of them merged into each other's base branches instead
of into `main`, so their content never landed and their issues stayed open.
This is the same three changes, unchanged, pointed at `main` where the closing
keywords can actually fire.

What is in it, in order:

- **#173 (issue #695)** — the pre-push hook is now `tools/hooks/pre-push`, a
  tracked `100755` file, and `install-hooks.sh` writes a shim that `exec`s it.
  `shellcheck tools/*.sh tools/hooks/pre-push` runs in the lint job, and caught
  SC1072 on its first run over the extracted file. `core.hooksPath` was
  considered and rejected, with the reasoning in #173.
- **#174 (issue #715)** — the pre-commit hook claimed to mirror each repo's CI
  lint job exactly and ran 2 of the core's 5 clippy passes and 4 of 5 here. The
  lists are fixed and a guard enforces them, replacing a "keep these in
  lockstep" comment.
- **#175 (issue #723)** — `AFFINE_BICUBIC_TOL = 2.0` is gone and
  `resize_vscale` is pinned at exactly 0, now that core #702 has landed.

**The acceptance criterion #695 was filed for.** Every new guard installs into a
throwaway workspace with the real `install-hooks.sh` and drives the installed
hook with a synthetic ref-update on stdin, from a linked worktree as well as a
main checkout. None of them inspects the hook by substring. The five substring
assertions that passed while the behaviour they named had been removed are
deleted.

The evidence that mattered, measured on `87e8103`: three mutations that break
the behaviour and leave the substring in a comment. All four old substring
guards stay green through every one; the new executing guards catch all three.

**One correction to the review finding that prompted #175.** The panel named
`resize --vscale 0.75` as the cell absorbing the divergence. It is not: it reads
0 before the fix, 0 after, and 0 with #668 fully reverted. On a float `.v` the
two binaries differ; on the committed uchar PNG they are byte-identical, so the
harness cannot see it there at all. Exactly one of the 22 cells moves under
anything, `affine 1.5 bicubic`, 2 to 1, attributed to the bicubic call site by a
targeted revert. That is why **libviprs/libviprs#724** is filed: the reduce half
of #668 has no guard here and no tolerance can give it one, because every
carrier in this file is uchar and the difference rounds away.

Local gate on the head: `cargo fmt --check` clean, `shellcheck tools/*.sh
tools/hooks/pre-push` clean, clippy silent under `RUSTFLAGS=-Dwarnings`, and
`cargo test` **772 passed / 0 failed / 11 ignored**.

---

Rebased onto `main` after #172 squash-merged, which is what left the original stack pointing at deleted bases. Two commits dropped as already upstream; the rest replayed clean. Gate on the rebased head: `cargo fmt --check` clean, `shellcheck` clean, clippy silent, **772 passed / 0 failed / 11 ignored**.