### PR TITLE
Lint the cli the way its CI now does, and bump the pin that carries it

### DIFF
--- a/CLI_COUNTERPART_REV
+++ b/CLI_COUNTERPART_REV
@@ -48,4 +48,18 @@
 # only such construction site in the crate. Nothing about the command surface
 # or the reference fixtures changed, so every existing differential cell keeps
 # its previous classification.
-2235c1194f2e492fb5cbd9f30c22a32d566d4b31
+#
+# Bumped to eef0591, libviprs-cli main after its two CI-shape PRs: libviprs-cli
+# #49 lints all five of that crate's configurations instead of one, and
+# libviprs-cli #51 gives it a nightly. The first is why this pin has to move
+# rather than wait: tests/install_hooks_mirror_ci.rs compares the cli's lint
+# lines against LIBVIPRS_CLI_CARGO_STEPS in tools/install-hooks.sh, and in CI
+# it reads the cli AT THIS PIN, so the hook list and the pin have to arrive in
+# the same commit or the guard goes red on one side or the other.
+#
+# Nothing in `src/` moved between 2235c11 and here. The diff is
+# .github/workflows/ci.yml plus a Cargo.lock re-resolution that puts the
+# pdfium-render fork rev in step with the core's pin (libviprs-cli#45), so the
+# `viprs` binary the CLI-differential cells build behaves exactly as it did at
+# the old pin and every cell keeps its classification.
+eef059101eb93be34b33ebb78bbafbcd2cd124bc

--- a/tools/install-hooks.sh
+++ b/tools/install-hooks.sh
@@ -76,9 +76,19 @@ LIBVIPRS_CARGO_STEPS=(
     "cargo clippy --all-targets --features tracing -- -D warnings -W clippy::incompatible_msrv -W deprecated"
 )
 
-# libviprs-cli has no `pdfium` feature; one clippy pass.
+# libviprs-cli lints five configurations, and this list has to carry all five
+# (libviprs-cli#48). The comment that stood here said the cli "has no `pdfium`
+# feature", which was wrong twice over: it has one and it is the default, so
+# the bare pass below IS the pdfium pass, and the `--no-default-features` one
+# is the only build that ever compiles the `#[cfg(not(feature = "pdfium"))]`
+# halves. The other three are there for the usual reason: the default pass
+# compiles none of the code behind them.
 LIBVIPRS_CLI_CARGO_STEPS=(
     "cargo clippy --all-targets -- -D warnings -W clippy::incompatible_msrv -W deprecated"
+    "cargo clippy --all-targets --features tracing -- -D warnings -W clippy::incompatible_msrv -W deprecated"
+    "cargo clippy --all-targets --features packfile -- -D warnings -W clippy::incompatible_msrv -W deprecated"
+    "cargo clippy --all-targets --features s3 -- -D warnings -W clippy::incompatible_msrv -W deprecated"
+    "cargo clippy --all-targets --no-default-features -- -D warnings -W clippy::incompatible_msrv -W deprecated"
 )
 
 # libviprs-tests CI is plainer — no incompatible_msrv / deprecated lints.


### PR DESCRIPTION
Closes #195

## What I changed

- `tools/install-hooks.sh`: `LIBVIPRS_CLI_CARGO_STEPS` now carries all five of the cli's lint passes, and the comment above it says something true.
- `CLI_COUNTERPART_REV`: bumped from `2235c11` to `eef0591`, libviprs-cli `main` with libviprs-cli#49 and libviprs-cli#51 on it, with the reason written into the file the way that file does it.

The old comment claimed the cli "has no `pdfium` feature". It has one, it is the default, so the bare pass in that list was always the pdfium pass, and the pdfium-free build the cli's manifest documents was the configuration nothing ever compiled.

## The ordering, which is the part that bites

`tests/install_hooks_mirror_ci.rs` compares the hook's cli steps against the cli's own `ci.yml`, and which copy of that file it reads depends on where it runs. Locally it reads the sibling checkout, so cli `main`. In CI it reads the cli at `CLI_COUNTERPART_REV`, because that is the revision the `cli-differential` job lays down.

So there are three possible orders and only one of them is safe:

1. Hook list here first: this repo's CI goes red immediately. The pinned cli workflow lints one thing, the hook would lint five, and the guard fails with "the pre-commit hook for libviprs-cli runs these and CI does not".
2. Pin bump here first, hook list later: CI goes red the same way, from the other side.
3. The cli first, then hook list and pin bump together here: nothing is ever red in CI. While the cli sits on `main` ahead of the pin, this repo's CI keeps comparing against the pinned workflow and stays green, and the only report of the drift is a local run against a fresh cli checkout, which is the guard telling the truth to the one person who can see both trees.

I used order 3. libviprs-cli#49 and libviprs-cli#51 are merged; this closes the window from both ends in one commit.

## Proof

With the sibling cli checkout at `eef0591`, the hook list as it stands on `main` here is red and the one in this PR is green.

Before, old list against the new cli workflow:

```
$ VIPRS_REQUIRE_CLI=1 cargo test --test install_hooks_mirror_ci
test the_hook_lints_the_cli_the_way_its_ci_does ... FAILED
test the_hook_lints_the_core_the_way_its_ci_does ... ok
test the_hook_lints_this_repo_the_way_its_ci_does ... ok

libviprs-cli's CI lints these and the pre-commit hook does not:
  cargo clippy --all-targets --features packfile -- -D warnings -W clippy::incompatible_msrv -W deprecated
  cargo clippy --all-targets --features s3 -- -D warnings -W clippy::incompatible_msrv -W deprecated
  cargo clippy --all-targets --features tracing -- -D warnings -W clippy::incompatible_msrv -W deprecated
  cargo clippy --all-targets --no-default-features -- -D warnings -W clippy::incompatible_msrv -W deprecated

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```

After:

```
$ VIPRS_REQUIRE_CLI=1 cargo test --test install_hooks_mirror_ci
running 3 tests
test the_hook_lints_the_cli_the_way_its_ci_does ... ok
test the_hook_lints_the_core_the_way_its_ci_does ... ok
test the_hook_lints_this_repo_the_way_its_ci_does ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

```
$ cargo test --test cli_counterpart_pinning
running 4 tests
test cli_counterpart_rev_pins_a_full_sha ... ok
test cli_differential_job_requires_the_cli_to_run ... ok
test ci_clones_pinned_cli_counterpart_with_no_branch_fallback ... ok
test cli_differential_job_runs_every_diff_binary ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ shellcheck tools/install-hooks.sh    # clean
```

## On the pin bump being safe

`git diff --name-only 2235c11 eef0591` in libviprs-cli is `.github/workflows/ci.yml` and `Cargo.lock`. Nothing under `src/`, so the `viprs` binary the 18 differential cells build behaves exactly as it did at the old pin and every cell keeps its classification. The lock change moves the `pdfium-render` fork rev into step with the core's own pin, which I wrote up on libviprs-cli#45.
