### PR TITLE
Make the hook installer cover the whole org, and hold it there

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,46 @@ jobs:
         # (libviprs/libviprs#715).
         run: cargo test --test install_hooks_mirror_ci --test cli_morphology_diff --test cli_bands_diff --test cli_extract_diff --test cli_conversion_diff --test cli_core_diff --test cli_convolution_diff --test cli_matrix_diff --test cli_colour_diff --test cli_resample_diff --test cli_histogram_diff --test cli_composite_diff --test cli_freqfilt_diff --test cli_mosaicing_diff --test cli_create_diff --test cli_draw_diff --test cli_aritha_diff --test cli_arithb_diff --test cli_iocleanup_diff
 
+  hook-mirror:
+    name: Hook Mirror (every repo in the org)
+    # The hook guards compare each repo's installed pre-commit hook against
+    # that repo's own ci.yml, so they need every repo laid down beside this
+    # one. Nothing else in this workflow does that, and a guard whose sibling
+    # is missing skips, which reads to `cargo test` as a pass. So this job
+    # exists to be the one place they cannot skip: VIPRS_REQUIRE_SIBLINGS=1
+    # turns a missing checkout into a panic, the same shape as
+    # VIPRS_REQUIRE_CLI on the cli-differential job (tests/common/cli.rs).
+    #
+    # Without it the three repos that gained hooks in #198 would be guarded by
+    # tests that never once ran.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/clone-counterpart
+      - uses: ./.github/actions/clone-cli-counterpart
+      - name: Clone the siblings that carry no pin
+        # These four are read for their workflow files only, so the default
+        # branch at whatever it is now is the right thing to compare against:
+        # a hook that has drifted from the CI running today is exactly what
+        # this job is for. The two that do carry a pin are cloned at it above.
+        run: |
+          set -euo pipefail
+          for repo in libviprs-bench libviprs-org libviprs-dep pdfium-render; do
+            git clone --depth 1 --single-branch \
+              "https://github.com/${{ github.repository_owner }}/$repo.git" \
+              "${GITHUB_WORKSPACE}/../$repo"
+          done
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          # install_hooks_pdfium_scope drives the fork's real hook against a
+          # throwaway crate, and that hook runs cargo fmt and cargo clippy.
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - env:
+          VIPRS_REQUIRE_SIBLINGS: 1
+          VIPRS_REQUIRE_CLI: 1
+        run: cargo test --test install_hooks_mirror_ci --test install_hooks_pdfium_scope --test install_hooks_pre_push_slots --test install_hooks_localci_selection --test install_hooks_localci_worktree
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/tests/common/hooks.rs
+++ b/tests/common/hooks.rs
@@ -16,6 +16,20 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+/// The repos `tools/install-hooks.sh` looks for as siblings, which is what a
+/// stand-in workspace has to lay down for it to install anything. Kept in one
+/// place because two guard suites and the installer all have to agree on it;
+/// `install_hooks_pre_push_slots` asserts the installer visits exactly these.
+pub const STANDIN_REPOS: &[&str] = &[
+    "libviprs",
+    "libviprs-cli",
+    "libviprs-tests",
+    "libviprs-bench",
+    "libviprs-org",
+    "libviprs-dep",
+    "pdfium-render",
+];
+
 /// This crate's root, which is also the repo root for the harness checkout.
 pub fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
