### PR TITLE
Run the packfile cells in CI, and fix the one they never caught

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
       # `object-store-sink`, so the default run compiles them out. Exercise the
       # feature so they actually run (#382).
       - run: cargo test --features object-store-sink --test phase3_object_store_sink --test phase3_validation_stress --test sink_object_store_stub_contract
+      # Same hole, same shape, for `packfile`: both packfile test files are
+      # `#![cfg(feature = "packfile")]`, the feature-cells matrix only lints
+      # them, and the default run above compiles them to nothing, so no job on
+      # either forge had ever executed the 14 tests in them. The first run
+      # found one of them red (#191).
+      - run: cargo test --features packfile --test phase3_packfile --test builder_sink_packfile
 
   test-pdfium:
     name: Integration Tests (pdfium)

--- a/tests/phase3_packfile.rs
+++ b/tests/phase3_packfile.rs
@@ -508,7 +508,14 @@ fn packfile_streaming_memory_bounded() {
     let src = canonical_raster_scaled(2048, 2048);
     let plan = make_plan(2048, 2048, 256);
 
-    let budget: u64 = 2_000_000; // 2 MB
+    // The budget has to clear the streaming engine's pre-flight floor or the
+    // run never starts. That floor is one minimum aligned strip, `2 *
+    // tile_size` rows at canvas width: 2048 * (2 * 256) * 3 = 3_145_728 bytes
+    // for this Rgb8 canvas. This test asked for 2 MB, which is under the
+    // floor, so `generate_pyramid_streaming` could only ever answer
+    // `BudgetExceeded` and every assertion below was unreachable. No job had
+    // ever run the cell, so nothing said so.
+    let budget: u64 = 4_000_000; // 4 MB, one strip plus room to work in
 
     let sink = make_packfile(
         out.clone(),
@@ -537,5 +544,18 @@ fn packfile_streaming_memory_bounded() {
         result.peak_memory_bytes,
         upper,
         budget,
+    );
+
+    // 4x a 4 MB budget is 16 MB, which is more than the whole 12 MB level-0
+    // raster, so the bound above would hold for an engine that read the image
+    // in one piece and streamed nothing. Pin the streaming claim separately:
+    // peak has to stay under one full canvas. Measured peak here is 5_505_024
+    // bytes, so both bounds have room, and this one is the tighter of the two.
+    let canvas_bytes = 2048u64 * 2048 * PixelFormat::Rgb8.bytes_per_pixel() as u64;
+    assert!(
+        result.peak_memory_bytes < canvas_bytes,
+        "peak memory {} reached the full canvas ({canvas_bytes} bytes), so \
+         nothing here was streamed",
+        result.peak_memory_bytes,
     );
 }


### PR DESCRIPTION
Closes #191

## What I changed

- `.github/workflows/ci.yml`: the `test` job now runs `cargo test --features packfile --test phase3_packfile --test builder_sink_packfile`, next to the object-store-sink line that closed the same hole in #382.
- `tests/phase3_packfile.rs`: `packfile_streaming_memory_bounded` asked for a 2 MB budget, which the streaming pre-flight refuses. It now asks for 4 MB, with the strip arithmetic written above the line, and it gained a second bound so the assertion is not carried entirely by a number larger than the image.

## Why the two go together

The 14 tests in those two files are behind `#![cfg(feature = "packfile")]`. The default `cargo test` compiles them to nothing, the `feature-cells` matrix only lints them, and `run_ported_cells.sh` runs one unrelated cell, so no job had ever executed them. The first run of the pair found one red, so the CI line on its own would have arrived red.

The failure is deterministic arithmetic. `generate_pyramid_streaming` refuses any budget below one minimum aligned strip, `2 * tile_size` rows at canvas width, which for this 2048x2048 Rgb8 raster at `tile_size = 256` is `2048 * 512 * 3 = 3_145_728` bytes. A 2 MB budget could only ever come back `BudgetExceeded`, so nothing below the `unwrap` had ever run.

## Is 4 MB still a meaningful test

Half of it, on its own, no. The existing assertion bounds peak at 4x the budget, which is 16 MB, and the whole level-0 raster is `2048 * 2048 * 3 = 12_582_912` bytes, so an engine that read the image in one piece and streamed nothing would still pass. That is why I added the second assertion: peak has to stay under one full canvas. Measured peak is 5_505_024 bytes on three consecutive runs, so both bounds hold with room, and the canvas bound is the one doing the work.

## Proof

Before, on `main` with the core at COUNTERPART_REV:

```
$ cargo test --features packfile --test phase3_packfile --test builder_sink_packfile
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out    (builder_sink_packfile)
test result: FAILED. 8 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out (phase3_packfile)

---- packfile_streaming_memory_bounded stdout ----
thread 'packfile_streaming_memory_bounded' panicked at tests/phase3_packfile.rs:525:10:
called `Result::unwrap()` on an `Err` value: BudgetExceeded { strip_bytes: 3145728, budget_bytes: 2000000 }
```

After:

```
$ cargo test --features packfile --test phase3_packfile --test builder_sink_packfile
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out    (builder_sink_packfile)
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out    (phase3_packfile)

$ cargo fmt -- --check                                    # clean
$ cargo clippy --all-targets --features packfile -- -D warnings   # clean
```
