### PR TITLE
Make the nightly select ignored tests by target instead of by #[ignore]

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,9 +1,19 @@
 name: Nightly
 
-# Wall-clock perf smokes are too timing-sensitive to gate every PR on a shared
-# runner, so they are `#[ignore]`d out of ci.yml and exercised here on a
-# schedule. A transient blip on a nightly is a retryable run, not a merge
-# blocker. Runs natively on GitHub Actions (libviprs/libviprs#585).
+# Wall-clock perf smokes and the large-image stress suite are too slow or too
+# timing-sensitive to gate every PR on a shared runner, so they are
+# `#[ignore]`d out of ci.yml and exercised here on a schedule. A transient blip
+# on a nightly is a retryable run, not a merge blocker. Runs natively on GitHub
+# Actions (libviprs/libviprs#585).
+#
+# Each step below names the test TARGET it runs. `#[ignore]` is the mechanism
+# that keeps these off the per-PR path, but it is not the selector: this repo
+# uses `#[ignore]` for at least seven unrelated things, so a crate-wide
+# `-- --ignored` also sweeps in the fixture generators (which rewrite committed
+# files), the manual pdfium diagnostics, tests needing a live S3 endpoint, and
+# deferred-feature stubs that are ignored precisely because they do not pass
+# yet. `nightly_selects_ignored_tests_by_target_not_crate_wide` in
+# tests/pdfium_ci_policy.rs refuses a re-widening.
 on:
   schedule:
     # 07:00 UTC daily.