@@ -97,10 +111,11 @@ impl Workspace {
         let dir = tempfile::tempdir().expect("temp dir for a stand-in workspace");
         let root = dir.path().canonicalize().expect("canonical temp path");
 
-        // libviprs-cli gets no pre-push hook (libviprs/libviprs#691) but it
-        // does get a pre-commit one, and #715's guard runs that, so it is here
-        // too. Nothing pushes from it.
-        for repo in ["libviprs", "libviprs-cli", "libviprs-tests"] {
+        // Only libviprs and libviprs-tests get a pre-push hook
+        // (libviprs/libviprs#691), but every one of these gets a pre-commit
+        // hook and install_hooks_mirror_ci runs all of them, so the whole org
+        // is here. Nothing pushes from any but the two.
+        for repo in STANDIN_REPOS {
             let repo_root = root.join(repo);
             std::fs::create_dir_all(&repo_root).expect("create the stand-in repo");
             git(&repo_root, &["init", "-q", "-b", "main"]);

--- a/tests/install_hooks_mirror_ci.rs
+++ b/tests/install_hooks_mirror_ci.rs
@@ -1,105 +1,575 @@
-//! Guards that the pre-commit hook runs what each repo's CI lint job runs
-//! (libviprs/libviprs#715).
+//! Guards that the pre-commit hook runs what each repo's CI runs
+//! (libviprs/libviprs#715, and libviprs-tests#198 for the org-wide sweep).
 //!
-//! `tools/install-hooks.sh` says its pre-commit hook "Mirrors each repo's
-//! `.github/workflows/ci.yml` Check & Lint job *exactly*, so a clean local
-//! commit means a clean remote Check & Lint", and then asks a human to keep
-//! the per-repo cargo step lists in lockstep by hand. That did not happen. The
-//! core's list ran two of the five clippy passes CI runs, missing
-//! `object-store-sink`, `svg` and `jxl`, and this repo's missed `jxl` while
-//! spending a compile on `s3`, a deprecated alias for a cell the matrix
-//! already covers under its real name.
+//! `tools/install-hooks.sh` states a contract at the top of the file: the
+//! pre-commit hook is the LINT HALF of a repo's CI, which is the jobs listed
+//! under `mirror_jobs` for that repo, minus the steps `exempt_steps` names
+//! with a reason; the pre-push hook is the TEST HALF; and `deferred_jobs`
+//! accounts for everything in neither. This file is what makes that a contract
+//! rather than a paragraph.
 //!
-//! Every one of those per-feature passes exists because the default pass
-//! compiles none of that code (#382, #500, #502, and libviprs-tests#55). So a
-//! commit that breaks `src/svg.rs` passed the local hook and failed CI, which
-//! is the exact failure the hook was written to prevent.
+//! Four things are enforced, and each one is a way the arrangement has already
+//! gone wrong at least once:
 //!
-//! The guard runs the generated hook with a recording stand-in for `cargo`
-//! first on `PATH` and compares the invocations it actually makes against the
-//! lint lines in that repo's `ci.yml`. Grepping either file would be worth
-//! nothing, which is the standing lesson of libviprs/libviprs#695.
+//! 1. Every job in a repo's workflow is either mirrored or deferred with a
+//!    reason. A new CI job that is in neither fails here. Without this, CI can
+//!    grow a whole job and the local gate says nothing, which is how the core's
+//!    list came to run two of ten clippy passes.
+//! 2. The hook runs every command in the jobs it mirrors. A missing one is a
+//!    commit that passes locally and fails remotely.
+//! 3. The hook runs nothing those jobs do not. An extra is a compile spent on
+//!    something nobody asked for, or a check CI quietly dropped.
+//! 4. Every exemption still names a step CI actually runs. A stale exemption is
+//!    a hole with a reassuring comment over it.
+//!
+//! Nothing here greps either file. The contract is read by running
+//! `tools/install-hooks.sh --describe`, and what the hook runs is read by
+//! running the generated hook with recording stand-ins in front of every tool
+//! it shells out to. Two earlier guards on these hooks asserted by substring
+//! and stayed green while the behaviour they named had been deleted, which is
+//! the whole of libviprs/libviprs#695.
 
-use std::collections::BTreeSet;
-use std::path::Path;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 mod common;
 use common::cli::{cli_dir, require_cli};
 use common::hooks::{Workspace, make_executable, repo_root};
 
-/// A `cargo` that records its arguments and succeeds, so the hook runs every
-/// step instead of stopping at the first one.
-const RECORDING_CARGO: &str = r#"#!/bin/sh
-printf 'cargo %s\n' "$*" >> "$LOCKSTEP_RECORD"
-exit 0
-"#;
+// ---------------------------------------------------------------------------
+// Recording stand-ins
+// ---------------------------------------------------------------------------
 
-/// The same for the one non-cargo lint step, which the hook invokes by
-/// relative path rather than through `PATH`.
-const RECORDING_PORTED_CELLS: &str = r#"#!/bin/sh
-printf './tools/run_ported_cells.sh %s\n' "$*" >> "$LOCKSTEP_RECORD"
-exit 0
-"#;
-
-/// Every lint command `ci.yml` runs, with the feature matrix expanded.
+/// A tool that records its arguments and succeeds, so the hook runs every step
+/// instead of stopping at the first one.
 ///
-/// `cargo check` and `cargo build` lines are deliberately out. The comment
-/// above the step lists already says clippy does `cargo check`'s work, and the
-/// core's `cargo build --features s3` is there to prove a deprecated alias
-/// still resolves, which the manifest settles and a whole extra build on every
-/// commit does not earn.
-fn ci_lint_commands(workflow: &str) -> BTreeSet<String> {
-    let features: Vec<String> = workflow
-        .lines()
-        .filter_map(|line| {
-            let line = line.trim();
-            let list = line.strip_prefix("feature: [")?.strip_suffix(']')?;
-            Some(
-                list.split(',')
-                    .map(|f| f.trim().to_string())
-                    .collect::<Vec<_>>(),
-            )
-        })
-        .flatten()
-        .collect();
-
-    let mut found = BTreeSet::new();
-    for line in workflow.lines() {
-        let line = line.trim();
-        let Some(cmd) = line
-            .strip_prefix("- run: ")
-            .or_else(|| line.strip_prefix("run: "))
-        else {
-            continue;
-        };
-        let cmd = cmd.trim();
-        let is_lint = cmd.starts_with("cargo clippy")
-            || cmd.starts_with("cargo fmt")
-            || (cmd.starts_with("./tools/run_ported_cells.sh") && cmd.contains("--clippy"));
-        if !is_lint {
-            continue;
-        }
-        if cmd.contains("${{ matrix.feature }}") {
-            assert!(
-                !features.is_empty(),
-                "a workflow line uses ${{{{ matrix.feature }}}} but no job \
-                 declares a `feature: [...]` list, so this guard cannot expand \
-                 it: {cmd}"
-            );
-            for feature in &features {
-                found.insert(cmd.replace("${{ matrix.feature }}", feature));
-            }
-        } else {
-            found.insert(cmd.to_string());
-        }
-    }
-    found
+/// It reports the directory it was called in, relative to the repo, because a
+/// CI step can carry a `working-directory:` and the hook mirrors that with a
+/// `cd`. Recording the command without the directory would let a hook that
+/// runs the right command in the wrong place read as correct.
+fn recorder(tool: &str) -> String {
+    format!(
+        r#"#!/bin/sh
+here=$(pwd)
+case "$here" in
+  "$LOCKSTEP_ROOT") printf '{tool} %s\n' "$*" >> "$LOCKSTEP_RECORD" ;;
+  *) printf 'cd %s && {tool} %s\n' "${{here#"$LOCKSTEP_ROOT"/}}" "$*" >> "$LOCKSTEP_RECORD" ;;
+esac
+exit 0
+"#
+    )
 }
 
-/// What the pre-commit hook `install-hooks.sh` writes for `repo` actually
-/// runs, observed by putting a recorder in front of it.
-fn hook_runs(ws: &Workspace, repo: &str) -> BTreeSet<String> {
+/// `git` is the one tool the hook uses for two different reasons: `git diff
+/// --exit-code` is a CI step, and everything else is plumbing the hook needs
+/// to work at all. Recording the first and handing the rest to the real git
+/// keeps the comparison exact without breaking the hook underneath it.
+fn git_recorder(real_git: &str) -> String {
+    format!(
+        r#"#!/bin/sh
+if [ "${{1-}}" = "diff" ]; then
+  here=$(pwd)
+  case "$here" in
+    "$LOCKSTEP_ROOT") printf 'git %s\n' "$*" >> "$LOCKSTEP_RECORD" ;;
+    *) printf 'cd %s && git %s\n' "${{here#"$LOCKSTEP_ROOT"/}}" "$*" >> "$LOCKSTEP_RECORD" ;;
+  esac
+  exit 0
+fi
+exec {real_git} "$@"
+"#
+    )
+}
+
+/// The same, for a script the hook reaches by a path relative to the repo
+/// rather than through `PATH`. It reports `$0`, which is the path the hook
+/// typed, so `./tools/x.sh` and `tools/x.sh` stay distinguishable: those are
+/// different commands and CI writes one of them.
+const SCRIPT_RECORDER: &str = r#"#!/bin/sh
+here=$(pwd)
+case "$here" in
+  "$LOCKSTEP_ROOT") printf '%s %s\n' "$0" "$*" >> "$LOCKSTEP_RECORD" ;;
+  *) printf 'cd %s && %s %s\n' "${here#"$LOCKSTEP_ROOT"/}" "$0" "$*" >> "$LOCKSTEP_RECORD" ;;
+esac
+exit 0
+"#;
+
+/// Tools the generated hooks reach through `PATH`.
+const RECORDED_TOOLS: &[&str] = &["cargo", "node", "shellcheck", "ruff", "pytest"];
+
+/// Scripts the generated hooks reach by a path relative to the repo, so a
+/// stand-in has to sit at that path rather than on `PATH`.
+const RECORDED_SCRIPTS: &[&str] = &["tools/run_ported_cells.sh", "cli/tools/sync-cli-src.sh"];
+
+/// Where the real `git` is, resolved once so the recording `git` can hand the
+/// plumbing calls on to it.
+fn real_git() -> String {
+    let out = Command::new("sh")
+        .args(["-c", "command -v git"])
+        .output()
+        .expect("these guards drive the real hooks, which need git on PATH");
+    let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    assert!(
+        !path.is_empty(),
+        "git is not on PATH, and these guards drive hooks that use it"
+    );
+    path
+}
+
+// ---------------------------------------------------------------------------
+// The contract, read out of the installer by running it
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default)]
+struct RepoContract {
+    workflow: String,
+    /// The subdirectory CI checks this repo out into, when it does. Every path
+    /// in that job's commands carries it and no local path does.
+    checkout_path: Option<String>,
+    mirrored: Vec<String>,
+    /// job -> why it is in neither half.
+    deferred: BTreeMap<String, String>,
+    /// step -> why the hook skips it.
+    exempt: BTreeMap<String, String>,
+    pre_push: bool,
+}
+
+/// Every repo the installer knows about, read by running it with `--describe`.
+fn contract() -> BTreeMap<String, RepoContract> {
+    let script = repo_root().join("tools/install-hooks.sh");
+    let out = Command::new("bash")
+        .arg(&script)
+        .arg("--describe")
+        .output()
+        .unwrap_or_else(|e| panic!("run {} --describe: {e}", script.display()));
+    assert!(
+        out.status.success(),
+        "tools/install-hooks.sh --describe exited {}:\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let text = String::from_utf8_lossy(&out.stdout).into_owned();
+
+    let mut repos: BTreeMap<String, RepoContract> = BTreeMap::new();
+    for line in text.lines() {
+        let f: Vec<&str> = line.split('\t').collect();
+        if f.len() < 2 {
+            continue;
+        }
+        let entry = repos.entry(f[1].to_string()).or_default();
+        match (f[0], f.len()) {
+            ("repo", _) => {}
+            ("workflow", 3) => entry.workflow = f[2].to_string(),
+            ("checkout-path", 3) => entry.checkout_path = Some(f[2].to_string()),
+            ("mirror", 3) => entry.mirrored.push(f[2].to_string()),
+            ("prepush", 3) => entry.pre_push = f[2] == "yes",
+            ("defer", 4) => {
+                entry.deferred.insert(f[2].to_string(), f[3].to_string());
+            }
+            ("exempt", 4) => {
+                entry.exempt.insert(f[2].to_string(), f[3].to_string());
+            }
+            _ => panic!(
+                "tools/install-hooks.sh --describe printed a line this guard cannot read, so the contract and the guard have gone out of step:\n  {line}"
+            ),
+        }
+    }
+    assert!(
+        !repos.is_empty(),
+        "tools/install-hooks.sh --describe printed nothing, so every comparison \
+         below would be vacuous"
+    );
+    repos
+}
+
+// ---------------------------------------------------------------------------
+// Enough of a workflow parser to read steps out of jobs
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, Clone)]
+struct Step {
+    name: Option<String>,
+    run: Option<String>,
+    working_directory: Option<String>,
+}
+
+#[derive(Debug, Default, Clone)]
+struct Job {
+    id: String,
+    steps: Vec<Step>,
+    /// The `feature: [...]` list, when the job has one.
+    features: Vec<String>,
+}
+
+fn indent_of(line: &str) -> usize {
+    line.len() - line.trim_start().len()
+}
+
+fn structural(line: &str) -> bool {
+    let t = line.trim();
+    !t.is_empty() && !t.starts_with('#')
+}
+
+/// The jobs of a workflow, in file order.
+///
+/// This is not a YAML parser and does not try to be. It reads the shape every
+/// workflow in this org is written in: `jobs:` at column zero, one job header
+/// per indent level below it, a `steps:` list, and `key: value` or `key: |`
+/// inside each step. Anything it cannot read it refuses rather than skips,
+/// because a parser that silently returns nothing turns every comparison below
+/// into a vacuous pass.
+fn parse_jobs(workflow: &str, whose: &str) -> Vec<Job> {
+    let lines: Vec<&str> = workflow.lines().collect();
+    let jobs_at = lines
+        .iter()
+        .position(|l| l.trim_end() == "jobs:")
+        .unwrap_or_else(|| {
+            panic!("{whose} has no `jobs:` block, so this guard would compare nothing")
+        });
+
+    // The jobs block runs to the end of the file or to the next column-zero key.
+    let end = lines[jobs_at + 1..]
+        .iter()
+        .position(|l| structural(l) && indent_of(l) == 0)
+        .map(|i| jobs_at + 1 + i)
+        .unwrap_or(lines.len());
+    let body = &lines[jobs_at + 1..end];
+
+    // Job headers all sit at the first indent seen inside the block.
+    let job_indent = body
+        .iter()
+        .find(|l| structural(l))
+        .map(|l| indent_of(l))
+        .unwrap_or_else(|| panic!("{whose} declares `jobs:` and then nothing"));
+
+    let is_header = |l: &str| {
+        structural(l) && indent_of(l) == job_indent && {
+            let t = l.trim();
+            t.ends_with(':')
+                && t[..t.len() - 1]
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+                && !t[..t.len() - 1].is_empty()
+        }
+    };
+
+    let starts: Vec<usize> = (0..body.len()).filter(|&i| is_header(body[i])).collect();
+    assert!(
+        !starts.is_empty(),
+        "{whose} declares `jobs:` but this guard found no job headers under it"
+    );
+
+    let mut jobs = Vec::new();
+    for (n, &start) in starts.iter().enumerate() {
+        let stop = starts.get(n + 1).copied().unwrap_or(body.len());
+        let id = body[start].trim().trim_end_matches(':').to_string();
+        jobs.push(parse_job(id, &body[start + 1..stop], whose));
+    }
+    jobs
+}
+
+fn parse_job(id: String, body: &[&str], whose: &str) -> Job {
+    let features = body
+        .iter()
+        .find_map(|l| {
+            let t = l.trim();
+            let list = t.strip_prefix("feature: [")?.strip_suffix(']')?;
+            Some(list.split(',').map(|f| f.trim().to_string()).collect())
+        })
+        .unwrap_or_default();
+
+    let Some(steps_at) = body.iter().position(|l| l.trim() == "steps:") else {
+        return Job {
+            id,
+            steps: Vec::new(),
+            features,
+        };
+    };
+    let rest = &body[steps_at + 1..];
+
+    // Every list item sits at the first indent seen after `steps:`.
+    let Some(dash_indent) = rest
+        .iter()
+        .find(|l| structural(l))
+        .map(|l| indent_of(l))
+        .filter(|_| rest.iter().any(|l| l.trim().starts_with("- ")))
+    else {
+        return Job {
+            id,
+            steps: Vec::new(),
+            features,
+        };
+    };
+
+    // Normalising the `- ` away puts every key of every step at one indent,
+    // which is what makes the block-scalar rule below a single comparison.
+    let key_indent = dash_indent + 2;
+    let flattened: Vec<String> = rest
+        .iter()
+        .map(|l| {
+            if structural(l) && indent_of(l) == dash_indent && l.trim_start().starts_with("- ") {
+                format!("{}{}", " ".repeat(key_indent), &l.trim_start()[2..])
+            } else {
+                (*l).to_string()
+            }
+        })
+        .collect();
+
+    let item_starts: Vec<usize> = (0..rest.len())
+        .filter(|&i| {
+            structural(rest[i])
+                && indent_of(rest[i]) == dash_indent
+                && rest[i].trim().starts_with("- ")
+        })
+        .collect();
+
+    let mut steps = Vec::new();
+    for (n, &start) in item_starts.iter().enumerate() {
+        let stop = item_starts.get(n + 1).copied().unwrap_or_else(|| {
+            // The step runs until the steps list itself ends.
+            rest.iter()
+                .enumerate()
+                .skip(start + 1)
+                .find(|(_, l)| structural(l) && indent_of(l) < dash_indent)
+                .map(|(i, _)| i)
+                .unwrap_or(rest.len())
+        });
+        steps.push(parse_step(&flattened[start..stop], key_indent, whose, &id));
+    }
+
+    Job {
+        id,
+        steps,
+        features,
+    }
+}
+
+fn parse_step(lines: &[String], key_indent: usize, whose: &str, job: &str) -> Step {
+    let mut step = Step::default();
+    let mut i = 0;
+    while i < lines.len() {
+        let line = &lines[i];
+        if !structural(line) || indent_of(line) != key_indent {
+            i += 1;
+            continue;
+        }
+        let t = line.trim();
+        let Some((key, value)) = t.split_once(':') else {
+            i += 1;
+            continue;
+        };
+        let key = key.trim();
+        let mut value = value.trim().to_string();
+
+        // A block scalar: the value is on the following, more-indented lines.
+        if value.is_empty() || value == "|" || value == "|-" || value == ">" || value == ">-" {
+            let mut block = Vec::new();
+            let mut j = i + 1;
+            while j < lines.len() && (!structural(&lines[j]) || indent_of(&lines[j]) > key_indent) {
+                if structural(&lines[j]) {
+                    block.push(lines[j].trim().to_string());
+                }
+                j += 1;
+            }
+            i = j;
+            value = block.join("\n");
+        } else {
+            i += 1;
+        }
+
+        match key {
+            "name" => step.name = Some(strip_quotes(&value)),
+            "run" => step.run = Some(value),
+            "working-directory" => step.working_directory = Some(strip_quotes(&value)),
+            _ => {}
+        }
+    }
+    let _ = (whose, job);
+    step
+}
+
+fn strip_quotes(s: &str) -> String {
+    let s = s.trim();
+    if s.len() >= 2
+        && (s.starts_with('\'') && s.ends_with('\'') || s.starts_with('"') && s.ends_with('"'))
+    {
+        s[1..s.len() - 1].to_string()
+    } else {
+        s.to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Turning a mirrored job into the commands the hook has to run
+// ---------------------------------------------------------------------------
+
+/// Expand any glob in `cmd` the way the hook's own shell did, in the same
+/// directory, so `shellcheck tools/*.sh` on the CI side and the file list the
+/// hook actually passed compare equal.
+///
+/// Only word expansion runs here, never the command, and only for a command
+/// that has a glob character and none of the shell metacharacters that would
+/// make that unsafe.
+fn expand_globs(cmd: &str, dir: &Path) -> String {
+    if !cmd.contains(['*', '?']) {
+        return cmd.to_string();
+    }
+    if cmd.contains(['&', '|', ';', '$', '`', '(', ')', '<', '>', '\'', '"']) {
+        return cmd.to_string();
+    }
+    let out = Command::new("bash")
+        .arg("-c")
+        .arg(format!("for w in {cmd}; do printf '%s\\n' \"$w\"; done"))
+        .current_dir(dir)
+        .output()
+        .expect("expand a glob the way the hook's shell would");
+    if !out.status.success() {
+        return cmd.to_string();
+    }
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// The directories the mirrored jobs ask their steps to run in, expressed the
+/// way they are locally: relative to the repo root, with CI's checkout
+/// subdirectory taken off.
+fn local_workdirs(c: &RepoContract, jobs: &[Job]) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for job in jobs.iter().filter(|j| c.mirrored.contains(&j.id)) {
+        for wd in job
+            .steps
+            .iter()
+            .filter_map(|s| s.working_directory.as_ref())
+        {
+            let local = match &c.checkout_path {
+                Some(p) if wd == p => String::new(),
+                Some(p) => wd.strip_prefix(&format!("{p}/")).unwrap_or(wd).to_string(),
+                None => wd.clone(),
+            };
+            if !local.is_empty() && local != "." {
+                out.insert(local);
+            }
+        }
+    }
+    out
+}
+
+struct Mirrored {
+    commands: BTreeSet<String>,
+    /// Which exemptions actually matched a step.
+    used_exemptions: BTreeSet<String>,
+}
+
+fn mirrored_commands(repo: &str, c: &RepoContract, jobs: &[Job], dir: &Path) -> Mirrored {
+    let by_id: BTreeMap<&str, &Job> = jobs.iter().map(|j| (j.id.as_str(), j)).collect();
+    let mut commands = BTreeSet::new();
+    let mut used = BTreeSet::new();
+
+    for want in &c.mirrored {
+        let job = by_id.get(want.as_str()).unwrap_or_else(|| {
+            panic!(
+                "tools/install-hooks.sh says the pre-commit hook for {repo} mirrors \
+                 the `{want}` job, and {} has no job by that name. Either the job \
+                 was renamed and the mirror list did not follow, or the hook is \
+                 standing in for something that no longer exists.",
+                c.workflow
+            )
+        });
+
+        for step in &job.steps {
+            let Some(run) = step.run.as_deref() else {
+                continue;
+            };
+            let first = run.lines().next().unwrap_or("").trim().to_string();
+            let ids = [step.name.clone(), Some(first.clone())];
+            if let Some(hit) = ids
+                .iter()
+                .flatten()
+                .find(|id| c.exempt.contains_key(id.as_str()))
+            {
+                used.insert(hit.clone());
+                continue;
+            }
+
+            assert!(
+                !run.contains('\n'),
+                "{repo}'s `{want}` job runs a multi-line shell block that the \
+                 pre-commit hook does not, and a hook cannot faithfully stand in \
+                 for an arbitrary block. Either exempt it in \
+                 tools/install-hooks.sh with a reason, or give the hook a step \
+                 that does the same job. The block starts:\n  {first}"
+            );
+
+            let mut cmd = run.trim().to_string();
+            if let Some(prefix) = &c.checkout_path {
+                let with_slash = format!("{prefix}/");
+                if let Some(rest) = cmd.strip_prefix(&with_slash) {
+                    cmd = rest.to_string();
+                }
+            }
+            if let Some(wd) = &step.working_directory {
+                let local = match &c.checkout_path {
+                    Some(p) if wd == p => String::new(),
+                    Some(p) => wd
+                        .strip_prefix(&format!("{p}/"))
+                        .unwrap_or(wd.as_str())
+                        .to_string(),
+                    None => wd.clone(),
+                };
+                if !local.is_empty() && local != "." {
+                    cmd = format!("cd {local} && {cmd}");
+                }
+            }
+
+            if cmd.contains("${{ matrix.feature }}") {
+                assert!(
+                    !job.features.is_empty(),
+                    "{repo}'s `{want}` job uses a feature matrix but declares no \
+                     `feature: [...]` list, so this guard cannot expand it: {cmd}"
+                );
+                for feature in &job.features {
+                    commands.insert(expand_globs(
+                        &cmd.replace("${{ matrix.feature }}", feature),
+                        dir,
+                    ));
+                }
+            } else {
+                commands.insert(expand_globs(&cmd, dir));
+            }
+        }
+    }
+
+    Mirrored {
+        commands,
+        used_exemptions: used,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// What the installed hook actually runs
+// ---------------------------------------------------------------------------
+
+/// Run the pre-commit hook `install-hooks.sh` wrote for `repo` with a recorder
+/// in front of every tool it can reach, and report what it invoked.
+fn hook_runs(ws: &Workspace, repo: &str, workdirs: &BTreeSet<String>) -> BTreeSet<String> {
+    let (ok, recorded, printed) = run_recorded(ws, repo, workdirs);
+    assert!(
+        ok,
+        "the pre-commit hook for {repo} failed with every command stubbed to \
+         succeed, so it is broken independently of what it runs:\n{printed}"
+    );
+    recorded
+}
+
+/// The same, handing back the verdict and the output as well, for the cases
+/// that are about a hook deciding not to run something.
+fn run_recorded(
+    ws: &Workspace,
+    repo: &str,
+    workdirs: &BTreeSet<String>,
+) -> (bool, BTreeSet<String>, String) {
     let repo_dir = ws.repo(repo);
     let hook = repo_dir.join(".git/hooks/pre-commit");
     assert!(
@@ -110,16 +580,31 @@ fn hook_runs(ws: &Workspace, repo: &str) -> BTreeSet<String> {
 
     let bin = ws.root.join("recorders").join(repo);
     std::fs::create_dir_all(&bin).expect("create the recorder directory");
-    let cargo = bin.join("cargo");
-    std::fs::write(&cargo, RECORDING_CARGO).expect("write the recording cargo");
-    make_executable(&cargo);
+    for tool in RECORDED_TOOLS {
+        let path = bin.join(tool);
+        std::fs::write(&path, recorder(tool)).expect("write a recording tool");
+        make_executable(&path);
+    }
+    let git = bin.join("git");
+    std::fs::write(&git, git_recorder(&real_git())).expect("write the recording git");
+    make_executable(&git);
 
-    // The hook reaches this one by relative path, so it has to sit in the
-    // stand-in repo rather than on PATH.
-    let ported = repo_dir.join("tools/run_ported_cells.sh");
-    std::fs::create_dir_all(ported.parent().expect("tools dir")).expect("create tools dir");
-    std::fs::write(&ported, RECORDING_PORTED_CELLS).expect("write the recording ported cells");
-    make_executable(&ported);
+    for script in RECORDED_SCRIPTS {
+        let path = repo_dir.join(script);
+        std::fs::create_dir_all(path.parent().expect("script directory"))
+            .expect("create a script directory");
+        std::fs::write(&path, SCRIPT_RECORDER).expect("write a recording script");
+        make_executable(&path);
+    }
+
+    // A step that carries a `working-directory:` becomes a `cd` in the hook,
+    // and a `cd` into a directory the stand-in does not have takes the hook
+    // down before it reaches anything. These come from the workflow rather
+    // than from reading the hook, so a hook that cds somewhere CI never asks
+    // it to still fails here rather than being quietly accommodated.
+    for dir in workdirs {
+        std::fs::create_dir_all(repo_dir.join(dir)).expect("create a stand-in working directory");
+    }
 
     let record = ws.root.join(format!("{repo}.record"));
     let _ = std::fs::remove_file(&record);
@@ -134,45 +619,141 @@ fn hook_runs(ws: &Workspace, repo: &str) -> BTreeSet<String> {
         .current_dir(&repo_dir)
         .env("PATH", path)
         .env("LOCKSTEP_RECORD", &record)
+        .env("LOCKSTEP_ROOT", &repo_dir)
         .output()
         .expect("run the generated pre-commit hook");
-    assert!(
-        out.status.success(),
-        "the pre-commit hook failed with every command stubbed to succeed:\n{}{}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr)
-    );
 
-    std::fs::read_to_string(&record)
+    let recorded = std::fs::read_to_string(&record)
         .unwrap_or_default()
         .lines()
         .map(|l| l.trim().to_string())
         .filter(|l| !l.is_empty())
-        .collect()
+        .collect();
+    let printed = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    (out.status.success(), recorded, printed)
 }
 
-/// The workflow for a repo, read out of that repo's checkout.
-fn workflow_of(root: &Path) -> String {
-    let path = root.join(".github/workflows/ci.yml");
+// ---------------------------------------------------------------------------
+// The comparison
+// ---------------------------------------------------------------------------
+
+/// Where a repo's checkout is, or `None` when it is not laid down here.
+fn sibling(repo: &str) -> Option<PathBuf> {
+    if repo == "libviprs-tests" {
+        return Some(repo_root());
+    }
+    if repo == "libviprs-cli" {
+        let dir = cli_dir();
+        return dir
+            .join(".github/workflows/ci.yml")
+            .is_file()
+            .then_some(dir);
+    }
+    let dir = repo_root().join("..").join(repo);
+    dir.join(".github").is_dir().then_some(dir)
+}
+
+/// A missing sibling reads to `cargo test` as a pass, so the job that lays
+/// them all down sets this and turns the skip into a panic. Same shape as
+/// `VIPRS_REQUIRE_CLI` (`tests/common/cli.rs`).
+fn require_siblings() -> bool {
+    std::env::var("VIPRS_REQUIRE_SIBLINGS").is_ok_and(|v| v == "1")
+}
+
+fn workflow_of(dir: &Path, rel: &str) -> String {
+    let path = dir.join(rel);
     std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
 }
 
-fn compare(repo: &str, ci: BTreeSet<String>, hook: BTreeSet<String>) {
+/// Resolve a repo to its checkout and parsed workflow, or report why it is
+/// being skipped. Returns `None` only where skipping is allowed.
+fn resolve(repo: &str, c: &RepoContract) -> Option<(PathBuf, Vec<Job>)> {
+    let Some(dir) = sibling(repo) else {
+        assert!(
+            !(require_siblings() || (repo == "libviprs-cli" && require_cli())),
+            "the siblings are required here but {repo} is not laid down beside \
+             this checkout, so this guard would compare nothing and report a \
+             false green"
+        );
+        return None;
+    };
+    let text = workflow_of(&dir, &c.workflow);
+    let jobs = parse_jobs(&text, repo);
+    Some((dir, jobs))
+}
+
+fn check_repo(repo: &str) {
+    let contract = contract();
+    let c = contract
+        .get(repo)
+        .unwrap_or_else(|| panic!("tools/install-hooks.sh --describe never mentions {repo}"));
+    let Some((_dir, jobs)) = resolve(repo, c) else {
+        return;
+    };
+
+    // 1. Every job is either mirrored or deferred with a reason.
+    let unaccounted: Vec<&str> = jobs
+        .iter()
+        .map(|j| j.id.as_str())
+        .filter(|id| !c.mirrored.iter().any(|m| m == id) && !c.deferred.contains_key(*id))
+        .collect();
     assert!(
-        !ci.is_empty(),
-        "found no lint commands in {repo}'s ci.yml, so this guard would pass \
-         on a workflow that lints nothing"
+        unaccounted.is_empty(),
+        "{repo}'s {} has jobs the local hooks account for neither way:\n  {}\n\
+         Every job is either in the lint half the pre-commit hook mirrors \
+         (`mirror_jobs`) or deferred with a reason (`deferred_jobs`). A job in \
+         neither is CI coverage with no local counterpart and nothing saying \
+         why. Decide which it is in tools/install-hooks.sh.",
+        c.workflow,
+        unaccounted.join("\n  ")
     );
 
-    let missing: Vec<&String> = ci.difference(&hook).collect();
-    let extra: Vec<&String> = hook.difference(&ci).collect();
+    // A deferral naming a job the workflow no longer has is dead text.
+    let stale: Vec<&str> = c
+        .deferred
+        .keys()
+        .map(|k| k.as_str())
+        .filter(|k| !jobs.iter().any(|j| j.id == *k))
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "tools/install-hooks.sh defers these jobs of {repo} and {} has no job by \
+         those names:\n  {}\n\
+         Either the job was renamed and the reason did not follow, or it is gone \
+         and the entry should be too.",
+        c.workflow,
+        stale.join("\n  ")
+    );
+
+    if c.mirrored.is_empty() {
+        return;
+    }
+
+    // 2, 3 and 4 need the hook actually run.
+    let ws = Workspace::new();
+    let hook = hook_runs(&ws, repo, &local_workdirs(c, &jobs));
+    let m = mirrored_commands(repo, c, &jobs, &ws.repo(repo));
+
+    assert!(
+        !m.commands.is_empty(),
+        "the jobs the hook mirrors for {repo} run no commands at all, so this \
+         guard would pass on a hook that runs nothing"
+    );
+
+    let missing: Vec<&String> = m.commands.difference(&hook).collect();
+    let extra: Vec<&String> = hook.difference(&m.commands).collect();
 
     assert!(
         missing.is_empty(),
-        "{repo}'s CI lints these and the pre-commit hook does not:\n  {}\n\
+        "{repo}'s CI runs these in the jobs the pre-commit hook mirrors, and the \
+         hook does not:\n  {}\n\
          Each one is a commit that passes locally and fails remotely, which is \
-         the whole reason the hook exists. Add them to the step list for \
-         {repo} in tools/install-hooks.sh (#715).",
+         the whole reason the hook exists. Add them to the step list for {repo} \
+         in tools/install-hooks.sh, or exempt them there with a reason.",
         missing
             .iter()
             .map(|c| c.as_str())
@@ -181,13 +762,85 @@ fn compare(repo: &str, ci: BTreeSet<String>, hook: BTreeSet<String>) {
     );
     assert!(
         extra.is_empty(),
-        "the pre-commit hook for {repo} runs these and CI does not:\n  {}\n\
+        "the pre-commit hook for {repo} runs these and the jobs it mirrors do \
+         not:\n  {}\n\
          Either CI lost a check the hook still remembers, or the hook is \
          spending a compile on something nothing asks for. Reconcile them in \
-         tools/install-hooks.sh (#715).",
+         tools/install-hooks.sh.",
         extra
             .iter()
             .map(|c| c.as_str())
+            .collect::<Vec<_>>()
+            .join("\n  ")
+    );
+
+    // 4. No exemption may name a step CI does not run.
+    let dead: Vec<&str> = c
+        .exempt
+        .keys()
+        .map(|k| k.as_str())
+        .filter(|k| !m.used_exemptions.contains(*k))
+        .collect();
+    assert!(
+        dead.is_empty(),
+        "tools/install-hooks.sh exempts these steps of {repo} from the \
+         pre-commit hook and no step in the jobs it mirrors matches \
+         them:\n  {}\n\
+         An exemption that matches nothing is a hole with a reassuring comment \
+         over it: the step it was written for has been renamed or moved, and \
+         whatever is there now is going unchecked.",
+        dead.join("\n  ")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// One test per repo, so a failure names the repo without reading the message
+// ---------------------------------------------------------------------------
+
+/// Every repo below has a test of its own, and this is what stops a new one
+/// arriving without one.
+///
+/// A repo added to `REPOS` in the installer gets a pre-commit hook in
+/// everybody's checkout immediately. Nothing else here would notice: the
+/// per-repo tests name the repos they check, so an eighth repo would simply be
+/// unmentioned, and unmentioned reads to `cargo test` as a pass. That is the
+/// shape of hole this whole file exists to close, so it gets closed here too.
+const CHECKED_REPOS: &[&str] = &[
+    "libviprs",
+    "libviprs-cli",
+    "libviprs-tests",
+    "libviprs-bench",
+    "libviprs-org",
+    "libviprs-dep",
+    "pdfium-render",
+];
+
+#[test]
+fn every_repo_the_installer_visits_has_a_test_here() {
+    let visits: BTreeSet<String> = contract().keys().cloned().collect();
+    let checked: BTreeSet<String> = CHECKED_REPOS.iter().map(|r| r.to_string()).collect();
+
+    let unchecked: Vec<&String> = visits.difference(&checked).collect();
+    assert!(
+        unchecked.is_empty(),
+        "tools/install-hooks.sh installs hooks into these and nothing here \
+         checks them against their CI:\n  {}\n\
+         Add a test calling check_repo for each, and add it to CHECKED_REPOS.",
+        unchecked
+            .iter()
+            .map(|r| r.as_str())
+            .collect::<Vec<_>>()
+            .join("\n  ")
+    );
+
+    let gone: Vec<&String> = checked.difference(&visits).collect();
+    assert!(
+        gone.is_empty(),
+        "these are checked here and the installer no longer visits them:\n  {}\n\
+         A test that resolves nothing still passes, so drop them from \
+         CHECKED_REPOS along with their tests.",
+        gone.iter()
+            .map(|r| r.as_str())
             .collect::<Vec<_>>()
             .join("\n  ")
     );
@@ -195,51 +848,178 @@ fn compare(repo: &str, ci: BTreeSet<String>, hook: BTreeSet<String>) {
 
 /// This repo. Its own workflow is always here, so there is nothing to skip.
 #[test]
-fn the_hook_lints_this_repo_the_way_its_ci_does() {
-    let ws = Workspace::new();
-    compare(
-        "libviprs-tests",
-        ci_lint_commands(&workflow_of(&repo_root())),
-        hook_runs(&ws, "libviprs-tests"),
-    );
+fn the_hook_mirrors_this_repos_ci() {
+    check_repo("libviprs-tests");
 }
 
-/// The core checkout. `libviprs = { path = "../libviprs" }` in this crate's
-/// manifest means it is there whenever this suite can run at all, and the
-/// Docker build context stages it with its `.github/` intact.
+/// The core. `libviprs = { path = "../libviprs" }` in this crate's manifest
+/// means it is there whenever this suite can run at all.
+///
+/// The core ships `tools/local-ci.py`, so its real pre-commit hook defers to
+/// that rather than to the step list below, and this arm is checking the
+/// fallback. The fallback still matters: it is what lands in any repo without
+/// one, it is what the core gets back if that script goes away, and it is the
+/// only written statement of what the core's lint half is. What `local-ci.py`
+/// runs is that script's own business and it derives its list from ci.yml at
+/// run time.
 #[test]
-fn the_hook_lints_the_core_the_way_its_ci_does() {
-    let ws = Workspace::new();
-    compare(
-        "libviprs",
-        ci_lint_commands(&workflow_of(&repo_root().join("../libviprs"))),
-        hook_runs(&ws, "libviprs"),
-    );
+fn the_hook_mirrors_the_cores_ci() {
+    check_repo("libviprs");
 }
 
 /// The cli is not laid down by the default `test` job or by the Docker gate,
-/// so this one has to skip where it is absent. Skipping reads to `cargo test`
-/// as a pass, so it follows the same false-green guard as the differential
-/// cells: `VIPRS_REQUIRE_CLI=1`, set on the job that does lay the cli down,
-/// turns the skip into a panic (`tests/common/cli.rs`).
+/// so this one skips where it is absent. Skipping reads to `cargo test` as a
+/// pass, so it follows the same false-green guard as the differential cells:
+/// `VIPRS_REQUIRE_CLI=1`, set on the job that does lay the cli down, turns the
+/// skip into a panic (`tests/common/cli.rs`).
 #[test]
-fn the_hook_lints_the_cli_the_way_its_ci_does() {
-    let dir = cli_dir();
-    let workflow = dir.join(".github/workflows/ci.yml");
-    if !workflow.is_file() {
-        assert!(
-            !require_cli(),
-            "VIPRS_REQUIRE_CLI=1 but there is no libviprs-cli workflow at {}, \
-             so this guard would compare nothing and report a false green",
-            workflow.display()
-        );
-        return;
-    }
+fn the_hook_mirrors_the_clis_ci() {
+    check_repo("libviprs-cli");
+}
 
+/// The benchmark crate, which had no local hook at all until #198. Its CI has
+/// no `cargo fmt` line, so neither does its hook: a hook step CI does not have
+/// is drift in the other direction and the comparison above refuses it.
+#[test]
+fn the_hook_mirrors_the_bench_ci() {
+    check_repo("libviprs-bench");
+}
+
+/// The doc site, which also had no local hook. Not a Rust repo: its CI is four
+/// regenerate-and-assert-no-drift gates in node, shell and a small cargo
+/// extractor, and the hook mirrors all four.
+#[test]
+fn the_hook_mirrors_the_org_site_ci() {
+    check_repo("libviprs-org");
+}
+
+/// The pdfium build inputs. This repo ships an installer of its own whose hook
+/// skips shellcheck when shellcheck is not installed, which is a green commit
+/// on a check CI will fail. Nothing held that script to this workflow; this
+/// does.
+#[test]
+fn the_hook_mirrors_the_dep_ci() {
+    check_repo("libviprs-dep");
+}
+
+/// pdfium-render is the one repo whose pre-commit hook is not a CI mirror, and
+/// that is only defensible while upstream's workflow really does run no lint.
+/// The moment it grows a `cargo fmt` or `cargo clippy` line there is something
+/// to mirror, and this goes red saying so.
+#[test]
+fn the_pdfium_fork_ci_still_has_no_lint_to_mirror() {
+    let contract = contract();
+    let c = contract
+        .get("pdfium-render")
+        .expect("tools/install-hooks.sh --describe never mentions pdfium-render");
+    assert!(
+        c.mirrored.is_empty(),
+        "pdfium-render now mirrors CI jobs, so this guard is the wrong shape \
+         for it and check_repo should cover it instead"
+    );
+    let Some((_dir, jobs)) = resolve("pdfium-render", c) else {
+        return;
+    };
+
+    let lints: Vec<String> = jobs
+        .iter()
+        .flat_map(|j| j.steps.iter().filter_map(|s| s.run.clone()))
+        .flat_map(|run| {
+            run.lines()
+                .map(|l| l.trim().to_string())
+                .collect::<Vec<_>>()
+        })
+        .filter(|l| l.starts_with("cargo clippy") || l.starts_with("cargo fmt"))
+        .collect();
+    assert!(
+        lints.is_empty(),
+        "pdfium-render's CI now runs lints:\n  {}\n\
+         The fork's pre-commit hook is fork policy rather than a CI mirror, and \
+         the reason written down for that is that upstream's workflow lints \
+         nothing. That is no longer true, so either mirror these or rewrite the \
+         reason.",
+        lints.join("\n  ")
+    );
+
+    // The same workflow still has to be readable, or the assertion above is
+    // vacuous: a parse that found no steps would also find no lints.
+    let steps: usize = jobs.iter().map(|j| j.steps.len()).sum();
+    assert!(
+        steps > 50,
+        "this guard read only {steps} steps out of pdfium-render's workflow, \
+         which is far fewer than the 205 compatibility cells it carries, so the \
+         `no lints` verdict above is about a file this guard failed to parse"
+    );
+}
+
+/// The doc site's sync check is the one conditional step in any of these
+/// hooks, and it mirrors a conditional in the workflow: CI runs the
+/// frozen-copy comparison only when the canonical `libviprs-cli` checkout
+/// succeeded, and skips it green otherwise. Locally the equivalent question is
+/// whether the sibling is there at all.
+///
+/// A condition has two arms and only one of them is exercised by the
+/// comparison above, which runs in a stand-in workspace that always has the
+/// sibling. So this drives the other arm. A condition that was accidentally
+/// always-true would pass every test in this file without it, and one that was
+/// always-false would silently drop the sync check in every real checkout.
+#[test]
+fn the_org_hook_skips_the_sync_check_only_when_the_cli_sibling_is_missing() {
+    let contract = contract();
+    let c = contract
+        .get("libviprs-org")
+        .expect("tools/install-hooks.sh --describe never mentions libviprs-org");
+    let Some((_dir, jobs)) = resolve("libviprs-org", c) else {
+        return;
+    };
+    let workdirs = local_workdirs(c, &jobs);
+    const SYNC: &str = "cli/tools/sync-cli-src.sh --check";
+
+    // With the sibling there, the check runs.
     let ws = Workspace::new();
-    compare(
-        "libviprs-cli",
-        ci_lint_commands(&workflow_of(&dir)),
-        hook_runs(&ws, "libviprs-cli"),
+    let (ok, recorded, printed) = run_recorded(&ws, "libviprs-org", &workdirs);
+    assert!(
+        ok,
+        "the doc site's hook failed with the sibling present:\n{printed}"
+    );
+    assert!(
+        recorded.iter().any(|l| l == SYNC),
+        "the doc site's hook did not run the frozen-copy sync check even with \
+         the libviprs-cli sibling laid down beside it, so the condition is \
+         always false and that check never runs anywhere.\nIt ran:\n  {}",
+        recorded.iter().cloned().collect::<Vec<_>>().join("\n  ")
+    );
+
+    // With the sibling gone, it skips, says so, and still runs everything else.
+    let ws = Workspace::new();
+    std::fs::remove_dir_all(ws.repo("libviprs-cli")).expect("take the cli sibling away");
+    let (ok, recorded, printed) = run_recorded(&ws, "libviprs-org", &workdirs);
+    assert!(
+        ok,
+        "the doc site's hook refused the commit because the libviprs-cli \
+         sibling is absent. CI skips that step green in the same situation, so \
+         this makes the hook stricter than the thing it stands in for and \
+         unusable for anyone who has not cloned the cli.\n{printed}"
+    );
+    assert!(
+        !recorded.iter().any(|l| l == SYNC),
+        "the doc site's hook ran the frozen-copy sync check with no \
+         libviprs-cli sibling to compare against, so the condition is always \
+         true and the check is comparing against whatever happens to be \
+         there.\nIt ran:\n  {}",
+        recorded.iter().cloned().collect::<Vec<_>>().join("\n  ")
+    );
+    assert!(
+        printed.contains("skipping") && printed.contains("libviprs-cli"),
+        "the doc site's hook skipped the sync check without saying so. A check \
+         that quietly does not run is worth less than no check, because the \
+         green still reads as a green:\n{printed}"
+    );
+    assert!(
+        recorded.len() >= 8,
+        "with the sync check skipped the hook only ran {} steps, so it did not \
+         carry on to the rest of the workflow.\nIt ran:\n  {}",
+        recorded.len(),
+        recorded.iter().cloned().collect::<Vec<_>>().join("\n  ")
     );
 }

--- a/tests/install_hooks_pdfium_scope.rs
+++ b/tests/install_hooks_pdfium_scope.rs
@@ -67,6 +67,11 @@ fn fixture() -> Workspace {
 /// Run the installed hook in the stand-in fork and hand back whether it
 /// allowed the commit, plus everything it printed.
 fn run_hook(ws: &Workspace) -> (bool, String) {
+    run_hook_with(ws, None)
+}
+
+/// The same, with a `RUSTFLAGS` of your choosing.
+fn run_hook_with(ws: &Workspace, rustflags: Option<&str>) -> (bool, String) {
     let repo = ws.repo("pdfium-render");
     let hook = repo.join(".git/hooks/pre-commit");
     assert!(
@@ -74,14 +79,17 @@ fn run_hook(ws: &Workspace) -> (bool, String) {
         "no pre-commit hook was installed into the stand-in fork, so every \
          assertion here would be about a hook that does not exist"
     );
-    let out = Command::new("bash")
-        .arg(&hook)
+    let mut cmd = Command::new("bash");
+    cmd.arg(&hook)
         .current_dir(&repo)
         .env_remove("GIT_DIR")
         .env_remove("GIT_WORK_TREE")
-        .env_remove("GIT_INDEX_FILE")
-        .output()
-        .expect("run the fork's pre-commit hook");
+        .env_remove("GIT_INDEX_FILE");
+    match rustflags {
+        Some(f) => cmd.env("RUSTFLAGS", f),
+        None => cmd.env_remove("RUSTFLAGS"),
+    };
+    let out = cmd.output().expect("run the fork's pre-commit hook");
     (
         out.status.success(),
         format!(
@@ -258,5 +266,66 @@ pub fn caller() -> usize {
         "the fork's pre-commit hook allowed a commit that stops the crate \
          building. The scope was empty because the change adds no lines, and an \
          empty scope was being read as nothing to check.\n{printed}"
+    );
+}
+
+/// `-D warnings` in the environment must not turn inherited debt into a
+/// refusal.
+///
+/// The scoping rests on clippy calling an inherited lint a warning, so the
+/// filter can drop it. With `-D warnings` set every one of them arrives as an
+/// error, clippy exits non-zero, and the hook refuses a commit over exactly
+/// the debt it exists to ignore. That is not a hypothetical: this repo's own
+/// ci.yml sets `RUSTFLAGS: -Dwarnings` at the workflow level, and the first
+/// run of this file on CI went red on it while every local run was green.
+///
+/// So the hook takes `-D warnings` back off for its own clippy call, and this
+/// pins that rather than leaving the next person to find it the same way.
+#[test]
+fn an_ambient_deny_warnings_does_not_turn_inherited_debt_into_a_refusal() {
+    let ws = fixture();
+    let repo = ws.repo("pdfium-render");
+    write(
+        &repo,
+        "src/lib.rs",
+        &format!(
+            "{INHERITED}
+pub fn added_clean(v: &[u8]) -> usize {{
+    v.len()
+}}
+"
+        ),
+    );
+    git(&repo, &["add", "-A"]);
+
+    let (ok, printed) = run_hook_with(&ws, Some("-Dwarnings"));
+    assert!(
+        ok,
+        "with RUSTFLAGS=-Dwarnings the fork's hook refused a change that \
+         introduces no lint of its own. The inherited lint came back as an \
+         error rather than a warning and the scope filter never got to drop \
+         it.\n{printed}"
+    );
+
+    // And a lint this change does write still has to be refused with the flag
+    // set, or the fix is just "ignore clippy when RUSTFLAGS is present".
+    write(
+        &repo,
+        "src/lib.rs",
+        &format!(
+            "{INHERITED}
+pub fn added_dirty(v: &Vec<u8>) -> usize {{
+    v.len()
+}}
+"
+        ),
+    );
+    git(&repo, &["add", "-A"]);
+    let (ok, printed) = run_hook_with(&ws, Some("-Dwarnings"));
+    assert!(
+        !ok,
+        "with RUSTFLAGS=-Dwarnings the fork's hook allowed a change whose own \
+         new line trips a lint, so taking the flag off has been widened into \
+         letting everything through.\n{printed}"
     );
 }

--- a/tests/install_hooks_pdfium_scope.rs
+++ b/tests/install_hooks_pdfium_scope.rs
@@ -1,0 +1,262 @@
+//! Guards the one hook in the org that is not a CI mirror: the pdfium-render
+//! fork's pre-commit hook (libviprs-tests#198).
+//!
+//! The fork runs a lint policy of its own because upstream's workflow runs no
+//! lint at all and the tree carries hundreds of pre-existing warnings. The
+//! policy is one sentence: block on lints the commit in hand introduces, stay
+//! quiet about everything it inherits. That is a hard thing to keep true,
+//! because both halves fail silently in opposite directions, and both have
+//! already happened here.
+//!
+//! It used to scope against the whole fork delta versus `upstream/master`,
+//! which meant every line the fork had ever written was in scope forever. A
+//! newer clippy grew `deref on an immutable reference`, 54 of them landed on
+//! fork lines written months earlier, and the hook then refused every commit
+//! on an unmodified `origin/master` checkout with nothing staged. Measured
+//! 2026-09-02 before the fix: 54 warnings, exit 1, clean tree.
+//!
+//! So this drives the real installed hook against a throwaway crate that has
+//! an inherited lint of its own, and pins all four answers. Nothing here reads
+//! the hook's text: the two guards that did that on the pre-push hook stayed
+//! green while the behaviour they named had been deleted
+//! (libviprs/libviprs#695).
+
+use std::path::Path;
+use std::process::Command;
+
+mod common;
+use common::hooks::{Workspace, git};
+
+/// The stand-in crate, committed first so it is what the fork "inherited".
+///
+/// `inherited_debt` takes a `&Vec<u8>`, which is `clippy::ptr_arg` and warns by
+/// default. It stands in for the 470-odd warnings the real fork carries. Every
+/// assertion below about the hook staying quiet is only worth something while
+/// this lint is really there, so `the_fixture_really_does_carry_a_lint` checks
+/// that directly rather than taking it on trust.
+const INHERITED: &str = r#"//! A stand-in for the fork, carrying one pre-existing lint.
+
+pub fn inherited_debt(v: &Vec<u8>) -> usize {
+    v.len()
+}
+"#;
+
+const MANIFEST: &str = r#"[package]
+name = "pdfium-render-standin"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+"#;
+
+/// A `pdfium-render` stand-in with the fork's hook installed and one commit of
+/// inherited lint debt behind it.
+fn fixture() -> Workspace {
+    let ws = Workspace::new();
+    let repo = ws.repo("pdfium-render");
+    std::fs::create_dir_all(repo.join("src")).expect("create the stand-in crate");
+    ws.commit(
+        "pdfium-render",
+        "the fork as inherited",
+        &[("Cargo.toml", MANIFEST), ("src/lib.rs", INHERITED)],
+    );
+    ws
+}
+
+/// Run the installed hook in the stand-in fork and hand back whether it
+/// allowed the commit, plus everything it printed.
+fn run_hook(ws: &Workspace) -> (bool, String) {
+    let repo = ws.repo("pdfium-render");
+    let hook = repo.join(".git/hooks/pre-commit");
+    assert!(
+        hook.is_file(),
+        "no pre-commit hook was installed into the stand-in fork, so every \
+         assertion here would be about a hook that does not exist"
+    );
+    let out = Command::new("bash")
+        .arg(&hook)
+        .current_dir(&repo)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .output()
+        .expect("run the fork's pre-commit hook");
+    (
+        out.status.success(),
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        ),
+    )
+}
+
+fn write(repo: &Path, rel: &str, body: &str) {
+    std::fs::write(repo.join(rel), body).expect("write into the stand-in fork");
+}
+
+/// The positive control for everything else here.
+///
+/// Three of the four cases below assert the hook stays quiet, and "quiet"
+/// looks identical whether clippy found nothing worth reporting or clippy
+/// never ran at all. So prove the fixture really is dirty first: a plain
+/// `cargo clippy` on it has to report the inherited lint. Without this, a
+/// clippy that silently failed to build would make this whole file pass.
+#[test]
+fn the_fixture_really_does_carry_a_lint() {
+    let ws = fixture();
+    let repo = ws.repo("pdfium-render");
+    let out = Command::new("cargo")
+        .args(["clippy", "--all-targets"])
+        .current_dir(&repo)
+        .output()
+        .expect("these guards drive a hook that runs cargo clippy");
+    let text = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        text.contains("ptr_arg") || text.contains("writing `&Vec`"),
+        "the stand-in fork was supposed to carry a pre-existing clippy lint and \
+         clippy did not report one, so every `the hook stayed quiet` assertion \
+         in this file would pass on a fixture with nothing to be quiet \
+         about:\n{text}"
+    );
+}
+
+/// The failure that was actually in the field: a clean checkout, nothing
+/// staged, and the hook refusing the commit over lints nobody had just
+/// written.
+#[test]
+fn a_clean_checkout_with_nothing_staged_commits() {
+    let ws = fixture();
+    let (ok, printed) = run_hook(&ws);
+    assert!(
+        ok,
+        "the fork's pre-commit hook refused a commit on a clean checkout with \
+         nothing staged. That is the failure the scoping fix was for: a gate \
+         that is red before you have typed anything is a gate people \
+         delete.\n{printed}"
+    );
+}
+
+/// The intent, kept: inherited lints stay out of the way.
+#[test]
+fn a_change_that_introduces_no_lint_commits_over_inherited_debt() {
+    let ws = fixture();
+    let repo = ws.repo("pdfium-render");
+    write(
+        &repo,
+        "src/lib.rs",
+        &format!(
+            "{INHERITED}
+pub fn added_clean(v: &[u8]) -> usize {{
+    v.len()
+}}
+"
+        ),
+    );
+    git(&repo, &["add", "-A"]);
+
+    let (ok, printed) = run_hook(&ws);
+    assert!(
+        ok,
+        "the fork's pre-commit hook refused a change that introduces no lint of \
+         its own. The tree still carries the inherited one, and blocking on \
+         that is what makes the hook unusable during an upstream merge.\n{printed}"
+    );
+}
+
+/// The intent, kept the other way: a lint this change writes does block.
+///
+/// Without this the fix would be indistinguishable from deleting the hook.
+#[test]
+fn a_change_that_introduces_a_lint_is_refused() {
+    let ws = fixture();
+    let repo = ws.repo("pdfium-render");
+    write(
+        &repo,
+        "src/lib.rs",
+        &format!(
+            "{INHERITED}
+pub fn added_dirty(v: &Vec<u8>) -> usize {{
+    v.len()
+}}
+"
+        ),
+    );
+    git(&repo, &["add", "-A"]);
+
+    let (ok, printed) = run_hook(&ws);
+    assert!(
+        !ok,
+        "the fork's pre-commit hook allowed a change whose own new line trips a \
+         clippy lint, so the scoping has been widened into letting everything \
+         through.\n{printed}"
+    );
+    assert!(
+        printed.contains("added_dirty") || printed.contains("&Vec"),
+        "the hook refused the commit without naming the lint it refused it \
+         for, which leaves whoever hit it with nothing to fix:\n{printed}"
+    );
+}
+
+/// A commit that only deletes lines has a real diff and no added lines to
+/// scope to, so the scope is empty while the tree can perfectly well be
+/// broken. Deleting something another file depends on is the everyday way to
+/// do it, and an empty scope must not read as a pass.
+#[test]
+fn a_deletion_that_breaks_the_build_is_refused() {
+    let ws = fixture();
+    let repo = ws.repo("pdfium-render");
+    write(
+        &repo,
+        "src/lib.rs",
+        "//! A stand-in for the fork, carrying one pre-existing lint.
+
+pub fn inherited_debt(v: &Vec<u8>) -> usize {
+    v.len()
+}
+
+pub fn caller() -> usize {
+    helper()
+}
+
+pub fn helper() -> usize {
+    0
+}
+",
+    );
+    ws.commit("pdfium-render", "add a caller and its helper", &[]);
+
+    // Delete only `helper`, which leaves `caller` calling something that is no
+    // longer there. Nothing on a line this change adds, because it adds none.
+    write(
+        &repo,
+        "src/lib.rs",
+        "//! A stand-in for the fork, carrying one pre-existing lint.
+
+pub fn inherited_debt(v: &Vec<u8>) -> usize {
+    v.len()
+}
+
+pub fn caller() -> usize {
+    helper()
+}
+",
+    );
+    git(&repo, &["add", "-A"]);
+
+    let out = git(&repo, &["diff", "--cached", "--numstat"]);
+    assert!(
+        out.split_whitespace().next() == Some("0"),
+        "this case is only about a deletion-only change and this one adds \
+         lines, so it is testing something else: {out}"
+    );
+
+    let (ok, printed) = run_hook(&ws);
+    assert!(
+        !ok,
+        "the fork's pre-commit hook allowed a commit that stops the crate \
+         building. The scope was empty because the change adds no lines, and an \
+         empty scope was being read as nothing to check.\n{printed}"
+    );
+}

--- a/tests/install_hooks_pre_push_slots.rs
+++ b/tests/install_hooks_pre_push_slots.rs
@@ -25,25 +25,24 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 mod common;
-use common::hooks::repo_root;
+use common::hooks::{STANDIN_REPOS, repo_root};
 
 /// The comment line every hook this installer writes carries. The installer
 /// uses it to tell its own output apart from a hand-written hook, so the
 /// guards have to agree with it byte for byte.
 const INSTALLER_MARKER: &str = "Installed by libviprs-tests/tools/install-hooks.sh";
 
-/// The four repos `install-hooks.sh` looks for as siblings.
-const REPOS: &[&str] = &[
-    "libviprs",
-    "libviprs-cli",
-    "libviprs-tests",
-    "pdfium-render",
-];
-
-/// A throwaway workspace with the four sibling repos the installer expects and
-/// a copy of the installer itself, so it can be run for real without touching
-/// a developer's checkouts. It removes hooks it recognises as its own, so
+/// A throwaway workspace with every sibling repo the installer expects and a
+/// copy of the installer itself, so it can be run for real without touching a
+/// developer's checkouts. It removes hooks it recognises as its own, so
 /// running it against the live workspace from a test would be destructive.
+///
+/// The repo list is shared with `tests/common/hooks.rs` rather than written
+/// out again here. It used to be a local copy of four names, and when the
+/// installer grew three more repos the copy did not: the stand-in workspace
+/// simply never created them, the installer skipped them as "not a git repo",
+/// and the table below asserted nothing about the three repos that had just
+/// started getting hooks.
 struct Workspace {
     _dir: tempfile::TempDir,
     root: PathBuf,
@@ -54,7 +53,7 @@ impl Workspace {
         let dir = tempfile::tempdir().expect("temp dir for a stand-in workspace");
         let root = dir.path().canonicalize().expect("canonical temp path");
 
-        for repo in REPOS {
+        for repo in STANDIN_REPOS {
             let repo_root = root.join(repo);
             std::fs::create_dir_all(&repo_root).expect("create a stand-in repo");
             git(&repo_root, &["init", "-q"]);
@@ -191,7 +190,33 @@ fn a_pre_push_hook_only_lands_where_the_suite_has_a_slot() {
             false,
             "the fork has no run-tests.sh integration at all",
         ),
+        (
+            "libviprs-bench",
+            false,
+            "the image holds no bench crate, so the gate could not fail on a bench change",
+        ),
+        (
+            "libviprs-org",
+            false,
+            "the image holds no doc site, and the site's own checks are all in its pre-commit hook",
+        ),
+        (
+            "libviprs-dep",
+            false,
+            "the image holds none of the pdfium build inputs, and that repo's checks are python and shell",
+        ),
     ];
+
+    // A repo the installer visits and this table does not name gets no
+    // assertion at all, and no assertion reads to `cargo test` as a pass.
+    let named: std::collections::BTreeSet<&str> = expected.iter().map(|(r, _, _)| *r).collect();
+    let visited: std::collections::BTreeSet<&str> = STANDIN_REPOS.iter().copied().collect();
+    assert_eq!(
+        named, visited,
+        "this table and the repos the installer visits have gone out of step, \
+         so some repo is getting hooks with nothing here saying which. The \
+         installer said:\n{printed}"
+    );
 
     for (repo, wants_pre_push, why) in expected {
         assert!(

--- a/tools/install-hooks.sh
+++ b/tools/install-hooks.sh
@@ -2,29 +2,54 @@
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
-# install-hooks.sh — Install git hooks for all libviprs repos.
+# install-hooks.sh: install git hooks for every repo in the libviprs org.
 #
-# Installs:
-#   pre-commit  — cargo fmt --check + cargo clippy (fast, on every commit)
-#                 Mirrors each repo's `.github/workflows/ci.yml` Check & Lint
-#                 job *exactly*, so a clean local commit means a clean remote
-#                 Check & Lint. Update the per-repo cargo command lists below
-#                 when a repo's CI matrix changes, and re-run this script.
-#   pre-push    — Docker test suite via run-tests.sh (slow, on every push)
-#                 The hook itself is a tracked file, tools/hooks/pre-push;
-#                 what lands in .git/hooks is a shim that runs it
-#                 (libviprs/libviprs#695).
-#                 Runs against the working tree being pushed, which for a
-#                 linked worktree is not the main checkout the hooks
-#                 directory lives in (libviprs/libviprs#684). Only where the
-#                 suite has a slot for the repo, which is libviprs and
-#                 libviprs-tests (libviprs/libviprs#691).
+# THE CONTRACT
 #
-# Usage:  ./tools/install-hooks.sh          # from libviprs-tests/
-#         ./libviprs-tests/tools/install-hooks.sh  # from workspace root
+# There are two hooks and the split between them is by cost, not by taste.
 #
-# Repos detected automatically as siblings of the script's parent directory:
-#   libviprs, libviprs-cli, libviprs-tests
+#   pre-commit  the LINT HALF of a repo's CI. `mirror_jobs` below names, per
+#               repo, the CI jobs this hook stands in for. It runs every `run:`
+#               step in those jobs, except the ones `exempt_steps` names with a
+#               reason. So a clean pre-commit means those jobs will be clean.
+#
+#   pre-push    the TEST HALF: tools/run-tests.sh, in the two repos that suite
+#               actually holds (`has_suite_slot`, libviprs/libviprs#691).
+#
+#   deferred_jobs names every CI job that is in neither half, and why. Between
+#               the two lists every job in a repo's workflow is accounted for,
+#               and tests/install_hooks_mirror_ci.rs goes red on a job that is
+#               in neither, so a new CI job cannot slip past unnoticed.
+#
+# WHY THE SPLIT FALLS WHERE IT DOES
+#
+# Measured in this repo on 2026-09-02, warm target directory, Apple M-series:
+# the lint half is 39s (fmt 1s, five clippy cells 36s, the ported clippy scope
+# 1s, shellcheck 1s) and `cargo test` alone is 279s, before the pre-push gate
+# has even built its image. A commit costs 39s and a push costs minutes, which
+# is the trade that keeps people off `--no-verify` (libviprs/libviprs#683).
+# Anything that runs a test binary is therefore on push, with one deliberate
+# exception argued from the same measurement:
+#
+#   libviprs-org's entire CI is four node scripts, one shell diff and a small
+#   cargo extractor, and it runs in 4s cold and under 1s warm. Splitting that
+#   buys nothing and leaving half of it unguarded locally costs something, so
+#   the pre-commit hook there mirrors the whole workflow.
+#   libviprs-dep is the same story at 2s, so it gets the same treatment.
+#
+# The lists here are not maintained by hand and hope. `install_hooks_mirror_ci`
+# runs the generated hook with recording stand-ins in front of every tool it
+# shells out to, and compares what it actually invoked against the workflow.
+# Grepping either file would be worth nothing, which is the standing lesson of
+# libviprs/libviprs#695.
+#
+# Usage:  ./tools/install-hooks.sh            # from libviprs-tests/
+#         ./libviprs-tests/tools/install-hooks.sh   # from the workspace root
+#         ./tools/install-hooks.sh --describe # print the contract, install
+#                                             # nothing (this is what the
+#                                             # guard reads)
+#
+# Repos are found as siblings of this checkout's parent directory.
 # ---------------------------------------------------------------------------
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -34,36 +59,145 @@ REPOS=(
     "$WORKSPACE_ROOT/libviprs"
     "$WORKSPACE_ROOT/libviprs-cli"
     "$WORKSPACE_ROOT/libviprs-tests"
+    "$WORKSPACE_ROOT/libviprs-bench"
+    "$WORKSPACE_ROOT/libviprs-org"
+    "$WORKSPACE_ROOT/libviprs-dep"
     "$WORKSPACE_ROOT/pdfium-render"
 )
 
 # ---------------------------------------------------------------------------
-# Per-repo cargo lint commands, in lockstep with the `cargo clippy` and
-# `cargo fmt` lines in each repo's `.github/workflows/ci.yml`, feature matrix
-# expanded. They run in order; the first failure aborts.
+# Where each repo keeps its workflow. Everything but the pdfium fork uses the
+# same path; the fork carries upstream's file name.
+# ---------------------------------------------------------------------------
+workflow_for_repo() {
+    case "$1" in
+        pdfium-render) printf '%s\n' ".github/workflows/build_test.yml" ;;
+        *)             printf '%s\n' ".github/workflows/ci.yml" ;;
+    esac
+}
+
+# Some workflows check the repo out into a named subdirectory so a sibling can
+# sit beside it, which puts that prefix on every path in those jobs' commands.
+# Locally the repo IS the working directory, so the prefix comes off.
+ci_checkout_path() {
+    case "$1" in
+        libviprs-bench) printf '%s\n' "libviprs-bench" ;;
+        libviprs-org)   printf '%s\n' "libviprs-org" ;;
+        *)              : ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Which CI jobs the pre-commit hook stands in for.
+# ---------------------------------------------------------------------------
+mirror_jobs() {
+    case "$1" in
+        libviprs)       printf '%s\n' check ;;
+        libviprs-cli)   printf '%s\n' check ;;
+        libviprs-tests) printf '%s\n' lint feature-cells ported-tests ;;
+        libviprs-bench) printf '%s\n' check ;;
+        # The whole workflow, on the cost argument in the header.
+        libviprs-org)   printf '%s\n' sync extract test-flags gen-op-sections ;;
+        libviprs-dep)   printf '%s\n' lint test shellcheck ;;
+        # Nothing. The fork's CI runs no lint at all, so there is nothing here
+        # to mirror; see the note above write_pdfium_pre_commit.
+        pdfium-render)  : ;;
+        *)              : ;;
+    esac
+}
+
+# Every CI job that is in neither half, and why. `job<TAB>reason`.
+deferred_jobs() {
+    case "$1" in
+        libviprs)
+            printf '%s\t%s\n' \
+                msrv 'pinned to a 1.97 toolchain, and checking with the toolchain you happen to have installed answers a different question' \
+                docs 'rustdoc over every feature; it cannot fail on anything the clippy cells pass' \
+                test 'the test half' \
+                integration-test 'the test half, and it lays this harness down beside the core'
+            ;;
+        libviprs-cli)
+            printf '%s\t%s\n' \
+                msrv 'pinned to a 1.97 toolchain, so a local run answers a different question' \
+                test 'the test half'
+            ;;
+        libviprs-tests)
+            printf '%s\t%s\n' \
+                test 'the test half; 279s measured, and the pre-push gate runs it' \
+                test-pdfium 'the test half, and it needs libpdfium.so installed' \
+                cli-differential 'the test half; 18 differential binaries against the cli at CLI_COUNTERPART_REV' \
+                hook-mirror 'the job that holds these hooks to every repo'"'"'s CI, which needs all seven laid down side by side'
+            ;;
+        libviprs-bench)
+            printf '%s\t%s\n' \
+                test 'the test half, and linking it needs libvips on the linker path rather than merely installed'
+            ;;
+        libviprs-org) : ;;
+        libviprs-dep) : ;;
+        pdfium-render)
+            printf '%s\t%s\n' \
+                build 'upstream'"'"'s file: one job of 205 compatibility cells plus a wasm-pack build, and it runs no lint at all'
+            ;;
+        *) : ;;
+    esac
+}
+
+# Steps inside a mirrored job that the hook deliberately does not run, and why.
+# `step<TAB>reason`, where step is the workflow step's `name:` when it has one
+# and its `run:` text when it does not. A stale entry here is a failure too:
+# the guard requires every one of these to still match a step CI actually runs.
+exempt_steps() {
+    case "$1" in
+        libviprs)
+            printf '%s\t%s\n' \
+                'cargo build --features s3' 'there to prove a deprecated feature alias still resolves, which the manifest settles without a whole extra build on every commit'
+            ;;
+        libviprs-cli)
+            printf '%s\t%s\n' \
+                'Clone libviprs (matching branch or main)' 'CI has to fetch the core to get a sibling; locally it already is one, which is the layout this script assumes'
+            ;;
+        libviprs-tests)
+            printf '%s\t%s\n' \
+                'Fetch libvips reference suite at pinned revision' 'a network fetch of the pinned reference suite, so it is setup rather than a check' \
+                './tools/run_ported_cells.sh --require-fixtures' 'this one runs the ported cells, so it is the test half, and it needs the fixtures the fetch above brings down'
+            ;;
+        libviprs-bench)
+            printf '%s\t%s\n' \
+                'Clone libviprs core (sibling path dep)' 'CI has to fetch the core to get a sibling; locally it already is one' \
+                'Install libvips' 'apt-get on the runner image; locally libvips is a prerequisite, and the cells below fail loudly without it'
+            ;;
+        libviprs-org)
+            printf '%s\t%s\n' \
+                'Skip note (canonical CLI unavailable)' 'the other arm of the sync step, which only prints a warning; the hook prints its own when the sibling is missing'
+            ;;
+        libviprs-dep)
+            printf '%s\t%s\n' \
+                'pip install ruff' 'installs the tool rather than checking anything; the hook fails loudly if ruff is not on PATH' \
+                'pip install pytest' 'same, for pytest'
+            ;;
+        *) : ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# What the pre-commit hook runs, in order; the first failure aborts.
 #
