### PR TITLE
Put the pre-commit hook back on the fast path, and stop it overselling itself

### DIFF
--- a/tests/install_hooks_localci_says_it_is_not_the_gate.rs
+++ b/tests/install_hooks_localci_says_it_is_not_the_gate.rs
@@ -1,0 +1,100 @@
+//! Guards the honesty of the LOCALCI pre-commit hook that
+//! `write_pre_commit` in `tools/install-hooks.sh` generates.
+//!
+//! The hook runs `tools/local-ci.py --fast --worktree`. The `--worktree` half
+//! is a deliberate speed choice: it bind-mounts the tree instead of
+//! provisioning it from git, which is about 12s per commit against about 107s
+//! measured, and nobody tolerates 107s on every commit.
+//!
+//! The cost is that a Docker Desktop bind mount off an APFS host is
+//! case-insensitive and carries untracked files, so the hook can pass on a
+//! tree CI rejects. That is not hypothetical: libviprs#977 was a fixture whose
+//! committed name differed from the referenced one only in case, it resolved
+//! fine through the bind mount, and `main` was red on ubuntu-latest for two
+//! days while the local mirror said PASS.
+//!
+//! So the hook has to say out loud that it is the fast check and not the gate.
+//! This guard pins that coupling in BOTH directions, because each half rots on
+//! its own: drop `--worktree` and the warning becomes a lie, keep
+//! `--worktree` and drop the warning and the hook oversells itself. It reads
+//! the generator rather than an installed hook, so it needs no harness and
+//! cannot be fooled by a stale install.
+
+use std::path::{Path, PathBuf};
+
+fn installer_source() -> String {
+    let p: PathBuf = Path::new(env!("CARGO_MANIFEST_DIR")).join("tools/install-hooks.sh");
+    std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("cannot read {}: {e}", p.display()))
+}
+
+/// The LOCALCI heredoc, which is the hook body for repos shipping
+/// `tools/local-ci.py`. Everything this guard asserts lives inside it, so
+/// slicing it out keeps an unrelated mention elsewhere in the installer from
+/// satisfying or breaking the check.
+fn localci_hook_body(src: &str) -> &str {
+    let start = src
+        .find("<< 'LOCALCI'")
+        .expect("install-hooks.sh no longer has a LOCALCI heredoc; this guard needs updating");
+    let rest = &src[start..];
+    let end = rest
+        .find("\nLOCALCI\n")
+        .expect("the LOCALCI heredoc is not terminated, so the installer is broken");
+    &rest[..end]
+}
+
+/// The line that actually RUNS local-ci.py, as opposed to the comments and
+/// `echo`s around it that also name its flags.
+///
+/// This distinction is the whole point. My first version of this guard read
+/// the entire heredoc, so removing `--worktree` from the command still left it
+/// in the explanatory comment and the guard passed a mutation it was written
+/// to catch. `pdfium_ci_policy.rs` learned the same lesson about prose that
+/// names a flag it is explaining.
+fn invocation(body: &str) -> &str {
+    body.lines()
+        .map(str::trim_start)
+        .find(|l| !l.starts_with('#') && !l.starts_with("echo") && l.contains("local-ci.py"))
+        .expect("the LOCALCI hook no longer invokes local-ci.py at all")
+}
+
+#[test]
+fn a_bind_mounted_pre_commit_hook_admits_it_is_not_the_gate() {
+    let src = installer_source();
+    let body = localci_hook_body(&src);
+
+    let runs_bind_mounted = invocation(body).contains("--worktree");
+    // "not the gate" in some casing, plus the command that IS the gate. Both,
+    // because a warning that does not say what to run instead is not actionable.
+    let lower = body.to_lowercase();
+    let warns = lower.contains("not the gate");
+    let names_the_gate = body.contains("make ci");
+
+    if runs_bind_mounted {
+        assert!(
+            warns && names_the_gate,
+            "the LOCALCI pre-commit hook runs local-ci.py with --worktree, which bind-mounts \
+             the tree (case-insensitive here, and it carries untracked files), so it can pass \
+             on a tree CI rejects. It must say it is not the gate and name `make ci` as the one \
+             that is. Found: says-not-the-gate={warns}, names-make-ci={names_the_gate}"
+        );
+    } else {
+        assert!(
+            !warns,
+            "the LOCALCI pre-commit hook no longer passes --worktree, so it provisions from git \
+             and IS case-exact, but it still tells the reader it is not the gate. That warning \
+             is now false and should go, along with this branch of the guard."
+        );
+    }
+}
+
+#[test]
+fn the_hook_still_runs_the_fast_half() {
+    let src = installer_source();
+    let body = localci_hook_body(&src);
+    assert!(
+        invocation(body).contains("--fast"),
+        "the LOCALCI pre-commit hook dropped --fast, so every commit now runs the full job list \
+         including the test and integration jobs. That is the pre-push half, not the pre-commit \
+         half (see the commit/push split this installer declares)."
+    );
+}

