### PR TITLE
test(resample): move off the struct-update form the Options structs now refuse

### DIFF
--- a/tests/resample_nearest_alpha.rs
+++ b/tests/resample_nearest_alpha.rs
@@ -112,10 +112,7 @@ fn resize_nearest_preserves_exact_alpha_pixels() {
     // reduces the fractional residual through `reduce_axis`; the residual pass
     // must not corrupt the exact pick either.
     let src = semi_transparent_raster(8, 8);
-    let opts = ResizeOptions {
-        kernel: ReduceKernel::Nearest,
-        ..ResizeOptions::default()
-    };
+    let opts = ResizeOptions::default().with_kernel(ReduceKernel::Nearest);
     let out = src.resize_with(0.4, opts);
     assert_exact_pick(&out, "resize 0.4 nearest");
 }

--- a/tests/resample_premultiplied_alpha_reference.rs
+++ b/tests/resample_premultiplied_alpha_reference.rs
@@ -183,13 +183,7 @@ fn mixed_axis_resize_matches_vips() {
     let src = load_rgba8(
         &fixtures_dir().join("resample_premultiplied_alpha_reference_input/split_rgba.png"),
     );
-    let out = src.resize_with(
-        2.0,
-        ResizeOptions {
-            vscale: Some(0.5),
-            ..ResizeOptions::default()
-        },
-    );
+    let out = src.resize_with(2.0, ResizeOptions::default().with_vscale(Some(0.5)));
     assert_matches_reference(
         &out,
         "resample_premultiplied_alpha_reference_expected/split_resize_h2_v05_expected.png",


### PR DESCRIPTION
Closes libviprs/libviprs-tests#181.

libviprs#630 landed `#[non_exhaustive]` on the ten Options structs (core PR #818), which
refuses a struct literal from another crate, **including the `..Default::default()` update
form**. This suite is a path dependency on the core, so it stops compiling the moment that
merges.

Two sites, both `ResizeOptions`:

- `tests/resample_nearest_alpha.rs:115` becomes `ResizeOptions::default().with_kernel(ReduceKernel::Nearest)`
- `tests/resample_premultiplied_alpha_reference.rs:188` becomes `ResizeOptions::default().with_vscale(Some(0.5))`

No behaviour change: the setters take the same values and `Default` supplies the rest,
which is exactly what the update form did.

## Why the update form was not already safe

Worth recording, because it is the opposite of the usual reason for this attribute.
libviprs#630's own measurement is that `..Default::default()` **already survived a field
addition** and only the exhaustive literal broke with `E0063`. So these two sites were
never at risk from the thing `#[non_exhaustive]` is normally added to prevent. They break
for the attribute itself, which is the price of the promise being enforced rather than
documented.

## Gate

`cargo fmt --check` clean, `clippy --all-targets -D warnings` silent, `cargo test`
**772 passed / 0 failed / 11 ignored**, against core `main` at `9b7aa7b` (the merge of #818)
in a paired worktree.