-# `tests/install_hooks_mirror_ci.rs` enforces the lockstep by running the
-# generated hook with a recording stand-in for `cargo` and comparing what it
-# invokes against those workflow lines, so a list that drifts fails there
-# naming the passes it lost. It used to be a comment asking a human to keep
-# them in step, and the core's list sat at two of five passes for as long as
-# that was true (libviprs/libviprs#715).
+# These have to be the mirrored jobs' steps, minus the exemptions above, or
+# tests/install_hooks_mirror_ci.rs fails naming what drifted. `cargo clippy`
+# already does `cargo check`'s work, so where a job runs both over the same
+# features only the clippy line is here; libviprs-bench is the exception,
+# because three of its four check cells have no clippy pass to hide behind.
 #
-# `cargo clippy` already runs `cargo check`'s work, so we don't repeat the
-# explicit `cargo check --all-targets` lines that CI also has — clippy
-# covers them. The core's `cargo build --features s3` is also out: it is there
-# to prove a deprecated alias still resolves, which the manifest settles
-# without a whole extra build on every commit.
+# A step may carry a condition, written `test%%skip note%%command`. Only
+# libviprs-org needs one, and it mirrors a step-level `if:` in the workflow.
 # ---------------------------------------------------------------------------
 
-# libviprs lints the default cell and nine feature-gated ones. Each of the
-# latter is in CI because the default pass compiles none of that code:
-# object-store-sink (#382), svg (#502) and jxl (#500) are all non-default and
-# all have `#[cfg(test)] mod tests` the default job never sees. jp2k, avif,
-# packfile, serde and tracing joined the matrix after this list did (caught by
-# tests/install_hooks_mirror_ci.rs going red on the COUNTERPART_REV bump that
-# picked up the newer ci.yml, libviprs-tests#185).
-LIBVIPRS_CARGO_STEPS=(
+# The core lints the default cell and nine feature-gated ones. Each of the
+# latter is in CI because the default pass compiles none of that code, and the
+# list sat at two of them for as long as a comment was the only thing asking
+# anyone to keep it in step (libviprs/libviprs#715).
+LIBVIPRS_STEPS=(
+    "cargo fmt -- --check"
     "cargo clippy --all-targets -- -D warnings -W clippy::incompatible_msrv -W deprecated"
     "cargo clippy --all-targets --features pdfium -- -D warnings -W clippy::incompatible_msrv -W deprecated"
     "cargo clippy --all-targets --features object-store-sink -- -D warnings -W clippy::incompatible_msrv -W deprecated"
@@ -76,14 +210,12 @@ LIBVIPRS_CARGO_STEPS=(
     "cargo clippy --all-targets --features tracing -- -D warnings -W clippy::incompatible_msrv -W deprecated"
 )
 
-# libviprs-cli lints five configurations, and this list has to carry all five
-# (libviprs-cli#48). The comment that stood here said the cli "has no `pdfium`
-# feature", which was wrong twice over: it has one and it is the default, so
-# the bare pass below IS the pdfium pass, and the `--no-default-features` one
-# is the only build that ever compiles the `#[cfg(not(feature = "pdfium"))]`
-# halves. The other three are there for the usual reason: the default pass
-# compiles none of the code behind them.
-LIBVIPRS_CLI_CARGO_STEPS=(
+# The cli lints five configurations (libviprs-cli#48). The bare pass IS the
+# pdfium pass, because pdfium is the cli's default feature, and the
+# `--no-default-features` one is the only build that ever compiles the
+# `#[cfg(not(feature = "pdfium"))]` halves.
+LIBVIPRS_CLI_STEPS=(
+    "cargo fmt -- --check"
     "cargo clippy --all-targets -- -D warnings -W clippy::incompatible_msrv -W deprecated"
     "cargo clippy --all-targets --features tracing -- -D warnings -W clippy::incompatible_msrv -W deprecated"
     "cargo clippy --all-targets --features packfile -- -D warnings -W clippy::incompatible_msrv -W deprecated"
@@ -91,32 +223,81 @@ LIBVIPRS_CLI_CARGO_STEPS=(
     "cargo clippy --all-targets --no-default-features -- -D warnings -W clippy::incompatible_msrv -W deprecated"
 )
 
-# libviprs-tests CI is plainer — no incompatible_msrv / deprecated lints.
-# These mirror the ci.yml `feature-cells` matrix one-for-one so the enforced
-# local mirror compiles and lints every feature cell, not just the default
-# one. Without the per-feature passes a regression in the object-store-sink /
-# packfile / tracing / jxl gated modules ships green locally because the
-# default harness never compiles that code (the failure #55 targets). `s3`
-# stood here in place of `object-store-sink` for a while, which is the same
-# feature under a deprecated alias, so the `jxl` cell was the one going
-# unlinted (libviprs/libviprs#715). The ported step is scoped through
-# tools/run_ported_cells.sh because the three deferred codec cells do not
-# compile yet (issue #77), so `--all-targets` cannot carry that feature.
-LIBVIPRS_TESTS_CARGO_STEPS=(
+# This harness. The feature cells are the `feature-cells` matrix expanded; the
+# ported step is scoped through tools/run_ported_cells.sh because the deferred
+# codec cells do not compile, so `--all-targets` cannot carry that feature
+# (issue #77). shellcheck is here because the `lint` job runs it and this hook
+# did not, which left the one check that reads the hook's own shell to CI.
+LIBVIPRS_TESTS_STEPS=(
+    "cargo fmt -- --check"
     "cargo clippy --all-targets -- -D warnings"
     "cargo clippy --all-targets --features object-store-sink -- -D warnings"
     "cargo clippy --all-targets --features packfile -- -D warnings"
     "cargo clippy --all-targets --features tracing -- -D warnings"
     "cargo clippy --all-targets --features jxl -- -D warnings"
     "./tools/run_ported_cells.sh --clippy"
+    "shellcheck tools/*.sh tools/hooks/pre-push"
 )
 
-cargo_steps_for_repo() {
+# libviprs-bench has no `cargo fmt` line in CI, so there is none here: a hook
+# step CI does not have is drift in the other direction and the guard refuses
+# it. Its check job is four `cargo check` cells and one clippy, and the checks
+# are not redundant with the clippy the way they are elsewhere, because that
+# clippy pass covers only the `libvips` feature.
+LIBVIPRS_BENCH_STEPS=(
+    "cargo check --lib --bins --tests"
+    "cargo check --lib --bins --tests --features libvips"
+    "cargo check --lib --bins --features pdfium"
+    "cargo check --lib --bins --features polars"
+    "cargo clippy --lib --tests --features libvips"
+)
+
+# The doc site. Not Rust, and the four jobs are regenerate-and-assert-no-drift
+# gates, which is exactly the check you want before a commit rather than after
+# it: they catch "you edited the source and did not re-run the generator".
+#
+# The sync step is conditional because the workflow's is. CI runs it only when
+# the canonical cli checkout succeeded; locally the equivalent question is
+# whether the sibling is there at all. Unlike CI's, this hook's sibling is
+# whatever you have checked out rather than CLI_COUNTERPART_REV, so a green
+# here is a weaker claim than a green there. The note it prints says so.
+LIBVIPRS_ORG_STEPS=(
+    "test -d ../libviprs-cli%%no libviprs-cli sibling, so the frozen-copy sync check has nothing to compare (CI skips it the same way)%%cli/tools/sync-cli-src.sh --check"
+    "cargo run --manifest-path cli/tools/extract-snippets/Cargo.toml"
+    "git diff --exit-code cli/js/snippets.generated.json"
+    "cd cli/tools/extract-snippets && cargo test --quiet"
+    "node cli/tools/test-flags/test.js"
+    "node cli/tools/test-flags/anchors.js"
+    "node cli/tools/gen-op-sections/index.js --out cli/tools/gen-op-sections/generated-op-sections.html"
+    "git diff --exit-code cli/tools/gen-op-sections/generated-op-sections.html"
+    "node cli/tools/gen-op-sections/placeholder-substitution.test.js"
+)
+
+# The pdfium build inputs. Python and shell rather than Rust, and the whole
+# workflow runs in about 2s locally, so all of it is here.
+#
+# This repo also ships its own tools/install-hooks.sh, which writes a hook that
+# skips shellcheck when shellcheck is not installed. That is the false green
+# this whole file exists to refuse, and nothing held that script to the
+# workflow, so the hook this one writes is the one that should be in place.
+# CI runs pytest on 3.9 and on 3.12; the hook runs it on whatever `pytest`
+# resolves to, which is one of the two cells rather than both.
+LIBVIPRS_DEP_STEPS=(
+    "ruff check pdfium/"
+    "ruff format --check pdfium/"
+    "shellcheck pdfium/patches/*.sh"
+    "pytest pdfium/tests/ -v"
+)
+
+steps_for_repo() {
     case "$1" in
-        libviprs)        printf '%s\n' "${LIBVIPRS_CARGO_STEPS[@]}" ;;
-        libviprs-cli)    printf '%s\n' "${LIBVIPRS_CLI_CARGO_STEPS[@]}" ;;
-        libviprs-tests)  printf '%s\n' "${LIBVIPRS_TESTS_CARGO_STEPS[@]}" ;;
-        *)               printf '%s\n' "cargo clippy --all-targets -- -D warnings" ;;
+        libviprs)       printf '%s\n' "${LIBVIPRS_STEPS[@]}" ;;
+        libviprs-cli)   printf '%s\n' "${LIBVIPRS_CLI_STEPS[@]}" ;;
+        libviprs-tests) printf '%s\n' "${LIBVIPRS_TESTS_STEPS[@]}" ;;
+        libviprs-bench) printf '%s\n' "${LIBVIPRS_BENCH_STEPS[@]}" ;;
+        libviprs-org)   printf '%s\n' "${LIBVIPRS_ORG_STEPS[@]}" ;;
+        libviprs-dep)   printf '%s\n' "${LIBVIPRS_DEP_STEPS[@]}" ;;
+        *)              : ;;
     esac
 }
 