--- a/tools/install-hooks.sh
+++ b/tools/install-hooks.sh
@@ -413,7 +413,23 @@ set -euo pipefail
 
 # Pre-commit hook: runs the fast half of this repo's real CI job list, in
 # Docker, via tools/local-ci.py. That script derives its commands from
-# .github/workflows/ci.yml, so this hook and CI cannot disagree.
+# .github/workflows/ci.yml, so the COMMANDS here cannot drift from CI.
+#
+# It runs with --worktree, which bind-mounts the tree instead of provisioning
+# it from git. That is the difference between about 12s and about 107s per
+# commit, measured, and 107s per commit is not a thing anyone will tolerate.
+#
+# The cost is real and you should know it: a Docker Desktop bind mount off an
+# APFS host is CASE-INSENSITIVE and it carries untracked files. So this hook
+# can pass on a tree CI will reject, and it has: libviprs#977 was a fixture
+# whose name differed from the committed file only in case, it resolved fine
+# through the bind mount, and it was red on ubuntu-latest for two days.
+#
+# So this hook is the fast check, NOT the gate. The gate is `make ci`, which
+# provisions from git and is case-exact. Run that before you push anything you
+# care about. libviprs/tests/fixture_paths_are_committed.rs catches the one
+# specific shape that bit us, but it does not make the bind mount case-exact.
+#
 # Installed by libviprs-tests/tools/install-hooks.sh.
 # To skip (emergency only): git commit --no-verify
 
@@ -423,16 +439,17 @@ set -euo pipefail
 # REPO_DIR from $0 always resolves to the main checkout (libviprs/libviprs#684,
 # the same bug install_pre_push below already dodges). Ask git instead.
 REPO_DIR="$(git rev-parse --show-toplevel)"
-echo "Running the fast CI jobs locally (tools/local-ci.py --fast)..."
-if ! python3 "$REPO_DIR/tools/local-ci.py" --fast; then
+echo "Running the fast CI jobs locally (tools/local-ci.py --fast --worktree)..."
+if ! python3 "$REPO_DIR/tools/local-ci.py" --fast --worktree; then
     echo ""
     echo "Failed. These are the real CI commands, so CI will fail the same way."
-    echo "Run everything including tests: tools/local-ci.py"
+    echo "Run everything including tests: make ci"
     echo "Skip this hook once:            git commit --no-verify"
     exit 1
 fi
-echo "Passed. Tests and the integration job run on push,"
-echo "or now with: tools/local-ci.py"
+echo "Passed, but this was the FAST check, not the gate: --worktree bind-mounts"
+echo "the tree, which is case-insensitive here and carries untracked files."
+echo "Before pushing, run the real gate: make ci"
 LOCALCI
         chmod +x "$pre_commit"
         return


### PR DESCRIPTION
Closes #200

libviprs#985 made `local-ci.py` provision from git rather than bind-mounting the tree. That was the right call, and the hook inherited it by accident.

## Measured, on the hook`s actual invocation

```
--fast --worktree   (bind mount)        12s
--fast              (git-provisioned)  107s
```

107s per commit gets you `--no-verify`, and then the hook checks nothing. A fast check that knows what it is beats a thorough one nobody runs.

## The honesty half

The old hook said the commands come from `ci.yml` "so this hook and CI cannot disagree". The commands cannot. The **tree** can, and that is exactly what libviprs#977 was: a fixture whose committed name differed only in case, which resolved fine through the case-insensitive bind mount while `main` sat red on ubuntu-latest for two days.

It now says it is the fast check and not the gate, names `make ci` as the gate, and says why. A warning that does not tell you what to run instead is not actionable.

## The guard, and the second pass it needed

`tests/install_hooks_localci_says_it_is_not_the_gate.rs` pins the coupling in both directions, because each half rots alone.

My first version was partly vacuous and my own mutations caught it. It read the entire heredoc, so removing `--worktree` from the command still matched it in the comment that explains `--worktree`:

```
first version:                      tightened:
M1 warning deleted        FAILED    FAILED
M2 --worktree removed     ok  <-    FAILED
M3 --fast removed         ok  <-    FAILED
restored                  ok        ok
```

It reads the invocation line now rather than the prose around it, which is the lesson `pdfium_ci_policy.rs` already learned about a flag named in the text explaining it.

## Verification

```
cargo fmt -- --check                        clean
cargo clippy --all-targets -- -D warnings   clean
cargo test                                  802 passed, 0 failed, 8 ignored
shellcheck tools/install-hooks.sh           clean
24 existing installer guard tests           pass
```

Run against the counterpart core this branch pins (`694fd4b2`), laid out as a sibling checkout.

**Unverified:** I did not re-measure 12s versus 107s on this branch; those numbers come from measuring both modes earlier today on libviprs `main`. The flag change is mechanical, but the figures are from that run, not this one.