### PR TITLE
docs(resample): stop the provenance documenting #668 as a design decision

### DIFF
--- a/tests/cli_fixture_audit.rs
+++ b/tests/cli_fixture_audit.rs
@@ -475,7 +475,8 @@ const REQUIRED_FIXTURES: &[&str] = &[
     "resample/resize_vscale_float_expected.v",
     "resample/resize_up_expected.png",
     "resample/resize_nearest_expected.png",
-    // affine (bilinear default ≤1 LSB; bicubic 2 LSB, noted divergence).
+    // affine (bilinear default; bicubic, which measured 2 LSB until libviprs#702
+    // rounded its offset onto vips's grid and now measures 1).
     "resample/affine_bilinear_expected.png",
     "resample/affine_bicubic_expected.png",
     // similarity (--angle / --scale) / rotate.

--- a/tests/cli_fixture_audit.rs
+++ b/tests/cli_fixture_audit.rs
@@ -475,8 +475,8 @@ const REQUIRED_FIXTURES: &[&str] = &[
     "resample/resize_vscale_float_expected.v",
     "resample/resize_up_expected.png",
     "resample/resize_nearest_expected.png",
-    // affine (bilinear default; bicubic, which measured 2 LSB until libviprs#702
-    // rounded its offset onto vips's grid and now measures 1).
+    // affine (bilinear, held at 1 LSB by libviprs#733's BILINEAR_INT weights;
+    // bicubic, 2 LSB until libviprs#702 and 1 until libviprs#704, EXACT now).
     "resample/affine_bilinear_expected.png",
     "resample/affine_bicubic_expected.png",
     // similarity (--angle / --scale) / rotate.

--- a/tests/cli_resample_diff.rs
+++ b/tests/cli_resample_diff.rs
@@ -8,21 +8,29 @@
 //! and committed. This cell copies the bands / morphology reference cells
 //! exactly — including the skip-guard / `VIPRS_REQUIRE_CLI` discipline.
 //!
-//! **Every resample op is oracle class BOUNDED-TOL** (the premultiply / rounding
-//! campaign #406-418), and since libviprs#668 the reason is a narrower one than
-//! this header used to give. The core no longer evaluates the reduce and
-//! bicubic kernels at the true sub-pixel offset. `table_offset` rounds the
-//! offset onto the same 65-entry grid `vips_reduceh` and
-//! `vips_interpolate_bicubic_interpolate` round onto, so the offset is not a
-//! source of divergence on either side any more.
+//! **Most resample ops are now bit-exact against the oracle**, which is not what
+//! this header said a landing ago. Three quantisations closed in sequence:
+//! `table_offset` rounds the sub-pixel offset onto libvips' 65-entry grid at
+//! both the reduce and the bicubic call sites (libviprs#668), the `uchar`
+//! bicubic reads `vips_bicubic_matrixi` as 12-bit fixed point the way
+//! `bicubic_unsigned_int_tab` does (libviprs#704), and the float bicubic
+//! narrows each row sum through `cubic_float<float>` the way vips does
+//! (libviprs#705). Measured against core `ed958d5`, **seventeen of the 23
+//! comparison cells here read 0** and six read 1.
 //!
-//! Two smaller things are left, and both have an issue of their own. On the
-//! integer carriers vips quantises the coefficients themselves, `matrixs` in
-//! reduce and `matrixi` in bicubic, where the core stays in f64
-//! (libviprs#704). And `bicubic_float` sums four rows and then the columns
-//! while the core runs one 16-term sum, which reassociates the same products
-//! and moves the last bit (libviprs#705). Together they are worth ≤1 LSB on a
-//! uchar carrier, and they are what the nine cells measuring 1 are made of.
+//! **The six that read 1 are two named divergences, not slack**, and both are
+//! carrier effects that go to 0 on the identical content promoted to float:
+//!
+//! * `affine` bilinear, both `similarity` cells and `rotate` carry
+//!   libviprs#733. vips sends an integer carrier to `BILINEAR_INT`, whose four
+//!   weights are truncated to 12-bit fixed point; the core keeps f64 because
+//!   adopting the quantisation would introduce 6.28 LSB of new error on a
+//!   16-bit carrier where there is currently none. That is a decision with a
+//!   measurement behind it, recorded in `src/resample.rs`.
+//! * `reduceh` and `reducev` carry libviprs#777, the `matrixs` fixed-point copy
+//!   of the reduce mask vips uses on the integer carriers. That one is
+//!   undecided rather than decided, and it is the last quantisation in the
+//!   family with no answer yet.
 //!
 //! **What this header said before, and why it mattered.** It said the core
 //! computed the masks in `f64` per output position "so the two agree to ≤1
@@ -31,14 +39,37 @@
 //! down as a design decision in two places across two repos, and it is a fair
 //! part of why the bug lasted. Both are gone.
 //!
-//! **What is pinned, and what deliberately is not** (measured in
-//! libviprs#723). After libviprs#702 thirteen of the 22 uchar comparison cells
-//! measure 0 and nine measure 1. Six mutations of the resampling offset, from
-//! reverting it outright to coarsening the grid four times over, move exactly
-//! two of them: `resize --vscale 0.75` and `affine … --interpolate bicubic`.
-//! Those two are pinned at what they measure, 0 and 1. The other twelve zeroes
-//! stay at ≤1, because no mutation of the offset separates 0 from 1 on them, so
-//! pinning them would buy no falsifiability and cost a vips-version tripwire.
+//! **What is pinned, and what deliberately is not.** A cell earns [`EXACT`] by
+//! being separated from 1 by a mutation of the thing it guards, never by
+//! happening to measure 0, because a pin that no mutation moves buys no
+//! falsifiability and costs a vips-version tripwire (libviprs#723). Eight
+//! mutations of a scratch core at `ed958d5`, and the only rows that move:
+//!
+//! | cell | tol | `ed958d5` | r1 | r2 | r3 | r4 | r5 | r6 | m704 | m705 |
+//! |---|---|---|---|---|---|---|---|---|---|---|
+//! | `resize 0.5 --vscale 0.75`, uchar | 0 | 0 | 0 | 0 | 0 | 1 | 0 | 1 | 0 | 0 |
+//! | `resize 0.5 --vscale 0.75`, float | 0 | 0 | .697 | .697 | 0 | 2.09 | 0 | 2.10 | 0 | 0 |
+//! | `resize 2.0` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | **1** | 0 |
+//! | `affine … bicubic` | 0 | 0 | 3 | 0 | 3 | 7 | 0 | 7 | **1** | 0 |
+//! | `mapim … bicubic` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | **1** | 0 |
+//!
+//! r1 reverts libviprs#668 outright, r2 its `reduce_axis` call site only, r3 its
+//! bicubic call sites only, r4 and r6 coarsen the 1/64 offset grid to 1/32 and
+//! 1/16, r5 truncates where `table_offset` floors, m704 stops the `uchar`
+//! bicubic taking the fixed-point arm, m705 stops the float rows narrowing.
+//! Every other cell reads the same in all nine columns, so the twelve remaining
+//! zeroes stay at [`BT1`] and the six ones stay there too.
+//!
+//! **m705 moves nothing here**, which is a hole rather than a result: #705 only
+//! fires on the float arm of the bicubic interpolator, every bicubic cell in
+//! this file is `uchar`, and the one float cell goes through `reduce_axis`.
+//! libviprs#780 is that hole.
+//!
+//! **r5 moves nothing either, and that one is fine.** floor and truncate differ
+//! only on a negative source coordinate, which these ops never produce; the
+//! core's own `resize_quantises_a_negative_source_coordinate_the_way_vips_shifted_space_does`
+//! fails at 0.1227 under r5, so the arm has a guard, just not one a CLI
+//! differential could carry.
 //!
 //! **The 23rd comparison cell is the reduce half of libviprs#668**
 //! (libviprs#724). No uchar cell can see that half and no tolerance can give
@@ -86,18 +117,42 @@ use common::cli::{cli_available, cli_fixture, decode_compare, run_viprs, run_vip
 
 use tempfile::TempDir;
 
-/// BOUNDED-TOL ≤1 LSB (CLI_CONTRACT.md §5): what is left of the core-vs-vips
-/// difference once both sides round the sub-pixel offset onto the same grid.
-/// The residual is the coefficient tables on the integer carriers
-/// (libviprs#704) plus the bicubic accumulation order (libviprs#705).
+/// BOUNDED-TOL ≤1 LSB (CLI_CONTRACT.md §5). Six cells are held here and every
+/// one of them is a carrier effect that goes to 0 on the identical content
+/// promoted to float, so this is not slack, it is two named divergences:
+///
+/// * `affine` bilinear, `similarity --angle`, `similarity --scale` and `rotate`
+///   carry libviprs#733. `SWITCH_INTERPOLATE` sends a `uchar` carrier to
+///   `BILINEAR_INT`, whose four weights are truncated to 12-bit fixed point,
+///   and the core deliberately keeps `f64` there: adopting the quantisation
+///   would introduce a mean error of 6.28 LSB on a 16-bit carrier where there
+///   is currently none. That decision is recorded in `src/resample.rs`, so this
+///   1 is permanent until that changes.
+/// * `reduceh` and `reducev` carry libviprs#777, the `matrixs` fixed-point copy
+///   of the reduce mask that vips uses on the integer carriers and the core
+///   does not. That one is undecided rather than decided.
+///
+/// It is NOT a general slack: everything else in this file measures 0 and is
+/// pinned at [`EXACT`].
 const BT1: f64 = 1.0;
 
-/// Bit-exact. Two cells are held here, both `resize 0.5 --vscale 0.75`: the
-/// uchar one because it is the one uchar cell besides `affine … bicubic` that a
-/// wrong resampling offset moves at all (libviprs#723), and the float one
-/// because on that carrier the same op is bit-exact and a wrong offset is worth
-/// 0.697 of a unit (libviprs#724). Twelve more cells measure 0, and they stay at
-/// [`BT1`] because no mutation of the offset separates 0 from 1 on them.
+/// Bit-exact. Five cells are held here, and the test for admitting one is not
+/// "it measures 0" but "a mutation of the thing it guards separates 0 from 1 on
+/// it" (libviprs#723). Seventeen cells measure 0 against core `ed958d5`; these
+/// five are the ones that earn the pin:
+///
+/// * `resize 0.5 --vscale 0.75` on `rgb.png`, which a resampling offset rounded
+///   onto the wrong grid moves to 1 (libviprs#723).
+/// * the same op on the float `hf.v`, where reverting libviprs#668's reduce
+///   half is worth 0.697 of a unit (libviprs#724).
+/// * `resize 2.0`, `affine … bicubic` and `mapim … bicubic`, which all read 1
+///   again with libviprs#704 reverted. They measured 1 themselves until that
+///   landed, so [`BT1`] on them now absorbs exactly the fix they exist to guard
+///   (libviprs#753).
+///
+/// The other twelve zeroes stay at [`BT1`], because no mutation in the table in
+/// this module's header separates 0 from 1 on them: pinning them would buy no
+/// falsifiability and cost a vips-version tripwire.
 const EXACT: f64 = 0.0;
 
 /// Skip-guard: `true` (with a printed reason) when the CLI sibling is absent.
@@ -223,6 +278,10 @@ fn reduceh_matches_vips_bounded_tol() {
         return;
     }
     let out = op("reduceh.png");
+    // MEASURED 1, and it is a carrier effect: the same content promoted to float
+    // reads 0. vips reduces an integer carrier through the `matrixs` fixed-point
+    // copy of the mask where the core stays in f64 (libviprs#777), which is the
+    // last quantisation in this family still undecided.
     run_viprs_ok(&["reduceh", &fx(GRAD), &out, "2"]);
     decode_compare(
         &PathBuf::from(&out),
@@ -237,6 +296,7 @@ fn reducev_matches_vips_bounded_tol() {
         return;
     }
     let out = op("reducev.png");
+    // MEASURED 1, same `matrixs` divergence as `reduceh` (libviprs#777).
     run_viprs_ok(&["reducev", &fx(GRAD), &out, "2"]);
     decode_compare(
         &PathBuf::from(&out),
@@ -321,18 +381,21 @@ fn resize_vscale_float_matches_vips_exactly() {
 }
 
 #[test]
-fn resize_up_matches_vips_bounded_tol() {
+fn resize_up_matches_vips_exactly() {
     if skip_if_no_cli("resize_up") {
         return;
     }
     let out = op("resize_up.png");
     // An UPSCALE exercises the affine enlargement path (distinct from the reduce
-    // downscale path the other resize cases take).
+    // downscale path the other resize cases take), and on a `uchar` carrier that
+    // path is the fixed-point bicubic. MEASURED 0 since libviprs#704, 1 before
+    // it and 1 again with it reverted, so EXACT is what makes this cell able to
+    // tell the two apart and BT1 was absorbing it (libviprs#753).
     run_viprs_ok(&["resize", &fx(GRAD), &out, "2.0"]);
     decode_compare(
         &PathBuf::from(&out),
         &cli_fixture("resample/resize_up_expected.png"),
-        BT1,
+        EXACT,
     );
 }
 
@@ -363,6 +426,12 @@ fn affine_bilinear_matches_vips_bounded_tol() {
     }
     let out = op("affine_bilinear.png");
     // No --interpolate: viprs default bilinear == vips's affine interpolator default.
+    // MEASURED 1, and it is a carrier effect: the same content promoted to float
+    // reads 0. `SWITCH_INTERPOLATE` sends a `uchar` carrier to `BILINEAR_INT`,
+    // whose four weights are truncated to 12-bit fixed point, and the core keeps
+    // f64 there on purpose (libviprs#733 measures adopting it at 6.28 LSB of new
+    // error on a 16-bit carrier). So this 1 is a decision, not slack, and it is
+    // the same 1 the two `similarity` cells and `rotate` carry.
     run_viprs_ok(&["affine", &fx(RGB), &out, "1.5 0 0 1.5"]);
     decode_compare(
         &PathBuf::from(&out),
@@ -372,17 +441,23 @@ fn affine_bilinear_matches_vips_bounded_tol() {
 }
 
 #[test]
-fn affine_bicubic_matches_vips_bounded_tol() {
+fn affine_bicubic_matches_vips_exactly() {
     if skip_if_no_cli("affine_bicubic") {
         return;
     }
     let out = op("affine_bicubic.png");
     // This used to be the ONE resample case that exceeded 1 LSB, at a measured
     // 2, and the reason given for it was the divergence libviprs#668 turned out
-    // to be. It MEASURES 1 once the core rounds the bicubic offset onto vips's
-    // grid, and 2 again if that is reverted, so BT1 is what makes this cell able
-    // to tell the two apart. It NEEDS core libviprs#702: against a core without
-    // it this is red, which is the point.
+    // to be. Two landings closed it. libviprs#702 rounded the bicubic offset
+    // onto vips's 1/64 grid and took it from 2 to 1; libviprs#704 ported
+    // `vips_bicubic_matrixi`, the 12-bit fixed-point coefficients
+    // `bicubic_unsigned_int_tab` reads on a `uchar` carrier, and took it from 1
+    // to 0.
+    //
+    // So EXACT here is three assertions in one, each with a mutation behind it:
+    // 1 with libviprs#704 reverted, 3 with libviprs#702's bicubic call sites
+    // reverted, 7 with the offset grid coarsened to 1/32. BT1 would pass the
+    // first of those, which is why it moved (libviprs#753).
     run_viprs_ok(&[
         "affine",
         &fx(RGB),
@@ -394,7 +469,7 @@ fn affine_bicubic_matches_vips_bounded_tol() {
     decode_compare(
         &PathBuf::from(&out),
         &cli_fixture("resample/affine_bicubic_expected.png"),
-        BT1,
+        EXACT,
     );
 }
 
@@ -408,6 +483,7 @@ fn similarity_angle_matches_vips_bounded_tol() {
         return;
     }
     let out = op("similarity_angle.png");
+    // MEASURED 1, the `BILINEAR_INT` divergence (libviprs#733).
     run_viprs_ok(&["similarity", &fx(RGB), &out, "--angle", "30"]);
     decode_compare(
         &PathBuf::from(&out),
@@ -422,6 +498,7 @@ fn similarity_scale_matches_vips_bounded_tol() {
         return;
     }
     let out = op("similarity_scale.png");
+    // MEASURED 1, the `BILINEAR_INT` divergence (libviprs#733).
     run_viprs_ok(&["similarity", &fx(RGB), &out, "--scale", "1.5"]);
     decode_compare(
         &PathBuf::from(&out),
@@ -436,6 +513,7 @@ fn rotate_matches_vips_bounded_tol() {
         return;
     }
     let out = op("rotate.png");
+    // MEASURED 1, the `BILINEAR_INT` divergence (libviprs#733).
     run_viprs_ok(&["rotate", &fx(RGB), &out, "30"]);
     decode_compare(
         &PathBuf::from(&out),
@@ -463,11 +541,15 @@ fn mapim_bilinear_matches_vips_bounded_tol() {
 }
 
 #[test]
-fn mapim_bicubic_matches_vips_bounded_tol() {
+fn mapim_bicubic_matches_vips_exactly() {
     if skip_if_no_cli("mapim_bicubic") {
         return;
     }
     let out = op("mapim_bicubic.png");
+    // MEASURED 0 since libviprs#704, and 1 with it reverted. `index.v` is an
+    // exact 2x zoom so every offset lands on the 1/64 grid and no mutation of
+    // the OFFSET moves this cell at all; the fixed-point coefficients are the
+    // only thing it can see, and BT1 could not see them (libviprs#753).
     run_viprs_ok(&[
         "mapim",
         &fx(RGB),
@@ -479,7 +561,7 @@ fn mapim_bicubic_matches_vips_bounded_tol() {
     decode_compare(
         &PathBuf::from(&out),
         &cli_fixture("resample/mapim_bicubic_expected.png"),
-        BT1,
+        EXACT,
     );
 }
 

--- a/tests/fixtures/cli/PROVENANCE.md
+++ b/tests/fixtures/cli/PROVENANCE.md
@@ -1147,9 +1147,20 @@ output against. Generated offline by `tools/gen_cli_expected.sh`, NEVER by CI.
   values in 0..250, all exactly representable in f32, high-frequency in both
   axes — the carrier the reduce half of libviprs#668 survives on).
 - **EVERY op is BOUNDED-TOL for NON-ALPHA inputs** (the premultiply / rounding
-  campaign #406-418): the core computes reduce / interpolate masks in f64 per
-  output position while vips quantises the sub-pixel offset into fixed-point
-  tables, so the two agree to ≤1 LSB. Non-alpha inputs are used deliberately:
+  campaign #406-418), and since libviprs#668 the reason is a narrower one than
+  this bullet used to give. It said the core computed the masks in f64 per
+  output position "while vips quantises the sub-pixel offset into fixed-point
+  tables, so the two agree to ≤1 LSB" — that was the #668 bug written down as a
+  design decision. `table_offset` (`src/resample.rs`) now rounds the offset onto
+  the same 65-entry grid `vips_reduceh` and
+  `vips_interpolate_bicubic_interpolate` round onto, at both the `reduce_axis`
+  and the bicubic call sites, so the offset is not a source of divergence on
+  either side any more. What is left is the coefficients themselves on the
+  integer carriers, `matrixs` in reduce and `matrixi` in bicubic, where the core
+  stays in f64 (libviprs#704), plus `bicubic_float` summing four rows and then
+  the columns against the core's one 16-term sum (libviprs#705). Together they
+  are worth ≤1 LSB on a uchar carrier, and they are what the nine cells
+  measuring 1 are made of. Non-alpha inputs are used deliberately:
   the core `reduce`/`shrink`/`resize` premultiply alpha before resampling (a
   documented, intentional divergence from bare `vips_reduce`/`vips_shrink`,
   which do not), so on an RGBA / GrayA input these ops diverge from vips
@@ -1187,13 +1198,17 @@ References (paths relative to `tests/fixtures/cli/`):
 | `resample/thumbnail_linear_expected.png` | ≤1 LSB (0) | `vips thumbnail rgb.png thumbnail_linear_expected.png 16 --linear` (linear-light reduce path) |
 | `resample/thumbnail_image_expected.png` | ≤1 LSB (0) | `vips thumbnail_image rgb.png thumbnail_image_expected.png 16` |
 
-**Open question**: `affine … --interpolate bicubic` measures **2 LSB** (not the
-≤1 LSB the rest of the family hits). The core evaluates exact f64 Catmull-Rom
-coefficients while vips's `VipsInterpolateBicubic` uses a coarser fixed-point
-coefficient table, so some interior samples land 2 apart. This is a genuine,
-measured core-vs-vips rounding difference (not a CLI bug); the differential
-compares that one case at tol 2. A follow-up could tighten the core bicubic
-coefficient path toward vips's table if exact bicubic parity is ever required.
+**What the open question here used to say**, and what closed it.
+`affine … --interpolate bicubic` measured **2 LSB**, and the reason given was
+that the core evaluated exact f64 Catmull-Rom coefficients while vips's
+`VipsInterpolateBicubic` read a coarser fixed-point table. The offset half of
+that was libviprs#668: since libviprs#702 the core rounds the bicubic offset
+onto vips's grid and the case **measures 1**, which is the row above and the
+`BT1` the differential now passes. It reads 2 again if that rounding is
+reverted, which is what makes the cell able to tell the two apart
+(libviprs#723). The coefficient half is real and still open as libviprs#704:
+on an integer carrier vips reads `vips_bicubic_matrixi`, 12-bit fixed point,
+where the core stays in f64.
 | `aritha/avg_expected.txt` | EXACT (S3, rational mean → rel-eps) | `vips avg agray.png` |
 | `aritha/deviate_expected.txt` | BOUNDED-TOL (S3, rel-eps) | `vips deviate agray.png` |
 | `aritha/min_expected.txt` | EXACT (S3, integer) | `vips min agray.png` |

--- a/tests/fixtures/cli/PROVENANCE.md
+++ b/tests/fixtures/cli/PROVENANCE.md
@@ -1146,21 +1146,20 @@ output against. Generated offline by `tools/gen_cli_expected.sh`, NEVER by CI.
   FLOAT 1-band holding `(i*37 + 11) mod 251` at `i = y*32 + x`: 251 distinct
   values in 0..250, all exactly representable in f32, high-frequency in both
   axes — the carrier the reduce half of libviprs#668 survives on).
-- **EVERY op is BOUNDED-TOL for NON-ALPHA inputs** (the premultiply / rounding
-  campaign #406-418), and since libviprs#668 the reason is a narrower one than
-  this bullet used to give. It said the core computed the masks in f64 per
-  output position "while vips quantises the sub-pixel offset into fixed-point
-  tables, so the two agree to ≤1 LSB" — that was the #668 bug written down as a
-  design decision. `table_offset` (`src/resample.rs`) now rounds the offset onto
-  the same 65-entry grid `vips_reduceh` and
-  `vips_interpolate_bicubic_interpolate` round onto, at both the `reduce_axis`
-  and the bicubic call sites, so the offset is not a source of divergence on
-  either side any more. What is left is the coefficients themselves on the
-  integer carriers, `matrixs` in reduce and `matrixi` in bicubic, where the core
-  stays in f64 (libviprs#704), plus `bicubic_float` summing four rows and then
-  the columns against the core's one 16-term sum (libviprs#705). Together they
-  are worth ≤1 LSB on a uchar carrier, and they are what the nine cells
-  measuring 1 are made of. Non-alpha inputs are used deliberately:
+- **MOST ops are EXACT for NON-ALPHA inputs**, which is not what this bullet
+  said a landing ago. It said the core computed the masks in f64 per output
+  position "while vips quantises the sub-pixel offset into fixed-point tables,
+  so the two agree to ≤1 LSB" — that was the #668 bug written down as a design
+  decision. Three quantisations have closed since: the sub-pixel offset grid
+  (libviprs#668), `vips_bicubic_matrixi` on the `uchar` carrier
+  (libviprs#704), and the `cubic_float<float>` row narrowing (libviprs#705).
+  Measured against core `ed958d5`, **17 of the 23 comparison cells read 0** and
+  six read 1. Those six are two named divergences, both carrier effects that go
+  to 0 on the identical content promoted to float: `BILINEAR_INT`'s 12-bit
+  weights on the four bilinear cells, which the core deliberately does not adopt
+  (libviprs#733), and the `matrixs` fixed-point reduce mask on `reduceh` /
+  `reducev`, which is undecided (libviprs#777). Non-alpha inputs are used
+  deliberately:
   the core `reduce`/`shrink`/`resize` premultiply alpha before resampling (a
   documented, intentional divergence from bare `vips_reduce`/`vips_shrink`,
   which do not), so on an RGBA / GrayA input these ops diverge from vips
@@ -1179,20 +1178,20 @@ References (paths relative to `tests/fixtures/cli/`):
 | `resample/shrinkv_expected.png` | ≤1 LSB (0) | `vips shrinkv grad.png shrinkv_expected.png 2` |
 | `resample/reduce_lanczos3_expected.png` | ≤1 LSB (0) | `vips reduce rgb.png reduce_lanczos3_expected.png 2 2` (default lanczos3) |
 | `resample/reduce_cubic_expected.png` | ≤1 LSB (0) | `vips reduce rgb.png reduce_cubic_expected.png 2 2 --kernel cubic` |
-| `resample/reduceh_expected.png` | ≤1 LSB (1) | `vips reduceh grad.png reduceh_expected.png 2` |
-| `resample/reducev_expected.png` | ≤1 LSB (1) | `vips reducev grad.png reducev_expected.png 2` |
+| `resample/reduceh_expected.png` | ≤1 LSB (1, libviprs#777) | `vips reduceh grad.png reduceh_expected.png 2` |
+| `resample/reducev_expected.png` | ≤1 LSB (1, libviprs#777) | `vips reducev grad.png reducev_expected.png 2` |
 | `resample/resize_half_expected.png` | ≤1 LSB (0) | `vips resize rgb.png resize_half_expected.png 0.5` |
 | `resample/resize_vscale_expected.png` | **EXACT (0)** | `vips resize rgb.png resize_vscale_expected.png 0.5 --vscale 0.75` |
 | `resample/resize_vscale_float_expected.v` | **EXACT (0, bitwise)** | `vips resize hf.v resize_vscale_float_expected.v 0.5 --vscale 0.75` (FLOAT carrier — the ONLY reference here that sees the reduce half of libviprs#668 unrounded: 0 on core `main`, 0.697464 with that half reverted, where the uchar row above reads 0 either way) |
-| `resample/resize_up_expected.png` | ≤1 LSB (1) | `vips resize grad.png resize_up_expected.png 2.0` (upscale → affine path) |
+| `resample/resize_up_expected.png` | **EXACT (0)** | `vips resize grad.png resize_up_expected.png 2.0` (upscale → affine path) |
 | `resample/resize_nearest_expected.png` | ≤1 LSB (0) | `vips resize rgb.png resize_nearest_expected.png 0.5 --kernel nearest` |
-| `resample/affine_bilinear_expected.png` | ≤1 LSB (1) | `vips affine rgb.png affine_bilinear_expected.png "1.5 0 0 1.5"` (default bilinear) |
-| `resample/affine_bicubic_expected.png` | ≤1 LSB (1) | `vips affine rgb.png affine_bicubic_expected.png "1.5 0 0 1.5" --interpolate bicubic` (was 2 before libviprs#702 rounded the bicubic offset onto vips's grid) |
-| `resample/similarity_angle_expected.png` | ≤1 LSB (1) | `vips similarity rgb.png similarity_angle_expected.png --angle 30` |
-| `resample/similarity_scale_expected.png` | ≤1 LSB (1) | `vips similarity rgb.png similarity_scale_expected.png --scale 1.5` |
-| `resample/rotate_expected.png` | ≤1 LSB (1) | `vips rotate rgb.png rotate_expected.png 30` |
+| `resample/affine_bilinear_expected.png` | ≤1 LSB (1, libviprs#733) | `vips affine rgb.png affine_bilinear_expected.png "1.5 0 0 1.5"` (default bilinear) |
+| `resample/affine_bicubic_expected.png` | **EXACT (0)** | `vips affine rgb.png affine_bicubic_expected.png "1.5 0 0 1.5" --interpolate bicubic` (2 before libviprs#702 rounded the bicubic offset onto vips's grid, 1 before libviprs#704 ported `vips_bicubic_matrixi`, 0 now) |
+| `resample/similarity_angle_expected.png` | ≤1 LSB (1, libviprs#733) | `vips similarity rgb.png similarity_angle_expected.png --angle 30` |
+| `resample/similarity_scale_expected.png` | ≤1 LSB (1, libviprs#733) | `vips similarity rgb.png similarity_scale_expected.png --scale 1.5` |
+| `resample/rotate_expected.png` | ≤1 LSB (1, libviprs#733) | `vips rotate rgb.png rotate_expected.png 30` |
 | `resample/mapim_bilinear_expected.png` | ≤1 LSB (0) | `vips mapim rgb.png mapim_bilinear_expected.png index.v` (S2; index is a 2nd input) |
-| `resample/mapim_bicubic_expected.png` | ≤1 LSB (1) | `vips mapim rgb.png mapim_bicubic_expected.png index.v --interpolate bicubic` |
+| `resample/mapim_bicubic_expected.png` | **EXACT (0)** | `vips mapim rgb.png mapim_bicubic_expected.png index.v --interpolate bicubic` |
 | `resample/thumbnail_expected.png` | ≤1 LSB (0) | `vips thumbnail rgb.png thumbnail_expected.png 16` (FILENAME input) |
 | `resample/thumbnail_crop_expected.png` | ≤1 LSB (0) | `vips thumbnail rgb.png thumbnail_crop_expected.png 16 --height 8 --crop centre` (NON-square target — centre-crop removes pixels, 16×8, distinct from the no-crop fixtures) |
 | `resample/thumbnail_linear_expected.png` | ≤1 LSB (0) | `vips thumbnail rgb.png thumbnail_linear_expected.png 16 --linear` (linear-light reduce path) |
@@ -1201,14 +1200,14 @@ References (paths relative to `tests/fixtures/cli/`):
 **What the open question here used to say**, and what closed it.
 `affine … --interpolate bicubic` measured **2 LSB**, and the reason given was
 that the core evaluated exact f64 Catmull-Rom coefficients while vips's
-`VipsInterpolateBicubic` read a coarser fixed-point table. The offset half of
-that was libviprs#668: since libviprs#702 the core rounds the bicubic offset
-onto vips's grid and the case **measures 1**, which is the row above and the
-`BT1` the differential now passes. It reads 2 again if that rounding is
-reverted, which is what makes the cell able to tell the two apart
-(libviprs#723). The coefficient half is real and still open as libviprs#704:
-on an integer carrier vips reads `vips_bicubic_matrixi`, 12-bit fixed point,
-where the core stays in f64.
+`VipsInterpolateBicubic` read a coarser fixed-point table. Both halves of that
+are now closed, in two landings. libviprs#702 rounded the bicubic offset onto
+vips's 1/64 grid and took the case from 2 to 1; libviprs#704 ported
+`vips_bicubic_matrixi`, the 12-bit fixed-point coefficients
+`bicubic_unsigned_int_tab` reads on a `uchar` carrier, and took it from 1 to
+**0**. It is pinned EXACT, and it reads 1 with libviprs#704 reverted, 3 with
+libviprs#702's bicubic call sites reverted and 7 with the offset grid coarsened
+to 1/32, so the pin separates a correct core from three different wrong ones.
 | `aritha/avg_expected.txt` | EXACT (S3, rational mean → rel-eps) | `vips avg agray.png` |
 | `aritha/deviate_expected.txt` | BOUNDED-TOL (S3, rel-eps) | `vips deviate agray.png` |
 | `aritha/min_expected.txt` | EXACT (S3, integer) | `vips min agray.png` |

--- a/tools/gen_cli_expected.sh
+++ b/tools/gen_cli_expected.sh
@@ -2135,18 +2135,18 @@ echo "==> [provenance] appending draw section to $FIX_ROOT/PROVENANCE.md"
 #
 # The same committed inputs feed BOTH this generator (to make the vips
 # references) and tests/cli_resample_diff.rs (which feeds them to `viprs`), so the
-# two sides compare like against like. EVERY resample op is oracle class
-# BOUNDED-TOL (the premultiply / rounding campaign #406-418), and since
-# libviprs#668 the reason is narrower than this comment used to give. It said
-# the core computed the masks in f64 per output position while vips quantised
-# the sub-pixel offset into fixed-point tables; `table_offset` now rounds the
-# offset onto the same 65-entry grid at both the reduce and the bicubic call
-# sites, so the offset is not a source of divergence on either side. What is
-# left is the coefficient tables on the integer carriers (libviprs#704) and the
-# bicubic accumulation order (libviprs#705). The MEASURED per-case max-abs-diff
-# is recorded in the provenance table, and EVERY case now lands at 0 or 1 LSB —
-# `affine … --interpolate bicubic` used to measure 2 and measures 1 since
-# libviprs#702.
+# two sides compare like against like. MOST resample ops are EXACT against the
+# oracle, which is not what this comment said a landing ago. It said the core
+# computed the masks in f64 per output position while vips quantised the
+# sub-pixel offset into fixed-point tables, so the two agreed to <=1 LSB; three
+# quantisations have closed since — the offset grid (libviprs#668),
+# vips_bicubic_matrixi on the uchar carrier (libviprs#704) and the
+# cubic_float<float> row narrowing (libviprs#705). The MEASURED per-case
+# max-abs-diff is recorded in the provenance table: against core ed958d5, 17 of
+# the 23 comparison cells read 0 and six read 1. Those six are two named
+# divergences the core keeps or has not decided, BILINEAR_INT's 12-bit weights
+# (libviprs#733) and the matrixs reduce mask (libviprs#777), and both go to 0 on
+# the identical content promoted to float.
 #
 # Carriers: most references are an integer uchar raster (1-band grad, or sRGB
 # 3-band rgb), so they round-trip losslessly through PNG. `mapim`'s index is a
@@ -2212,7 +2212,7 @@ echo "==> [shrink] grad 2 2 + shrinkh/shrinkv 2 (S1 box shrink, ≤1 LSB)"
 "$VIPS" shrinkh "$RESAMPLE/grad.png" "$RESAMPLE/shrinkh_expected.png" 2
 "$VIPS" shrinkv "$RESAMPLE/grad.png" "$RESAMPLE/shrinkv_expected.png" 2
 
-echo "==> [reduce] rgb 2 2 lanczos3 (default) + cubic (enum) + reduceh/reducev grad 2 (≤1 LSB)"
+echo "==> [reduce] rgb 2 2 lanczos3 (default) + cubic (enum) + reduceh/reducev grad 2 (EXACT / 1 LSB, libviprs#777)"
 "$VIPS" reduce  "$RESAMPLE/rgb.png"  "$RESAMPLE/reduce_lanczos3_expected.png" 2 2
 "$VIPS" reduce  "$RESAMPLE/rgb.png"  "$RESAMPLE/reduce_cubic_expected.png"    2 2 --kernel cubic
 "$VIPS" reduceh "$RESAMPLE/grad.png" "$RESAMPLE/reduceh_expected.png" 2
@@ -2231,7 +2231,7 @@ echo "==> [resize] rgb 0.5 + --vscale + upscale (affine path) + --kernel nearest
 # one (libviprs#723, libviprs#724).
 "$VIPS" resize "$RESAMPLE/hf.v" "$RESAMPLE/resize_vscale_float_expected.v" 0.5 --vscale 0.75
 
-echo "==> [affine] rgb 1.5x bilinear (≤1 LSB) + bicubic (≤1 LSB since libviprs#702)"
+echo "==> [affine] rgb 1.5x bilinear (1 LSB, libviprs#733) + bicubic (EXACT since libviprs#704)"
 "$VIPS" affine "$RESAMPLE/rgb.png" "$RESAMPLE/affine_bilinear_expected.png" "1.5 0 0 1.5"
 "$VIPS" affine "$RESAMPLE/rgb.png" "$RESAMPLE/affine_bicubic_expected.png"  "1.5 0 0 1.5" --interpolate bicubic
 
@@ -3467,21 +3467,20 @@ output against. Generated offline by \`tools/gen_cli_expected.sh\`, NEVER by CI.
   FLOAT 1-band holding \`(i*37 + 11) mod 251\` at \`i = y*32 + x\`: 251 distinct
   values in 0..250, all exactly representable in f32, high-frequency in both
   axes — the carrier the reduce half of libviprs#668 survives on).
-- **EVERY op is BOUNDED-TOL for NON-ALPHA inputs** (the premultiply / rounding
-  campaign #406-418), and since libviprs#668 the reason is a narrower one than
-  this bullet used to give. It said the core computed the masks in f64 per
-  output position "while vips quantises the sub-pixel offset into fixed-point
-  tables, so the two agree to ≤1 LSB" — that was the #668 bug written down as a
-  design decision. \`table_offset\` (\`src/resample.rs\`) now rounds the offset onto
-  the same 65-entry grid \`vips_reduceh\` and
-  \`vips_interpolate_bicubic_interpolate\` round onto, at both the \`reduce_axis\`
-  and the bicubic call sites, so the offset is not a source of divergence on
-  either side any more. What is left is the coefficients themselves on the
-  integer carriers, \`matrixs\` in reduce and \`matrixi\` in bicubic, where the core
-  stays in f64 (libviprs#704), plus \`bicubic_float\` summing four rows and then
-  the columns against the core's one 16-term sum (libviprs#705). Together they
-  are worth ≤1 LSB on a uchar carrier, and they are what the nine cells
-  measuring 1 are made of. Non-alpha inputs are used deliberately:
+- **MOST ops are EXACT for NON-ALPHA inputs**, which is not what this bullet
+  said a landing ago. It said the core computed the masks in f64 per output
+  position "while vips quantises the sub-pixel offset into fixed-point tables,
+  so the two agree to ≤1 LSB" — that was the #668 bug written down as a design
+  decision. Three quantisations have closed since: the sub-pixel offset grid
+  (libviprs#668), \`vips_bicubic_matrixi\` on the \`uchar\` carrier
+  (libviprs#704), and the \`cubic_float<float>\` row narrowing (libviprs#705).
+  Measured against core \`ed958d5\`, **17 of the 23 comparison cells read 0** and
+  six read 1. Those six are two named divergences, both carrier effects that go
+  to 0 on the identical content promoted to float: \`BILINEAR_INT\`'s 12-bit
+  weights on the four bilinear cells, which the core deliberately does not adopt
+  (libviprs#733), and the \`matrixs\` fixed-point reduce mask on \`reduceh\` /
+  \`reducev\`, which is undecided (libviprs#777). Non-alpha inputs are used
+  deliberately:
   the core \`reduce\`/\`shrink\`/\`resize\` premultiply alpha before resampling (a
   documented, intentional divergence from bare \`vips_reduce\`/\`vips_shrink\`,
   which do not), so on an RGBA / GrayA input these ops diverge from vips
@@ -3500,20 +3499,20 @@ References (paths relative to \`tests/fixtures/cli/\`):
 | \`resample/shrinkv_expected.png\` | ≤1 LSB (0) | \`vips shrinkv grad.png shrinkv_expected.png 2\` |
 | \`resample/reduce_lanczos3_expected.png\` | ≤1 LSB (0) | \`vips reduce rgb.png reduce_lanczos3_expected.png 2 2\` (default lanczos3) |
 | \`resample/reduce_cubic_expected.png\` | ≤1 LSB (0) | \`vips reduce rgb.png reduce_cubic_expected.png 2 2 --kernel cubic\` |
-| \`resample/reduceh_expected.png\` | ≤1 LSB (1) | \`vips reduceh grad.png reduceh_expected.png 2\` |
-| \`resample/reducev_expected.png\` | ≤1 LSB (1) | \`vips reducev grad.png reducev_expected.png 2\` |
+| \`resample/reduceh_expected.png\` | ≤1 LSB (1, libviprs#777) | \`vips reduceh grad.png reduceh_expected.png 2\` |
+| \`resample/reducev_expected.png\` | ≤1 LSB (1, libviprs#777) | \`vips reducev grad.png reducev_expected.png 2\` |
 | \`resample/resize_half_expected.png\` | ≤1 LSB (0) | \`vips resize rgb.png resize_half_expected.png 0.5\` |
 | \`resample/resize_vscale_expected.png\` | **EXACT (0)** | \`vips resize rgb.png resize_vscale_expected.png 0.5 --vscale 0.75\` |
 | \`resample/resize_vscale_float_expected.v\` | **EXACT (0, bitwise)** | \`vips resize hf.v resize_vscale_float_expected.v 0.5 --vscale 0.75\` (FLOAT carrier — the ONLY reference here that sees the reduce half of libviprs#668 unrounded: 0 on core \`main\`, 0.697464 with that half reverted, where the uchar row above reads 0 either way) |
-| \`resample/resize_up_expected.png\` | ≤1 LSB (1) | \`vips resize grad.png resize_up_expected.png 2.0\` (upscale → affine path) |
+| \`resample/resize_up_expected.png\` | **EXACT (0)** | \`vips resize grad.png resize_up_expected.png 2.0\` (upscale → affine path) |
 | \`resample/resize_nearest_expected.png\` | ≤1 LSB (0) | \`vips resize rgb.png resize_nearest_expected.png 0.5 --kernel nearest\` |
-| \`resample/affine_bilinear_expected.png\` | ≤1 LSB (1) | \`vips affine rgb.png affine_bilinear_expected.png "1.5 0 0 1.5"\` (default bilinear) |
-| \`resample/affine_bicubic_expected.png\` | ≤1 LSB (1) | \`vips affine rgb.png affine_bicubic_expected.png "1.5 0 0 1.5" --interpolate bicubic\` (was 2 before libviprs#702 rounded the bicubic offset onto vips's grid) |
-| \`resample/similarity_angle_expected.png\` | ≤1 LSB (1) | \`vips similarity rgb.png similarity_angle_expected.png --angle 30\` |
-| \`resample/similarity_scale_expected.png\` | ≤1 LSB (1) | \`vips similarity rgb.png similarity_scale_expected.png --scale 1.5\` |
-| \`resample/rotate_expected.png\` | ≤1 LSB (1) | \`vips rotate rgb.png rotate_expected.png 30\` |
+| \`resample/affine_bilinear_expected.png\` | ≤1 LSB (1, libviprs#733) | \`vips affine rgb.png affine_bilinear_expected.png "1.5 0 0 1.5"\` (default bilinear) |
+| \`resample/affine_bicubic_expected.png\` | **EXACT (0)** | \`vips affine rgb.png affine_bicubic_expected.png "1.5 0 0 1.5" --interpolate bicubic\` (2 before libviprs#702 rounded the bicubic offset onto vips's grid, 1 before libviprs#704 ported \`vips_bicubic_matrixi\`, 0 now) |
+| \`resample/similarity_angle_expected.png\` | ≤1 LSB (1, libviprs#733) | \`vips similarity rgb.png similarity_angle_expected.png --angle 30\` |
+| \`resample/similarity_scale_expected.png\` | ≤1 LSB (1, libviprs#733) | \`vips similarity rgb.png similarity_scale_expected.png --scale 1.5\` |
+| \`resample/rotate_expected.png\` | ≤1 LSB (1, libviprs#733) | \`vips rotate rgb.png rotate_expected.png 30\` |
 | \`resample/mapim_bilinear_expected.png\` | ≤1 LSB (0) | \`vips mapim rgb.png mapim_bilinear_expected.png index.v\` (S2; index is a 2nd input) |
-| \`resample/mapim_bicubic_expected.png\` | ≤1 LSB (1) | \`vips mapim rgb.png mapim_bicubic_expected.png index.v --interpolate bicubic\` |
+| \`resample/mapim_bicubic_expected.png\` | **EXACT (0)** | \`vips mapim rgb.png mapim_bicubic_expected.png index.v --interpolate bicubic\` |
 | \`resample/thumbnail_expected.png\` | ≤1 LSB (0) | \`vips thumbnail rgb.png thumbnail_expected.png 16\` (FILENAME input) |
 | \`resample/thumbnail_crop_expected.png\` | ≤1 LSB (0) | \`vips thumbnail rgb.png thumbnail_crop_expected.png 16 --height 8 --crop centre\` (NON-square target — centre-crop removes pixels, 16×8, distinct from the no-crop fixtures) |
 | \`resample/thumbnail_linear_expected.png\` | ≤1 LSB (0) | \`vips thumbnail rgb.png thumbnail_linear_expected.png 16 --linear\` (linear-light reduce path) |
@@ -3522,14 +3521,14 @@ References (paths relative to \`tests/fixtures/cli/\`):
 **What the open question here used to say**, and what closed it.
 \`affine … --interpolate bicubic\` measured **2 LSB**, and the reason given was
 that the core evaluated exact f64 Catmull-Rom coefficients while vips's
-\`VipsInterpolateBicubic\` read a coarser fixed-point table. The offset half of
-that was libviprs#668: since libviprs#702 the core rounds the bicubic offset
-onto vips's grid and the case **measures 1**, which is the row above and the
-\`BT1\` the differential now passes. It reads 2 again if that rounding is
-reverted, which is what makes the cell able to tell the two apart
-(libviprs#723). The coefficient half is real and still open as libviprs#704:
-on an integer carrier vips reads \`vips_bicubic_matrixi\`, 12-bit fixed point,
-where the core stays in f64.
+\`VipsInterpolateBicubic\` read a coarser fixed-point table. Both halves of that
+are now closed, in two landings. libviprs#702 rounded the bicubic offset onto
+vips's 1/64 grid and took the case from 2 to 1; libviprs#704 ported
+\`vips_bicubic_matrixi\`, the 12-bit fixed-point coefficients
+\`bicubic_unsigned_int_tab\` reads on a \`uchar\` carrier, and took it from 1 to
+**0**. It is pinned EXACT, and it reads 1 with libviprs#704 reverted, 3 with
+libviprs#702's bicubic call sites reverted and 7 with the offset grid coarsened
+to 1/32, so the pin separates a correct core from three different wrong ones.
 | \`aritha/avg_expected.txt\` | EXACT (S3, rational mean → rel-eps) | \`vips avg agray.png\` |
 | \`aritha/deviate_expected.txt\` | BOUNDED-TOL (S3, rel-eps) | \`vips deviate agray.png\` |
 | \`aritha/min_expected.txt\` | EXACT (S3, integer) | \`vips min agray.png\` |

--- a/tools/gen_cli_expected.sh
+++ b/tools/gen_cli_expected.sh
@@ -2136,13 +2136,17 @@ echo "==> [provenance] appending draw section to $FIX_ROOT/PROVENANCE.md"
 # The same committed inputs feed BOTH this generator (to make the vips
 # references) and tests/cli_resample_diff.rs (which feeds them to `viprs`), so the
 # two sides compare like against like. EVERY resample op is oracle class
-# BOUNDED-TOL (the premultiply / rounding campaign #406-418): the core computes
-# the reduce / interpolate masks in f64 per output position while vips quantises
-# the sub-pixel offset into fixed-point tables, so the two agree to ≤1 LSB. The
-# MEASURED per-case max-abs-diff is recorded in the provenance table; all cases
-# land at 0 or 1 LSB EXCEPT `affine … --interpolate bicubic`, which measures 2
-# LSB (the bicubic Catmull-Rom coefficients quantise more coarsely in vips — a
-# genuine, honest core-vs-vips divergence, NOT a CLI bug; see the open question).
+# BOUNDED-TOL (the premultiply / rounding campaign #406-418), and since
+# libviprs#668 the reason is narrower than this comment used to give. It said
+# the core computed the masks in f64 per output position while vips quantised
+# the sub-pixel offset into fixed-point tables; `table_offset` now rounds the
+# offset onto the same 65-entry grid at both the reduce and the bicubic call
+# sites, so the offset is not a source of divergence on either side. What is
+# left is the coefficient tables on the integer carriers (libviprs#704) and the
+# bicubic accumulation order (libviprs#705). The MEASURED per-case max-abs-diff
+# is recorded in the provenance table, and EVERY case now lands at 0 or 1 LSB —
+# `affine … --interpolate bicubic` used to measure 2 and measures 1 since
+# libviprs#702.
 #
 # Carriers: most references are an integer uchar raster (1-band grad, or sRGB
 # 3-band rgb), so they round-trip losslessly through PNG. `mapim`'s index is a
@@ -2227,7 +2231,7 @@ echo "==> [resize] rgb 0.5 + --vscale + upscale (affine path) + --kernel nearest
 # one (libviprs#723, libviprs#724).
 "$VIPS" resize "$RESAMPLE/hf.v" "$RESAMPLE/resize_vscale_float_expected.v" 0.5 --vscale 0.75
 
-echo "==> [affine] rgb 1.5x bilinear (≤1 LSB) + bicubic (2 LSB — noted divergence)"
+echo "==> [affine] rgb 1.5x bilinear (≤1 LSB) + bicubic (≤1 LSB since libviprs#702)"
 "$VIPS" affine "$RESAMPLE/rgb.png" "$RESAMPLE/affine_bilinear_expected.png" "1.5 0 0 1.5"
 "$VIPS" affine "$RESAMPLE/rgb.png" "$RESAMPLE/affine_bicubic_expected.png"  "1.5 0 0 1.5" --interpolate bicubic
 
@@ -3464,9 +3468,20 @@ output against. Generated offline by \`tools/gen_cli_expected.sh\`, NEVER by CI.
   values in 0..250, all exactly representable in f32, high-frequency in both
   axes — the carrier the reduce half of libviprs#668 survives on).
 - **EVERY op is BOUNDED-TOL for NON-ALPHA inputs** (the premultiply / rounding
-  campaign #406-418): the core computes reduce / interpolate masks in f64 per
-  output position while vips quantises the sub-pixel offset into fixed-point
-  tables, so the two agree to ≤1 LSB. Non-alpha inputs are used deliberately:
+  campaign #406-418), and since libviprs#668 the reason is a narrower one than
+  this bullet used to give. It said the core computed the masks in f64 per
+  output position "while vips quantises the sub-pixel offset into fixed-point
+  tables, so the two agree to ≤1 LSB" — that was the #668 bug written down as a
+  design decision. \`table_offset\` (\`src/resample.rs\`) now rounds the offset onto
+  the same 65-entry grid \`vips_reduceh\` and
+  \`vips_interpolate_bicubic_interpolate\` round onto, at both the \`reduce_axis\`
+  and the bicubic call sites, so the offset is not a source of divergence on
+  either side any more. What is left is the coefficients themselves on the
+  integer carriers, \`matrixs\` in reduce and \`matrixi\` in bicubic, where the core
+  stays in f64 (libviprs#704), plus \`bicubic_float\` summing four rows and then
+  the columns against the core's one 16-term sum (libviprs#705). Together they
+  are worth ≤1 LSB on a uchar carrier, and they are what the nine cells
+  measuring 1 are made of. Non-alpha inputs are used deliberately:
   the core \`reduce\`/\`shrink\`/\`resize\` premultiply alpha before resampling (a
   documented, intentional divergence from bare \`vips_reduce\`/\`vips_shrink\`,
   which do not), so on an RGBA / GrayA input these ops diverge from vips
@@ -3504,13 +3519,17 @@ References (paths relative to \`tests/fixtures/cli/\`):
 | \`resample/thumbnail_linear_expected.png\` | ≤1 LSB (0) | \`vips thumbnail rgb.png thumbnail_linear_expected.png 16 --linear\` (linear-light reduce path) |
 | \`resample/thumbnail_image_expected.png\` | ≤1 LSB (0) | \`vips thumbnail_image rgb.png thumbnail_image_expected.png 16\` |
 
-**Open question**: \`affine … --interpolate bicubic\` measures **2 LSB** (not the
-≤1 LSB the rest of the family hits). The core evaluates exact f64 Catmull-Rom
-coefficients while vips's \`VipsInterpolateBicubic\` uses a coarser fixed-point
-coefficient table, so some interior samples land 2 apart. This is a genuine,
-measured core-vs-vips rounding difference (not a CLI bug); the differential
-compares that one case at tol 2. A follow-up could tighten the core bicubic
-coefficient path toward vips's table if exact bicubic parity is ever required.
+**What the open question here used to say**, and what closed it.
+\`affine … --interpolate bicubic\` measured **2 LSB**, and the reason given was
+that the core evaluated exact f64 Catmull-Rom coefficients while vips's
+\`VipsInterpolateBicubic\` read a coarser fixed-point table. The offset half of
+that was libviprs#668: since libviprs#702 the core rounds the bicubic offset
+onto vips's grid and the case **measures 1**, which is the row above and the
+\`BT1\` the differential now passes. It reads 2 again if that rounding is
+reverted, which is what makes the cell able to tell the two apart
+(libviprs#723). The coefficient half is real and still open as libviprs#704:
+on an integer carrier vips reads \`vips_bicubic_matrixi\`, 12-bit fixed point,
+where the core stays in f64.
 | \`aritha/avg_expected.txt\` | EXACT (S3, rational mean → rel-eps) | \`vips avg agray.png\` |
 | \`aritha/deviate_expected.txt\` | BOUNDED-TOL (S3, rel-eps) | \`vips deviate agray.png\` |
 | \`aritha/min_expected.txt\` | EXACT (S3, integer) | \`vips min agray.png\` |


### PR DESCRIPTION
Closes libviprs/libviprs#753

**Stacked on #178** (libviprs#724), based on `main` so the cross-repo closing
keyword fires. Merge #178 first; this branch then needs
`git rebase --onto origin/main <old-base>` rather than a merge, per the
squash-orphan trap in the epic notes. Its own two commits are the last two below.
#180 sits on top of this one.

Two things, and they are the same defect twice: a claim about a number that the
number no longer supports. One is in prose, the other is in a tolerance.

## Part 1: four stale copies of the #668 prose

libviprs-tests#177 tightened `AFFINE_BICUBIC_TOL` out of existence and rewrote
`cli_resample_diff.rs`'s header onto the truth, but it moved only the `.rs`.
Four more copies of the two claims libviprs#723 filed that header for were still
live, and one of them is inside `tools/gen_cli_expected.sh`, which regenerates
`PROVENANCE.md`, so a re-run would have reinstated the stale text over the fixed
one.

* **"`affine … --interpolate bicubic` measures 2 LSB … the differential compares
  that one case at tol 2."** In `PROVENANCE.md`, in the generator heredoc, in the
  generator's RESAMPLE block comment, in its `[affine]` echo, and in
  `cli_fixture_audit.rs`. Contradicted by the table row three lines above it,
  which #177 updated to `≤1 LSB (1)`, and by the code, which passes `BT1 = 1.0`.
  Now contradicted twice over: it measures **0**.
* **"the core computes reduce / interpolate masks in f64 per output position
  while vips quantises the sub-pixel offset into fixed-point tables, so the two
  agree to ≤1 LSB."** That sentence is the #668 bug written down as a design
  decision. `table_offset` has rounded both call sites onto vips's 1/64 grid
  since libviprs#702.

## Part 2: core `ed958d5` moved three tolerances into absorbing the fix

#704, #705, #692, #736, #732 and #733 landed under this lane. Re-measuring every
cell against `ed958d5` moved three of them from 1 to 0.

Oracle `/opt/homebrew/bin/vips` 8.18.6, release CLI `0988110`, core a local clone
with one thing changed:

| cell | tol before | `ed958d5` | #704 reverted |
|---|---|---|---|
| `resize 2.0` | `BT1` | **0** | 1 |
| `affine … --interpolate bicubic` | `BT1` | **0** | 1 |
| `mapim … --interpolate bicubic` | `BT1` | **0** | 1 |

### The tightening is absorbing something, and here is the run that shows it

Same core with #704 reverted, `cargo test --test cli_resample_diff`:

| tolerances | result |
|---|---|
| `BT1`, i.e. #178's head | **25 passed, 0 failed** — the file goes green over a reverted fix |
| `EXACT`, i.e. this branch | **22 passed, 3 failed** — `resize_up`, `affine_bicubic`, `mapim_bicubic` |

The three test names move from `_matches_vips_bounded_tol` to
`_matches_vips_exactly` so they stop claiming a bound they no longer assert.

### The twelve other zeroes are NOT tightened, on purpose

libviprs#723's rule is that a cell earns `EXACT` by being separated from 1 by a
mutation, not by measuring 0. I re-ran all eight mutations against `ed958d5` and
every one of the twelve reads 0 in all nine columns, so pinning them would buy
no falsifiability and cost a vips-version tripwire. They stay at `BT1`.

### The six that read 1 now name their owner

"1" with nobody accountable for it is how #668 lasted. Both are carrier effects
and both go to 0 on the identical content promoted to float:

| cell | measured | owner |
|---|---|---|
| `affine "1.5 0 0 1.5"` (bilinear) | 1 | libviprs#733, `BILINEAR_INT`'s 12-bit weights, deliberately not adopted |
| `similarity --angle 30` | 1 | libviprs#733 |
| `similarity --scale 1.5` | 1 | libviprs#733 |
| `rotate 30` | 1 | libviprs#733 |
| `reduceh … 2` | 1 | libviprs#777, the `matrixs` fixed-point reduce mask, undecided |
| `reducev … 2` | 1 | libviprs#777 |

The carrier isolation, same op and same content, only the storage format
changing:

| op | uchar | the SAME content as float |
|---|---|---|
| `reduceh … 2` | 1 | **0** |
| `reducev … 2` | 1 | **0** |
| `affine "1.5 0 0 1.5"` bilinear | 1 | **0** |

libviprs#777 is new, filed off that measurement: `vips_reduce_make_mask` builds
`matrixf` in `double` and `matrixs` in fixed point and picks by band format, the
core keeps f64, and it is the last quantisation in the family with no issue on
it. It wants the treatment #732 and #733 got, a measured decision either way,
which is a **core** change and not one this repo can land.

## Positive control for "no fixture moved"

Re-running the patched generator into a scratch tree byte-compares the whole
`resample/` directory at **26 of 27 identical**, the exception being `index.v`,
which differs by one byte, the `4` of `8.18.4` in the XML namespace URL vips
writes into its own `.v` trailer at offset 8334. So the comparison does find a
differing byte where there is one; it found none this PR caused.

## Gate

| check | result |
|---|---|
| `cargo fmt -- --check` | clean |
| `shellcheck tools/*.sh tools/hooks/pre-push` | clean |
| `RUSTFLAGS="-Dwarnings" cargo clippy --all-targets -- -D warnings` | clean |
| `cargo test` | **773 passed, 0 failed, 11 ignored** — identical to #178's head, which is the point |