@@ -133,7 +314,9 @@ cargo_steps_for_repo() {
 # The cli is not left unguarded: the dedicated `cli-differential` CI job lays
 # it down at CLI_COUNTERPART_REV and runs with VIPRS_REQUIRE_CLI=1, so a silent
 # skip there is a hard panic (tests/common/cli.rs, CLI_CONTRACT.md §7). What
-# goes away is a local promise the suite could not keep.
+# goes away is a local promise the suite could not keep. The same is true of
+# the three repos added since: the image holds no bench, no doc site and no
+# pdfium build inputs.
 #
 # tests/install_hooks_pre_push_slots.rs runs this script against a stand-in
 # workspace and pins the answer per repo. It also asks run-tests.sh whether it
@@ -149,6 +332,51 @@ has_suite_slot() {
 # The comment line every hook this script writes carries. It is what tells our
 # own output apart from a hook somebody wrote by hand.
 INSTALLER_MARKER="Installed by libviprs-tests/tools/install-hooks.sh"
+
+# ---------------------------------------------------------------------------
+# --describe: print the contract and install nothing.
+#
+# The guard reads this rather than the arrays, so the script stays the single
+# place any of it is written down and the guard is still driving the real
+# thing rather than parsing it.
+# ---------------------------------------------------------------------------
+describe() {
+    local repo_dir repo name reason job
+    for repo_dir in "${REPOS[@]}"; do
+        repo="$(basename "$repo_dir")"
+        printf 'repo\t%s\n' "$repo"
+        printf 'workflow\t%s\t%s\n' "$repo" "$(workflow_for_repo "$repo")"
+        if name="$(ci_checkout_path "$repo")" && [ -n "$name" ]; then
+            printf 'checkout-path\t%s\t%s\n' "$repo" "$name"
+        fi
+        while IFS= read -r job; do
+            [ -z "$job" ] && continue
+            printf 'mirror\t%s\t%s\n' "$repo" "$job"
+        done < <(mirror_jobs "$repo")
+        while IFS=$'\t' read -r job reason; do
+            [ -z "$job" ] && continue
+            printf 'defer\t%s\t%s\t%s\n' "$repo" "$job" "$reason"
+        done < <(deferred_jobs "$repo")
+        while IFS=$'\t' read -r job reason; do
+            [ -z "$job" ] && continue
+            printf 'exempt\t%s\t%s\t%s\n' "$repo" "$job" "$reason"
+        done < <(exempt_steps "$repo")
+        if has_suite_slot "$repo"; then
+            printf 'prepush\t%s\tyes\n' "$repo"
+        else
+            printf 'prepush\t%s\tno\n' "$repo"
+        fi
+    done
+}
+
+if [ "${1:-}" = "--describe" ]; then
+    describe
+    exit 0
+fi
+if [ $# -gt 0 ]; then
+    echo "usage: $0 [--describe]" >&2
+    exit 2
+fi
 
 # A repo that no longer gets the gate must not keep the copy an older version
 # of this script left in it. Nothing but this script writes to .git/hooks, so
@@ -176,8 +404,8 @@ write_pre_commit() {
     # A repo that ships tools/local-ci.py gets a hook that runs THAT. It reads
     # .github/workflows/ci.yml at run time and executes whatever is in there,
     # inside a container carrying the toolchains the workflow asks for, so it
-    # cannot drift from CI. The hardcoded per-repo lists further up are the
-    # fallback for repos without one, and they are only ever a subset.
+    # cannot drift from CI. The step list above is the fallback for repos
+    # without one, and it is only ever a subset.
     if [ -n "$repo_dir" ] && [ -f "$repo_dir/tools/local-ci.py" ]; then
         cat > "$pre_commit" << 'LOCALCI'
 #!/usr/bin/env bash
@@ -211,47 +439,82 @@ LOCALCI
     fi
 
     {
-        cat << 'HEAD'
+        cat << HEAD
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Pre-commit hook: a SUBSET of this repo's CI Check & Lint job, not all of
-# it. A repo with tools/local-ci.py gets the real thing instead.
-# Installed by libviprs-tests/tools/install-hooks.sh — to update, edit
-# the script and re-run it. To skip (emergency only):
+# Pre-commit hook: the lint half of this repo's CI, which is the jobs
+# install-hooks.sh lists under mirror_jobs for $repo_name. Tests run on push.
+# A repo with tools/local-ci.py gets the real job list instead of this.
+# $INSTALLER_MARKER
+# To update it, edit that script and re-run it. To skip (emergency only):
 #   git commit --no-verify
 
-echo "Running pre-commit checks (mirrors CI)..."
-
-# Format check (fast — no compilation needed).
-echo "  cargo fmt --check..."
-if ! cargo fmt -- --check; then
-    echo ""
-    echo "Formatting check failed. Run 'cargo fmt' and re-stage."
-    exit 1
-fi
+echo "Running pre-commit checks (the lint half of CI)..."
 
 HEAD
-        # Emit one cargo command per CI step so a failure prints exactly
-        # which CI line it would have flunked.
-        while IFS= read -r cmd; do
-            [ -z "$cmd" ] && continue
-            cat <<HOOK
-echo "  $cmd"
-if ! $cmd; then
-    echo ""
-    echo "Failed: $cmd"
-    echo "Fix and re-stage. (This command mirrors a CI step; if it"
-    echo "passes locally the matching CI step will too.)"
-    exit 1
+        # One command per CI step, so a failure prints exactly which CI line it
+        # would have flunked.
+        local step guard note cmd
+        while IFS= read -r step; do
+            [ -z "$step" ] && continue
+            if [[ "$step" == *"%%"* ]]; then
+                guard="${step%%\%\%*}"
+                cmd="${step##*%%}"
+                note="${step#*%%}"
+                note="${note%%\%\%*}"
+                cat <<HOOK
+if $guard; then
+HOOK
+                emit_step "$cmd" "    "
+                cat <<HOOK
+else
+    echo "  skipping: $cmd"
+    echo "    $note"
 fi
 
 HOOK
-        done < <(cargo_steps_for_repo "$repo_name")
+            else
+                emit_step "$step" ""
+                printf '\n'
+            fi
+        done < <(steps_for_repo "$repo_name")
 
-        echo 'echo "Pre-commit checks passed."'
+        echo 'echo "Pre-commit checks passed. Tests run on push."'
     } > "$pre_commit"
     chmod +x "$pre_commit"
+}
+
+# One step of the generated hook. `$2` is the indent, so a conditional step
+# nests without the heredoc having to know.
+#
+# The subshell around the command is load-bearing twice over. `if ! cd x &&
+# cargo test` parses as `(! cd x) && (cargo test)`, so with the `cd` working
+# the second half never runs at all and the step reports a pass having done
+# nothing, which is the exact false green these hooks exist to refuse. And a
+# `cd` that is not contained moves the working directory for every step after
+# it. `( ... )` fixes both.
+emit_step() {
+    local cmd="$1"
+    local pad="$2"
+    local hint="Fix and re-stage. (This command is a CI step; if it passes"
+
+    case "$cmd" in
+        "cargo fmt"*) hint="Run 'cargo fmt' and re-stage. (This command is a CI step; if it passes" ;;
+        "ruff format"*) hint="Run 'ruff format pdfium/' and re-stage. (This command is a CI step; if it passes" ;;
+        "git diff --exit-code"*) hint="Re-run the generator above and commit what it wrote. (This command is a CI step; if it passes" ;;
+    esac
+
+    cat <<HOOK
+${pad}echo "  $cmd"
+${pad}if ! ( $cmd ); then
+${pad}    echo ""
+${pad}    echo "Failed: $cmd"
+${pad}    echo "$hint"
+${pad}    echo "locally the matching CI step will too.)"
+${pad}    exit 1
+${pad}fi
+HOOK
 }
 
 # The pre-push hook is not generated. It is a real file at tools/hooks/pre-push