@@ -39,7 +49,12 @@ jobs:
           sudo cp pdfium/lib/libpdfium.so /usr/local/lib/
           sudo cp -r pdfium/include/* /usr/local/include/
           sudo ldconfig
-      # Run only the `#[ignore]`d tests (the wall-clock perf-ratio smokes).
-      # These assert streaming <= 12x cached and are the signal moved off the
-      # per-PR path in issue #59.
-      - run: cargo test --features pdfium -- --ignored
+      # The wall-clock perf-ratio smokes: streaming <= 12x cached, moved off
+      # the per-PR path in issue #59.
+      - name: Perf-ratio smokes
+        run: cargo test --features pdfium --test pdfium_streaming_perf_smoke -- --ignored
+      # The large-image stress suite (10K x 10K and 4K x 4K synthetic rasters).
+      # Release profile because these are throughput paths and a debug build
+      # makes them pointlessly slow.
+      - name: Large-image stress suite
+        run: cargo test --release --test stress -- --ignored

--- a/tests/builder_resume_observer_parity.rs
+++ b/tests/builder_resume_observer_parity.rs
@@ -13,12 +13,18 @@
 //! wiring are caught by a uniform set of counters rather than
 //! engine-specific assertions scattered across other files.
 //!
-//! The Verify-mode coverage for Streaming and MapReduce is gated on the
-//! stream-verify implementation that the builder currently rejects with
-//! `EngineError::IncompatibleSource`. Those two tests (`streaming_verify_*`
-//! and `mapreduce_verify_*`) are marked `#[ignore]` until the feature lands;
-//! their bodies express the final contract so the implementer has a
-//! concrete assertion target.
+//! Every test in this file runs on the normal `cargo test` path. Two of them
+//! used to sit behind `#[ignore]` waiting on stream-verify, which has since
+//! landed (see `streaming_verify_is_now_supported` in
+//! `builder_resume_streaming.rs`, and the fuller coverage in
+//! `builder_stream_verify.rs`), so they gate CI now like the rest.
+//!
+//! On Resume the observer and the sink measure different things, and both
+//! resume tests below pin both halves. The engine presents every planned tile
+//! to the observer, while `ResumeAwareSink` short-circuits the writes for
+//! tiles the checkpoint already records. Asserting only the event count would
+//! still pass if Resume had ignored the checkpoint and rewritten everything,
+//! so each of those tests carries a sink-write count as its positive control.
 
 use std::path::Path;
 use std::sync::Arc;
@@ -164,6 +170,50 @@ impl TileSink for PanickingSink {
     }
 }
 
+/// Counts the writes that actually reach the inner sink. Mirrors the helper
+/// in `tests/builder_resume_streaming.rs`, copied for the same reason as
+/// `PanickingSink` above and trimmed to just the count this file needs.
+struct RecordingSink {
+    inner: FsSink,
+    writes: AtomicUsize,
+}
+
+impl RecordingSink {
+    fn new(inner: FsSink) -> Self {
+        Self {
+            inner,
+            writes: AtomicUsize::new(0),
+        }
+    }
+
+    fn write_count(&self) -> usize {
+        self.writes.load(Ordering::SeqCst)
+    }
+}
+
+impl TileSink for RecordingSink {
+    fn write_tile(&self, tile: &Tile) -> Result<(), SinkError> {
+        self.writes.fetch_add(1, Ordering::SeqCst);
+        self.inner.write_tile(tile)
+    }
+
+    fn finish(&self) -> Result<(), SinkError> {
+        self.inner.finish()
+    }
+
+    fn checkpoint_root(&self) -> Option<&Path> {
+        self.inner.checkpoint_root()
+    }
+
+    fn record_engine_config(&self, config: &EngineConfig) {
+        self.inner.record_engine_config(config)
+    }
+
+    fn init_level_count(&self, levels: usize) {
+        self.inner.init_level_count(levels)
+    }
+}
+
 /// Load the persisted checkpoint as `JobMetadata`. Panics loudly if the
 /// checkpoint is missing or unparsable, the test that uses this needs a
 /// partial checkpoint to exist, so absence is a real bug.
@@ -204,19 +254,18 @@ fn monolithic_overwrite_emits_full_event_stream() {
 }
 
 // ---------------------------------------------------------------------------
-// 2. Monolithic + Resume — only new writes emit events.
+// 2. Monolithic + Resume: every visited tile emits an event, and only the
+//    unfinished tiles reach the sink.
 // ---------------------------------------------------------------------------
 
-// Ignored: captures the pre-unification semantic where Monolithic resume
-// suppressed TileCompleted events for skipped tiles. The unified resume
-// path (EngineBuilder + ResumeAwareSink) now fires progress events for
-// every tile the engine visits regardless of whether the wrapper
-// short-circuits the actual write — sink writes and observer events are
-// separate concerns. Kept as a ratchet: if we decide later to re-introduce
-// skip-aware event suppression, un-ignore this test and flip the wiring.
+// The unified resume path (EngineBuilder + ResumeAwareSink) fires progress
+// events for every tile the engine visits, whether or not the wrapper
+// short-circuits the actual write. Sink writes and observer events are
+// separate concerns, and this test pins both of them at once, so
+// re-introducing skip-aware event suppression fails the first assertion
+// while a resume that lost its checkpoint fails the second.
 #[test]
-#[ignore = "resolved semantic: observer fires for every engine-visited tile, not per sink write"]
-fn monolithic_resume_emits_events_for_new_writes_only() {
+fn monolithic_resume_emits_events_for_every_visited_tile() {
     let dir = tempfile::tempdir().unwrap();
     let base = dir.path().join("tiles");
     std::fs::create_dir_all(&base).unwrap();
@@ -254,12 +303,13 @@ fn monolithic_resume_emits_events_for_new_writes_only() {
     );
     let remaining = total - already_done as u64;
 
-    // Second run: fresh observer, Resume mode. Only the uncompleted tiles
-    // should produce TileCompleted events; level and finish events still
-    // fire for every level / the single Finished.
+    // Second run: fresh observer, Resume mode. The engine still renders and
+    // presents every tile, so TileCompleted fires once per planned tile, while
+    // the resume wrapper short-circuits the writes the checkpoint already has.
     let inner = FsSink::new(base.clone(), plan.clone()).with_format(TileFormat::Raw);
+    let recording = RecordingSink::new(inner);
     let obs = Arc::new(CollectingObserver::new());
-    EngineBuilder::new(&src, plan.clone(), &inner)
+    EngineBuilder::new(&src, plan.clone(), &recording)
         .with_engine(EngineKind::Monolithic)
         .with_resume(ResumePolicy::resume())
         .with_observer_arc(obs.clone())
@@ -268,10 +318,19 @@ fn monolithic_resume_emits_events_for_new_writes_only() {
 
     let counts = EventCounts::from_events(&obs.events());
     assert_eq!(
-        counts.tile_completed as u64, remaining,
-        "Resume should emit TileCompleted only for the {remaining} unfinished tiles \
-         (already_done={already_done}, total={total}), got {}",
+        counts.tile_completed as u64, total,
+        "the observer sees every tile the engine visits, so TileCompleted should \
+         fire {total} times (already_done={already_done}), got {}",
         counts.tile_completed,
+    );
+    // Positive control. Without this the assertion above would still pass if
+    // Resume had ignored the checkpoint and rewritten the whole pyramid.
+    assert_eq!(
+        recording.write_count() as u64,
+        remaining,
+        "Resume should write only the {remaining} unfinished tiles \
+         (already_done={already_done}, total={total}), got {}",
+        recording.write_count(),
     );
     assert_eq!(counts.finished, 1, "Finished must fire exactly once");
     assert_eq!(
@@ -355,18 +414,15 @@ fn streaming_overwrite_emits_full_event_stream() {
 }
 
 // ---------------------------------------------------------------------------
-// 5. Streaming + Resume after a full run — no new tile events.
+// 5. Streaming + Resume after a full run: events still fire, writes do not.
 // ---------------------------------------------------------------------------
 
-// Ignored: same reason as monolithic_resume_emits_events_for_new_writes_only.
-// The streaming engine emits TileCompleted for every tile it renders;
-// ResumeAwareSink only filters write_tile, not observer events. The
-// regression guards live in builder_resume_streaming.rs
-// (streaming_resume_short_circuits_already_complete_tiles) which counts
-// sink writes rather than observer events.
+// The streaming engine emits TileCompleted for every tile it renders, and
+// ResumeAwareSink filters write_tile rather than observer events. This pins
+// both sides on a fully-complete checkpoint, which is the sharpest case: the
+// event count is at its maximum while the write count is at zero.
 #[test]
-#[ignore = "resolved semantic: observer fires for every engine-visited tile, not per sink write"]
-fn streaming_resume_emits_no_tile_events_when_complete() {
+fn streaming_resume_emits_tile_events_but_writes_nothing_when_complete() {
     let dir = tempfile::tempdir().unwrap();
     let base = dir.path().join("tiles");
     let src = canonical_raster_scaled(256, 192);
@@ -382,12 +438,13 @@ fn streaming_resume_emits_no_tile_events_when_complete() {
             .expect("seed streaming run should succeed");
     }
 
-    // Second run: Resume against a complete checkpoint. Every tile is
-    // short-circuited by ResumeAwareSink, so no TileCompleted events
-    // should fire — but Finished and the per-level bookends still do.
-    let sink = FsSink::new(base, plan.clone()).with_format(TileFormat::Raw);
+    // Second run: Resume against a complete checkpoint. Every write is
+    // short-circuited by ResumeAwareSink, but the engine still renders and
+    // presents every tile, so the observer sees the full event stream.
+    let inner = FsSink::new(base, plan.clone()).with_format(TileFormat::Raw);
+    let recording = RecordingSink::new(inner);
     let obs = Arc::new(CollectingObserver::new());
-    EngineBuilder::new(&src, plan.clone(), &sink)
+    EngineBuilder::new(&src, plan.clone(), &recording)
         .with_engine(EngineKind::Streaming)
         .with_resume(ResumePolicy::resume())
         .with_observer_arc(obs.clone())
@@ -396,9 +453,21 @@ fn streaming_resume_emits_no_tile_events_when_complete() {
 
     let counts = EventCounts::from_events(&obs.events());
     assert_eq!(
-        counts.tile_completed, 0,
-        "Fully short-circuited Resume must not emit TileCompleted, got {}",
+        counts.tile_completed as u64,
+        plan.total_tile_count(),
+        "the observer sees every tile the engine visits, so TileCompleted should fire \
+         {} times, got {}",
+        plan.total_tile_count(),
         counts.tile_completed
+    );
+    // Positive control. A fully short-circuited Resume must reach the inner
+    // sink zero times; the event assertion alone cannot tell a working
+    // short-circuit from a full rewrite.
+    assert_eq!(
+        recording.write_count(),
+        0,
+        "Resume wrote {} tiles even though the checkpoint recorded a full run",
+        recording.write_count()
     );
     assert_eq!(
         counts.finished, 1,
@@ -419,14 +488,13 @@ fn streaming_resume_emits_no_tile_events_when_complete() {
 // ---------------------------------------------------------------------------
 // 6. Streaming + Verify — one event per tile.
 //
-// Pending stream-verify implementation. Currently the builder rejects this
-// combination with `EngineError::IncompatibleSource` (see
-// `streaming_verify_is_rejected` in `builder_resume_streaming.rs`). This
-// test expresses the target contract for when stream-verify lands.
+// Stream-verify has landed, so the builder runs this combination instead of
+// rejecting it with `EngineError::IncompatibleSource`. See
+// `streaming_verify_is_now_supported` in `builder_resume_streaming.rs`, and
+// `builder_stream_verify.rs` for the fuller coverage.
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "pending stream-verify implementation; currently IncompatibleSource"]
 fn streaming_verify_emits_events_for_every_tile() {
     let dir = tempfile::tempdir().unwrap();
     let base = dir.path().join("tiles");
@@ -451,7 +519,7 @@ fn streaming_verify_emits_events_for_every_tile() {
         .with_resume(ResumePolicy::verify())
         .with_observer_arc(obs.clone())
         .run()
-        .expect("streaming verify should succeed once implemented");
+        .expect("streaming verify should succeed against intact output");
 
     let counts = EventCounts::from_events(&obs.events());
     assert_eq!(
@@ -492,13 +560,12 @@ fn mapreduce_overwrite_emits_full_event_stream() {
 // ---------------------------------------------------------------------------
 // 8. MapReduce + Verify — one event per tile.
 //
-// Pending stream-verify implementation for MapReduce. Currently rejected
-// with `EngineError::IncompatibleSource`; this test expresses the target
-// contract.
+// Stream-verify has landed for MapReduce too, so this runs rather than being
+// rejected with `EngineError::IncompatibleSource`. See
+// `mapreduce_verify_is_now_supported` in `builder_resume_streaming.rs`.
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "pending stream-verify implementation; currently IncompatibleSource"]
 fn mapreduce_verify_emits_events_for_every_tile() {
     let dir = tempfile::tempdir().unwrap();
     let base = dir.path().join("tiles");
@@ -522,7 +589,7 @@ fn mapreduce_verify_emits_events_for_every_tile() {
         .with_resume(ResumePolicy::verify())
         .with_observer_arc(obs.clone())
         .run()
-        .expect("mapreduce verify should succeed once implemented");
+        .expect("mapreduce verify should succeed against intact output");
 
     let counts = EventCounts::from_events(&obs.events());
     assert_eq!(

--- a/tests/builder_stream_verify.rs
+++ b/tests/builder_stream_verify.rs
@@ -2,7 +2,9 @@
 //! surface on `EngineBuilder`.
 //!
 //! Today `EngineKind::Streaming` paired with `ResumePolicy::verify()` is
-//! rejected outright (see `builder_resume_streaming::streaming_verify_is_rejected`).
+//! rejected outright (see
+//! `builder_resume_streaming::streaming_verify_is_now_supported`, which pins
+//! that it is not rejected any more).
 //! That blanket rejection is about to be lifted: the builder will wrap the
 //! user-provided sink in a verifying adapter that walks every tile recorded
 //! by the plan and re-reads it from the target directory without producing

--- a/tests/pdfium_ci_policy.rs
+++ b/tests/pdfium_ci_policy.rs
@@ -109,15 +109,48 @@ fn perf_ratio_smoke_is_ignored_out_of_normal_ci() {
     );
 }
 
+/// The nightly must select what it runs by TARGET, not by `#[ignore]`.
+///
+/// `#[ignore]` is the mechanism that keeps a test off the per-PR path, but it
+/// is not a category. This repo spends it on at least seven unrelated things:
+/// perf smokes, fixture generators, manual diagnostics, tests needing a live
+/// S3 endpoint, stress runs, unimplemented-feature deferrals, and tests kept
+/// as documentation of a contract that was deliberately abandoned. So a
+/// crate-wide `cargo test -- --ignored` runs all of them, and it did: the
+/// nightly went red on tests it was never meant to run, and three of the
+/// generators it swept in rewrite committed fixture files.
+///
+/// This guard refuses rather than reports. Every `cargo test` line in
+/// nightly.yml that passes `--ignored` must also name a `--test` target, so
+/// the selector cannot silently widen back.
 #[test]
-fn nightly_workflow_runs_the_ignored_perf_smoke_on_a_schedule() {
+fn nightly_selects_ignored_tests_by_target_not_crate_wide() {
     let nightly = read_workflow("nightly.yml");
     assert!(
         nightly.contains("schedule:") && nightly.contains("cron:"),
         "nightly.yml must run on a cron schedule"
     );
+
+    let ignored_cmds: Vec<&str> = cargo_test_command_lines(&nightly)
+        .into_iter()
+        .filter(|c| c.contains("--ignored"))
+        .collect();
     assert!(
-        nightly.contains("cargo test --features pdfium -- --ignored"),
-        "nightly.yml must run the ignored (perf-ratio smoke) tests"
+        !ignored_cmds.is_empty(),
+        "nightly.yml must still run the ignored tests this job exists for"
+    );
+    for cmd in &ignored_cmds {
+        assert!(
+            cmd.contains("--test "),
+            "nightly.yml must select ignored tests by target. `{cmd}` runs every ignored test \
+             in the crate, which sweeps in fixture generators that rewrite committed files, \
+             manual diagnostics, and deferred stubs that do not pass yet (issue #59)"
+        );
+    }
+    assert!(
+        ignored_cmds
+            .iter()
+            .any(|c| c.contains("--features pdfium") && c.contains("pdfium_streaming_perf_smoke")),
+        "nightly.yml must still run the wall-clock perf-ratio smokes (issue #59)"
     );
 }

--- a/tests/pdfium_streaming_perf_smoke.rs
+++ b/tests/pdfium_streaming_perf_smoke.rs
@@ -125,7 +125,7 @@ fn warmup(fixture: &str) -> u32 {
 }
 
 #[test]
-#[ignore = "wall-clock perf-ratio smoke: nightly-only, runs via `cargo test --features pdfium -- --ignored` in nightly.yml"]
+#[ignore = "wall-clock perf-ratio smoke: nightly-only, runs via `cargo test --features pdfium --test pdfium_streaming_perf_smoke -- --ignored` in nightly.yml"]
 fn streaming_within_constant_factor_of_cached_blueprint() {
     let _ = warmup(FIXTURE_BLUEPRINT);
     // Run cached first, then streaming. Either order is fine — both
@@ -142,7 +142,7 @@ fn streaming_within_constant_factor_of_cached_blueprint() {
 }
 
 #[test]
-#[ignore = "wall-clock perf-ratio smoke: nightly-only, runs via `cargo test --features pdfium -- --ignored` in nightly.yml"]
+#[ignore = "wall-clock perf-ratio smoke: nightly-only, runs via `cargo test --features pdfium --test pdfium_streaming_perf_smoke -- --ignored` in nightly.yml"]
 fn streaming_within_constant_factor_of_cached_portrait() {
     let _ = warmup(FIXTURE_PORTRAIT);
     let cached = time_cached_n_strips(FIXTURE_PORTRAIT, STRIPS);


### PR DESCRIPTION
Closes #189

The nightly ran `cargo test --features pdfium -- --ignored`, which selects every ignored test in the crate. `#[ignore]` here is a mechanism, not a category: this repo uses it for perf smokes, fixture generators, manual diagnostics, tests wanting a live S3 endpoint, stress runs, unimplemented-feature deferrals, and tests kept as documentation of a contract we deliberately abandoned. The job existed for the first of those, so it ran 17 tests to reach 2, and three of the ones it swept in rewrite committed fixture files.

## The two reported failures could never pass

Both are the abandoned-contract kind, and their own ignore reasons said so. They assert Resume suppresses `TileCompleted` for skipped tiles; the unified resume path made the observer fire for every tile the engine visits, with `ResumeAwareSink` filtering `write_tile` instead.

I rewrote both to pin the contract we actually have, and gave each a sink-write count as a positive control. Without that control the event assertion alone would still pass if Resume had ignored the checkpoint and rewritten the whole pyramid, which is the vacuity trap this repo keeps rediscovering.

I checked the controls bite rather than assuming it. Mutating `resume()` to `overwrite()` in both tests:

```
monolithic_resume_emits_events_for_every_visited_tile ... FAILED
  Resume should write only the 17 unfinished tiles (already_done=10, total=27), got 27
streaming_resume_emits_tile_events_but_writes_nothing_when_complete ... FAILED
  Resume wrote 23 tiles even though the checkpoint recorded a full run
```

Both fail on the write count while the event assertion survives, which is the split I wanted.

## Fixing only the reported failures would not have been enough

`cargo test` stops at the first failing binary, so the run aborted at `builder_resume_observer_parity` and never reached the rest. `blanks_dedupe_reduces_disk_usage` also fails (`none=19094 bytes, dedupe=13373 bytes`), and it would have become the next red.

## Stream-verify landed, so two ignores were stale

`streaming_verify_is_rejected` is now `streaming_verify_is_now_supported`, so `streaming_verify_emits_events_for_every_tile` and `mapreduce_verify_emits_events_for_every_tile` already pass. They gate CI now instead of idling in the nightly. I fixed the stale cross-references to the old test name too.

## The guard was pinning the bug

`pdfium_ci_policy.rs` asserted `nightly.yml` contained the broad command verbatim, so the guard held the broken selector in place. It refuses now: every `cargo test` line in nightly.yml passing `--ignored` must also name a `--test` target, and the message quotes the offending line. I verified it by re-widening the selector and watching it go red.

## What the nightly runs now

The perf smokes by target, plus the large-image stress suite, which is the other set that genuinely wants a scheduled run. Stress passes 3/3 in release, so this keeps coverage that was previously only running by accident.

## Verification

```
cargo fmt -- --check                          clean
cargo clippy --all-targets -- -D warnings     clean
cargo test                                    782 passed, 0 failed, 8 ignored
cargo test --test builder_resume_observer_parity   8 passed, 0 ignored
cargo test --test pdfium_ci_policy            4 passed
cargo test --release --test stress -- --ignored    3 passed
```

Run against the counterpart core this branch pins (`694fd4b2`), laid out as a sibling checkout the way the integration job does it.

**Unverified:** I have no libpdfium on this machine, so I could not execute the pdfium leg (`--test pdfium_streaming_perf_smoke`). The 17-vs-2 selection counts for that leg are from a static read of the ignore attributes, not from a run. The new guard covers the selector shape, not that the smokes themselves pass.