@@ -276,7 +539,7 @@ install_pre_push() {
     # time. Nothing else in this chunk expands.
     cat > "$pre_push" << HOOK
 #!/usr/bin/env bash
-# Pre-push shim. Installed by libviprs-tests/tools/install-hooks.sh
+# Pre-push shim. $INSTALLER_MARKER
 # To skip (emergency only): git push --no-verify
 #
 # No behaviour lives here on purpose. The hook is checked in at
@@ -312,26 +575,50 @@ HOOK
     chmod +x "$pre_push"
 }
 
-# pdfium-render gets a different pre-commit hook because we run it as a
-# fork: upstream pdfium-render carries hundreds of pre-existing clippy
-# lints (~470 missing-safety-doc, ~22 doc-nested-refdefs, etc.), so a
-# blanket `cargo clippy -- -D warnings` would block every commit including
-# merges from upstream. The scoped variant runs clippy on the whole tree
-# but filters to lints whose primary span sits on a line *this fork has
-# actually changed* relative to its base on `upstream/master`. Net: strict
-# on lints we introduce, silent on the ambient debt we don't own.
+# ---------------------------------------------------------------------------
+# pdfium-render gets a hook of its own, and it is the one place here that is
+# not a CI mirror. Upstream's workflow runs `cargo build`, `cargo test`, a
+# wasm-pack build and 205 `cargo check` compatibility cells, and not one line
+# of `cargo fmt` or `cargo clippy`. So there is nothing to mirror, and what
+# this hook enforces is fork policy instead: keep the lines we write clean.
+#
+# It cannot be a blanket `cargo clippy -- -D warnings`, because upstream
+# carries hundreds of pre-existing lints (~470 missing-safety-doc, ~22
+# doc-nested-refdefs) and that would block every commit including merges from
+# upstream. So clippy runs over the whole tree and the result is filtered to
+# lints whose primary span sits on a line the commit in hand is changing.
+#
+# It used to filter against the whole fork delta vs upstream/master, and that
+# does not survive a clippy upgrade: a newer clippy grew `deref on an
+# immutable reference`, 54 of them landed on fork lines written months ago,
+# and the hook then refused every commit on an unmodified `origin/master`
+# checkout with nothing staged. Measured 2026-09-02: 54 warnings, exit 1, on a
+# clean tree. A gate that is red before you have typed anything is a gate
+# people delete.
+#
+# The scope is `git diff HEAD`, the working tree against the commit you are
+# on, and not `git diff --cached`, because clippy compiles the working tree.
+# Scoping to the index would number the lints against content clippy never
+# saw, and the failure mode of that is a lint pointing at an innocent line or
+# a real one slipping through because its line moved. For the ordinary `git
+# add` then `git commit` the two sets are identical anyway.
+# ---------------------------------------------------------------------------
 write_pdfium_pre_commit() {
     local hooks_dir="$1"
     local pre_commit="$hooks_dir/pre-commit"
 
-    cat > "$pre_commit" << 'HOOK'
+    cat > "$pre_commit" << HOOK
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Pre-commit hook for the libviprs/pdfium-render fork.
-# Installed by libviprs-tests/tools/install-hooks.sh — to update, edit
-# the script and re-run it. To skip (emergency only):
+# Pre-commit hook for the libviprs/pdfium-render fork. This is fork policy,
+# not a CI mirror: upstream's workflow runs no lint at all.
+# $INSTALLER_MARKER
+# To update it, edit that script and re-run it. To skip (emergency only):
 #   git commit --no-verify
+HOOK
+
+    cat >> "$pre_commit" << 'HOOK'
 
 echo "Running pre-commit checks (fork-scoped)..."
 
@@ -342,74 +629,70 @@ if ! cargo fmt -- --check; then
     exit 1
 fi
 
-# Determine fork base.
-git fetch -q upstream master 2>/dev/null || true
-if git rev-parse upstream/master >/dev/null 2>&1; then
-    BASE_REF="upstream/master"
-elif git rev-parse origin/master >/dev/null 2>&1; then
-    BASE_REF="origin/master"
-else
-    echo "  warn: no upstream/master or origin/master found; skipping scoped clippy"
-    echo "Pre-commit checks passed."
-    exit 0
-fi
-BASE=$(git merge-base HEAD "$BASE_REF")
-
-echo "  cargo clippy --all-targets (scoped to fork-changed lines)..."
+echo "  cargo clippy --all-targets (scoped to the lines this commit changes)..."
 
 if ! command -v python3 >/dev/null 2>&1; then
-    echo "  warn: python3 not on PATH; skipping scoped clippy"
-    echo "Pre-commit checks passed."
-    exit 0
+    echo "  python3 is not on PATH, and the scoping needs it." >&2
+    echo "  Install python3, or commit with --no-verify and say so." >&2
+    exit 1
 fi
 
-python3 - "$BASE" <<'PY'
+python3 - <<'PY'
 import json
-import re
 import subprocess
 import sys
 
-base = sys.argv[1]
-
-# Build {file: set(line_numbers)} for lines our branch added or changed
-# vs the fork base. `--unified=0` makes the hunk headers line up exactly
-# with added lines (no surrounding context to confuse the math).
-diff_proc = subprocess.run(
-    ["git", "diff", "--unified=0", base, "HEAD", "--", "*.rs"],
-    check=True,
+# Lines the working tree changes against HEAD. That is the commit in hand,
+# and it is also exactly the content clippy is about to compile, so the line
+# numbers on both sides refer to the same file. `--unified=0` makes the hunk
+# headers line up with the changed lines and nothing else.
+diff = subprocess.run(
+    ["git", "diff", "--unified=0", "HEAD", "--", "*.rs"],
     capture_output=True,
     text=True,
 )
+if diff.returncode != 0:
+    print("  git diff failed, so the scope cannot be computed:", file=sys.stderr)
+    print(diff.stderr, file=sys.stderr)
+    sys.exit(1)
 
 file_lines = {}
 current_file = None
-hunk_re = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
-for line in diff_proc.stdout.splitlines():
+for line in diff.stdout.splitlines():
     if line.startswith("+++ b/"):
         current_file = line[6:]
-    elif current_file:
-        m = hunk_re.match(line)
-        if m:
-            start = int(m.group(1))
-            cnt = int(m.group(2)) if m.group(2) is not None else 1
-            if cnt > 0:
-                file_lines.setdefault(current_file, set()).update(
-                    range(start, start + cnt)
-                )
+    elif line.startswith("@@") and current_file:
+        # "@@ -a,b +c,d @@", where c is the first changed line on the new side and
+        # d how many there are, defaulting to 1 when it is left off.
+        plus = line.split("+", 1)[1].split(" ", 1)[0]
+        start, _, count = plus.partition(",")
+        count = int(count) if count else 1
+        if count:
+            file_lines.setdefault(current_file, set()).update(
+                range(int(start), int(start) + count)
+            )
 
-if not file_lines:
-    print("  no Rust line additions/changes vs " + base[:8] + "; skipping clippy scope check")
+if not diff.stdout.strip():
+    print("  no Rust file differs from HEAD, so there is nothing to check")
     sys.exit(0)
 
-# Run clippy; consume its JSON line-stream.
-clippy_proc = subprocess.run(
+# A commit can be all deletions, which gives a real diff and no added lines to
+# scope to. Skipping there would be a commit that changes the crate and gets no
+# check at all, and deleting the wrong line is a perfectly ordinary way to
+# break a build, so clippy still runs and the exit code below still counts.
+if not file_lines:
+    print("  only deletions against HEAD, so nothing is scoped, but the tree")
+    print("  still has to build")
+
+clippy = subprocess.run(
     ["cargo", "clippy", "--all-targets", "--message-format=json"],
     capture_output=True,
     text=True,
 )
 
 hits = []
-for line in clippy_proc.stdout.splitlines():
+errors = []
+for line in clippy.stdout.splitlines():
     try:
         rec = json.loads(line)
     except json.JSONDecodeError:
@@ -420,28 +703,43 @@ for line in clippy_proc.stdout.splitlines():
     level = msg.get("level")
     if level not in ("warning", "error"):
         continue
+    if level == "error":
+        errors.append(msg.get("rendered") or msg.get("message", ""))
     for span in msg.get("spans") or []:
         if not span.get("is_primary"):
             continue
-        f = span.get("file_name")
-        ls = span.get("line_start")
-        le = span.get("line_end") or ls
-        owned = file_lines.get(f)
-        if owned and any(i in owned for i in range(ls, le + 1)):
+        owned = file_lines.get(span.get("file_name"))
+        first = span.get("line_start")
+        last = span.get("line_end") or first
+        if owned and any(i in owned for i in range(first, last + 1)):
             hits.append(
                 f"  {level}: {msg.get('message','')}\n"
-                f"    --> {f}:{ls}:{span.get('column_start','?')}"
+                f"    --> {span.get('file_name')}:{first}:{span.get('column_start','?')}"
             )
             break
 
+# A crate that does not build is not a pass. The filter above only ever looks
+# at lines this commit touches, so a hard error anywhere else would otherwise
+# come back green, which is the shape of false green this hook is here to
+# avoid rather than to grow. Deleting a line another file depends on is the
+# everyday way to land one of those.
+if clippy.returncode != 0 and not hits:
+    print("")
+    print("cargo clippy exited %d, so the tree does not build." % clippy.returncode)
+    print("None of it lands on a line this commit changes, so it is not")
+    print("something you introduced, but it still has to be fixed to commit.")
+    print("")
+    print("".join(errors[:5]) if errors else clippy.stderr[-2000:])
+    sys.exit(1)
+
 if hits:
     print("")
-    print("Clippy lints on fork-changed lines:")
+    print("Clippy lints on lines this commit changes:")
     print("\n".join(hits))
     print("")
-    print("Fix and re-stage. (Pre-existing upstream lints on lines our fork")
-    print("hasn't touched are ignored; this hook only blocks on lints whose")
-    print("primary span sits on a line we added or changed.)")
+    print("Fix and re-stage. (Lints on lines this commit leaves alone are")
+    print("ignored, whether they came from upstream or from an older commit")
+    print("of ours that a newer clippy has since caught up with.)")
     sys.exit(1)
 PY
 
@@ -465,17 +763,15 @@ for REPO_DIR in "${REPOS[@]}"; do
 
     case "$REPO_NAME" in
         pdfium-render)
-            # Heavily-rotted upstream → fork-scoped pre-commit only; no Docker
-            # pre-push (no `run-tests.sh` integration on this repo).
             write_pdfium_pre_commit "$HOOKS_DIR"
-            echo "  done: $REPO_NAME (scoped pre-commit)"
+            echo "  done: $REPO_NAME (fork-scoped pre-commit)"
             drop_generated_pre_push "$HOOKS_DIR"
             ;;
         *)
             # The pre-commit hook goes everywhere: it runs the repo's own
-            # `cargo fmt` and `cargo clippy` in the repo it is installed in, so
-            # for the cli it gates the cli. $REPO_DIR lets it detect a
-            # tools/local-ci.py in the target repo and defer to that instead.
+            # checks in the repo it is installed in, so for the cli it gates
+            # the cli. $REPO_DIR lets it detect a tools/local-ci.py in the
+            # target repo and defer to that instead.
             write_pre_commit "$HOOKS_DIR" "$REPO_NAME" "$REPO_DIR"
             if has_suite_slot "$REPO_NAME"; then
                 install_pre_push "$HOOKS_DIR"

--- a/tools/install-hooks.sh
+++ b/tools/install-hooks.sh
@@ -639,6 +639,7 @@ fi
 
 python3 - <<'PY'
 import json
+import os
 import subprocess
 import sys
 
@@ -684,10 +685,34 @@ if not file_lines:
     print("  only deletions against HEAD, so nothing is scoped, but the tree")
     print("  still has to build")
 
+# An ambient `-D warnings` has to come off for this one call. The whole
+# arrangement here rests on clippy reporting an inherited lint as a warning so
+# the scope filter can drop it; with `-D warnings` in RUSTFLAGS every one of
+# them arrives as an error instead, clippy exits non-zero, and the hook refuses
+# a commit over debt it was written to ignore. That is not hypothetical: this
+# repo's own CI sets RUSTFLAGS at the workflow level, and the guard for this
+# hook went red there the first time it ran. Real compile errors are unaffected,
+# because they are errors without it.
+env = dict(os.environ)
+flags = env.get("RUSTFLAGS", "").split()
+kept = []
+i = 0
+while i < len(flags):
+    if flags[i] in ("-Dwarnings", "--deny=warnings"):
+        i += 1
+        continue
+    if flags[i] in ("-D", "--deny") and i + 1 < len(flags) and flags[i + 1] == "warnings":
+        i += 2
+        continue
+    kept.append(flags[i])
+    i += 1
+env["RUSTFLAGS"] = " ".join(kept)
+
 clippy = subprocess.run(
     ["cargo", "clippy", "--all-targets", "--message-format=json"],
     capture_output=True,
     text=True,
+    env=env,
 )
 
 hits = []


### PR DESCRIPTION
Closes #198.

I measured every repo in the org against its own CI, closed the gaps, wrote the commit/push split down as something a test can check, and then broke every guard here deliberately in both directions to prove it can go red.

## CI versus the local hook, before and after

| repo | CI lint checks | hook before | hook after |
|---|---|---|---|
| libviprs | `check`: fmt + 10 clippy cells + `cargo build --features s3` | fmt + 10 clippy (via `local-ci.py` in practice) | same, plus the `s3` build exempted with a reason |
| libviprs-cli | `check`: fmt + 5 clippy cells | fmt + 5 clippy | same, plus the sibling clone exempted |
| libviprs-tests | `lint`: fmt + clippy + **shellcheck**; `feature-cells`: 4 clippy; `ported-tests`: `run_ported_cells.sh --clippy` | fmt + 5 clippy + ported clippy, **no shellcheck** | all of it, shellcheck included |
| libviprs-bench | `check`: 4 `cargo check` cells + 1 clippy, **no fmt** | **nothing** | the 5 cells, and no fmt, because CI has none |
| libviprs-org | `sync` + `extract` + `test-flags` + `gen-op-sections`, 9 commands | **nothing** | all 9, sync under the same condition CI puts on it |
| libviprs-dep | `lint` + `test` + `shellcheck`, 4 commands | its own installer, shellcheck **silently skipped** if absent | all 4, and it refuses rather than skipping |
| pdfium-render | `build`: no lint at all | fork-scoped clippy, **red on a clean tree** | fork-scoped clippy against the commit in hand |

## The contract I settled on

pre-commit is the lint half, pre-push is the test half, and the split is by cost. Measured here on 2026-09-02 with a warm target directory: the lint half is 39s (fmt 1s, five clippy cells 36s, ported clippy 1s, shellcheck 1s) and `cargo test` alone is 279s, before the pre-push gate builds its image.

Two repos are deliberate exceptions, argued from the same measurement rather than from taste: libviprs-org's whole workflow runs in 4s cold and under 1s warm, and libviprs-dep's in 2s. Splitting those buys nothing and leaving half of each unguarded costs something, so their hooks mirror the whole workflow.

The split is no longer a paragraph. Per repo the installer now declares `mirror_jobs` (the jobs the hook stands in for), `exempt_steps` (steps it skips, each with a reason) and `deferred_jobs` (every job in neither half, with a reason). Between them every job in every workflow is accounted for, and the guard refuses a job that is in neither.

`--describe` prints all of it, and that is what the guard reads. Neither the installer nor the hook is ever grepped: the contract comes from running the script, and what the hook runs comes from running the hook with recorders in front of every tool it shells out to.

## pdfium-render

The old hook scoped clippy to the whole fork delta against `upstream/master`, so every line the fork had ever written stayed in scope forever. A newer clippy grew `deref on an immutable reference` and 54 landed on fork lines written months ago.

Measured on an unmodified `origin/master` checkout with nothing staged, before the fix:

```
  warning: deref on an immutable reference
    --> src/pdf/document/page/object/group.rs:534:64
  ... 54 of them ...
EXIT=1
```

After, same checkout, same state:

```
Running pre-commit checks (fork-scoped)...
  cargo fmt --check...
  cargo clippy --all-targets (scoped to the lines this commit changes)...
  no Rust file differs from HEAD, so there is nothing to check
Pre-commit checks passed.
EXIT=0    (0s)
```

Lint-free staged change, on the same tree that still carries all 54:

```
Pre-commit checks passed.
EXIT=0    (2s)
```

Same change with `&[u8]` turned into `&Vec<u8>`:

```
Clippy lints on lines this commit changes:
  warning: writing `&Vec` instead of `&[_]` involves a new object where a slice will do
    --> src/lib.rs:205:30
EXIT=1
```

Deletion-only change that breaks an untouched line (I deleted one prelude re-export):

```
  only deletions against HEAD, so nothing is scoped, but the tree
  still has to build

cargo clippy exited 101, so the tree does not build.
error[E0433]: cannot find type `PdfRect` in this scope
EXIT=1
```

The scope is `git diff HEAD` rather than `git diff --cached` on purpose: clippy compiles the working tree, so scoping to the index would number lints against content clippy never saw. For the ordinary add-then-commit the two sets are identical.

## libviprs-dep: folded in, and why

It stays a separate repo but it stops having a separate installer's hook. Its own `tools/install-hooks.sh` writes a hook that soft-skips shellcheck when shellcheck is not installed, which is a green commit on a check CI will fail, and nothing held that script to its workflow. "It is Python, not Rust" stopped being a reason the moment the doc site joined, and the whole workflow runs in 2s. The shared hook fails loudly when a tool is missing instead of skipping it.

The one thing I could not do from here is retire libviprs-dep's own installer, which is a tracked file in a repo this PR does not touch. Both scripts write the same path, so whichever ran last wins; the shared one carries the installer marker line, so they are at least tellable apart. Worth a follow-up issue over there.

## Two bugs that fell out of writing the contract down

`shellcheck tools/*.sh tools/hooks/pre-push` is in this repo's `lint` job and the hook did not run it, so the one check that reads the hook's own shell was left entirely to CI.

And the generated hook emitted `if ! cd x && cargo test; then`, which parses as `(! cd x) && (cargo test)`. With the `cd` working, the second half never ran and the step reported a pass having done nothing. Every step is now wrapped in a subshell, which also stops a `cd` moving the working directory for everything after it.


## What CI caught that I could not

The first run of the new guard went red on all three jobs that run it, and the cause was one thing invisible on my machine: this repo's ci.yml sets `RUSTFLAGS: -Dwarnings` at the workflow level.

The fork hook's scoping rests on clippy calling an inherited lint a *warning*, so the filter can drop it. With `-D warnings` in the environment every one of them arrives as an error, clippy exits non-zero, and the "the tree does not build" branch refuses the commit over exactly the debt the hook exists to ignore. My shell has no RUSTFLAGS set, so every local run was green and every CI run was red.

The hook now takes `-D warnings` back off for its own clippy call and nothing else, so a real compile error is still an error. Verified against the real fork with `RUSTFLAGS=-Dwarnings` and all 54 inherited lints present: clean tree passes, a lint-free change passes, a change whose own new line trips `ptr_arg` is refused.

`an_ambient_deny_warnings_does_not_turn_inherited_debt_into_a_refusal` pins both halves so CI is no longer the only thing that would notice. Falsified: putting the flag back into the clippy call turns it red on the first half, and letting every lint through turns it red on the second.

## Falsification evidence

Every guard here, broken deliberately, in both directions. Each line is the assertion that fired.

| # | what I broke | which test went red | what it said |
|---|---|---|---|
| F1 | removed a clippy cell from the hook's step list | `the_hook_mirrors_this_repos_ci` | `CI runs these ... and the hook does not: cargo clippy --all-targets --features jxl` |
| F2 | dropped `jxl` from the `feature-cells` matrix in ci.yml | `the_hook_mirrors_this_repos_ci` | `the hook ... runs these and the jobs it mirrors do not: cargo clippy ... --features jxl` |
| F3 | added a step to the hook CI has no line for | `the_hook_mirrors_this_repos_ci` | `... runs these and the jobs it mirrors do not: cargo clippy ... --features made-up` |
| F4 | added a repo to `REPOS` with no steps and no test arm | `every_repo_the_installer_visits_has_a_test_here` | `installs hooks into these and nothing here checks them: libviprs-newthing` |
| F5 | added a new job to ci.yml, mirrored by nothing, deferred by nothing | `the_hook_mirrors_this_repos_ci` | `has jobs the local hooks account for neither way: brand-new-audit` |
| F6 | renamed a deferred job | `the_hook_mirrors_this_repos_ci` | `... neither way: test-pdfium-renamed` |
| F6b | deleted a deferred job, leaving the deferral behind | `the_hook_mirrors_this_repos_ci` | `defers these jobs ... and ci.yml has no job by those names: test-pdfium` |
| F7 | renamed the step an exemption names | `the_hook_mirrors_this_repos_ci` | `CI runs these ... and the hook does not: ./tools/fetch_reference_suite.sh` |
| F7b | deleted the exempted step, leaving the exemption pointing at nothing | `the_hook_mirrors_this_repos_ci` | `exempts these steps ... and no step in the jobs it mirrors matches them` |
| F8 | added a `cargo clippy` line to the fork's workflow | `the_pdfium_fork_ci_still_has_no_lint_to_mirror` | `the reason written down ... is that upstream's workflow lints nothing. That is no longer true` |
| F9 | gave libviprs-bench a pre-push slot | `a_pre_push_hook_only_lands_where_the_suite_has_a_slot` | `libviprs-bench must not get a pre-push hook` |
| F9b | dropped a repo from the shared stand-in list | `the_hook_mirrors_the_org_site_ci` | `no pre-commit hook was installed into libviprs-org` |
| F9c | same, seen from the slots table | `a_pre_push_hook_only_lands_where_the_suite_has_a_slot` | `this table and the repos the installer visits have gone out of step` |
| F10a | made the fork hook always pass | `a_change_that_introduces_a_lint_is_refused`, `a_deletion_that_breaks_the_build_is_refused` | `allowed a change whose own new line trips a clippy lint` |
| F10b | made the fork hook block on every lint | `a_clean_checkout_with_nothing_staged_commits`, `a_change_that_introduces_no_lint_commits_over_inherited_debt` | `refused a commit on a clean checkout with nothing staged` |
| F10c | took the lint out of the fork fixture | `the_fixture_really_does_carry_a_lint` | `every "the hook stayed quiet" assertion would pass on a fixture with nothing to be quiet about` |
| F11a | made the doc site's sync condition always true | `the_org_hook_skips_the_sync_check_only_when_the_cli_sibling_is_missing` | `ran the frozen-copy sync check with no libviprs-cli sibling to compare against` |
| F11b | made it always false | same, plus `the_hook_mirrors_the_org_site_ci` | `did not run the frozen-copy sync check even with the sibling laid down` |
| F12 | pointed a repo at a workflow that is not there | `the_pdfium_fork_ci_still_has_no_lint_to_mirror` | `cannot read .../workflows/gone.yml` |
| F13b | dropped the exemption covering a multi-line CI shell block | `the_hook_mirrors_the_bench_ci` | `runs a multi-line shell block that the pre-commit hook does not ... exempt it with a reason` |
| F14 | hid a sibling with `VIPRS_REQUIRE_SIBLINGS=1` set | `the_hook_mirrors_the_dep_ci` | `not laid down beside this checkout, so this guard would compare nothing and report a false green` |
| F15 | put the ambient `-D warnings` back into the fork hook's clippy call | `an_ambient_deny_warnings_does_not_turn_inherited_debt_into_a_refusal` | `refused a change that introduces no lint of its own ... came back as an error rather than a warning` |

F14 is worth spelling out. Without the flag a missing sibling skips, and a skip reads to `cargo test` as a pass, so the three new arms would be guarded by tests that never once ran. The new `hook-mirror` CI job lays all seven repos down side by side and sets the flag, which is the only place they cannot skip. Same shape as `VIPRS_REQUIRE_CLI` on `cli-differential`.

F10c is the other one. Three of the four fork tests assert the hook stayed quiet, and quiet looks identical whether clippy found nothing or clippy never ran, so the fixture's own lint is checked directly first.

## Verified

- `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `shellcheck tools/*.sh tools/hooks/pre-push`: all clean
- the five hook suites: 24 tests, all green
- `cargo test`: green (134 suites, 212s), and again with `RUSTFLAGS=-Dwarnings` the way CI runs it (134 suites, 316s)
- all nine CI jobs green on this branch, including the new `Hook Mirror` one
- the three new hooks run against their real checkouts: libviprs-org 1s, libviprs-dep 1s, libviprs-bench 3s, all pass
- this repo's own hook run against this branch: 10s, passes, shellcheck included
- `shellcheck` on all seven generated hooks: clean
- the fork's hook run for real against `origin/master` in all four states above

## Not verified

The core's live pre-commit hook runs `tools/local-ci.py`, which is somebody else's file and derives its own list from ci.yml at run time. This PR's core arm checks the hardcoded fallback, which is what lands in a repo without that script and what the core falls back to if it goes away. What `local-ci.py --fast` actually runs is not checked here.
